### PR TITLE
Feat: add branch risk review command

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ node dist/cli.js scan /path/to/repo
 | `codeward scan . --format sarif --output codeward.sarif` | Generate SARIF for code scanning integrations. |
 | `codeward report . --output CODEWARD_REPORT.md` | Generate a Markdown report for PRs or audits. |
 | `codeward doctor .` | Summarize whether the repo is ready for AI-assisted work. |
+| `codeward review . --base origin/main --head HEAD` | Show new CodeWard findings introduced by a branch. |
 | `codeward context . --write AGENTS.md` | Generate starter agent instructions for the repo. |
 | `codeward init .` | Create a starter `codeward.config.json`. |
 
@@ -202,7 +203,7 @@ Near-term priorities:
 
 - publish the first npm package
 - add a GitHub Action wrapper with PR annotations
-- add branch-aware `review` output for PR risk
+- improve branch-aware `review` output for PR comments and annotations
 - expand agent instruction detection across Codex, Claude Code, Cursor, Copilot, Gemini, and related surfaces
 - generate rule documentation from scanner metadata
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -28,9 +28,10 @@ Start advisory, then tighten the gate once the findings are understood.
 | --- | --- | --- |
 | 1. Baseline | `codeward scan .` | See current repo-level AI agent risks without blocking work. |
 | 2. Doctor | `codeward doctor .` | Get an agent-readiness summary by guardrail area. |
-| 3. Report | `codeward report . --output CODEWARD_REPORT.md` | Share a readable audit artifact in a PR or maintainer discussion. |
-| 4. High-risk gate | `codeward scan . --fail-on high` | Block obvious risks such as committed env files or unsafe scripts. |
-| 5. Medium-risk gate | `codeward scan . --fail-on medium` | Require stronger agent guidance, tests, and workflow permissions. |
+| 3. Review | `codeward review . --base origin/main --head HEAD` | See new findings introduced by the branch. |
+| 4. Report | `codeward report . --output CODEWARD_REPORT.md` | Share a readable audit artifact in a PR or maintainer discussion. |
+| 5. High-risk gate | `codeward scan . --fail-on high` | Block obvious risks such as committed env files or unsafe scripts. |
+| 6. Medium-risk gate | `codeward scan . --fail-on medium` | Require stronger agent guidance, tests, and workflow permissions. |
 
 ## What To Fix First
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,7 +12,7 @@ CodeWard starts as a local CLI for repo-level AI agent readiness. The project ca
 
 - Add a GitHub Action wrapper with PR annotations.
 - Improve `doctor` output with clearer scoring and remediation grouping.
-- Add `review` output that focuses on risk introduced by a branch or pull request.
+- Improve `review` output for PR comments, summaries, and changed-line locations.
 - Expand agent instruction detection across Codex, Claude Code, Cursor, GitHub Copilot, Gemini, and related surfaces.
 - Generate rule documentation from scanner metadata.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,8 +5,9 @@ import { loadConfig, writeDefaultConfig } from "./config.js";
 import { generateAgentContext } from "./context.js";
 import { buildDoctorResult, formatDoctorReport } from "./doctor.js";
 import { formatMarkdownReport, formatSarifReport, formatTextReport, hasFindingsAtOrAbove } from "./report.js";
+import { formatReviewReport, reviewProject } from "./review.js";
 import { scanProject } from "./scanner.js";
-import { isSeverity } from "./severity.js";
+import { isAtLeastSeverity, isSeverity } from "./severity.js";
 import type { CodeWardConfig } from "./types.js";
 import type { Severity } from "./types.js";
 import { VERSION } from "./version.js";
@@ -23,6 +24,8 @@ interface ParsedOptions {
   force: boolean;
   failOn?: Severity;
   maxFiles?: number;
+  base?: string;
+  head?: string;
 }
 
 async function main(argv: string[]): Promise<number> {
@@ -66,6 +69,20 @@ async function main(argv: string[]): Promise<number> {
     await printOrWrite(output, options.output);
     const failOn = options.failOn ?? loadedConfig.config.failOn;
     return failOn && hasFindingsAtOrAbove(result, failOn) ? 1 : 0;
+  }
+
+  if (command === "review") {
+    const options = parseOptions(rest);
+    const loadedConfig = await loadConfig(options.path, options.config);
+    const result = await reviewProject(options.path, {
+      base: options.base,
+      head: options.head,
+      scanOptions: buildScanOptions(options, loadedConfig),
+    });
+    const output = formatReviewOutput(result, options.format ?? (options.json ? "json" : "text"));
+    await printOrWrite(output, options.output);
+    const failOn = options.failOn ?? loadedConfig.config.failOn;
+    return failOn && result.newFindings.some((finding) => isAtLeastSeverity(finding.severity, failOn)) ? 1 : 0;
   }
 
   if (command === "context") {
@@ -162,6 +179,16 @@ function parseOptions(args: string[]): ParsedOptions {
       continue;
     }
 
+    if (arg === "--base") {
+      options.base = readValue(args, ++index, arg);
+      continue;
+    }
+
+    if (arg === "--head") {
+      options.head = readValue(args, ++index, arg);
+      continue;
+    }
+
     if (arg === "--max-files") {
       const value = Number.parseInt(readValue(args, ++index, arg), 10);
       if (!Number.isFinite(value) || value < 1) {
@@ -231,6 +258,16 @@ function formatDoctorOutput(result: Awaited<ReturnType<typeof scanProject>>, for
   return formatDoctorReport(result);
 }
 
+function formatReviewOutput(result: Awaited<ReturnType<typeof reviewProject>>, format: OutputFormat): string {
+  if (format === "json") {
+    return `${JSON.stringify(result, null, 2)}\n`;
+  }
+  if (format !== "text") {
+    throw new Error(`Review supports text or json output, not ${format}`);
+  }
+  return formatReviewReport(result);
+}
+
 async function printOrWrite(output: string, outputPath?: string): Promise<void> {
   if (outputPath) {
     const resolvedOutputPath = path.resolve(outputPath);
@@ -262,6 +299,7 @@ Usage:
   codeward scan [path] [--format <format>] [--fail-on <severity>] [--max-files <n>]
   codeward report [path] [--format <format>] [--output <file>] [--fail-on <severity>]
   codeward doctor [path] [--json] [--output <file>] [--fail-on <severity>]
+  codeward review [path] [--base <ref>] [--head <ref>] [--json] [--fail-on <severity>]
   codeward context [path] [--write [file]] [--force]
   codeward init [path] [--write <file>] [--force]
 
@@ -277,6 +315,7 @@ Examples:
   codeward scan . --fail-on medium
   codeward report . --output CODEWARD_REPORT.md
   codeward doctor .
+  codeward review . --base origin/main --head HEAD
   codeward context . --write AGENTS.md
   codeward init .
 `);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ export { defaultConfig, loadConfig, writeDefaultConfig } from "./config.js";
 export { generateAgentContext } from "./context.js";
 export { buildDoctorResult, formatDoctorReport } from "./doctor.js";
 export { formatMarkdownReport, formatSarifReport, formatTextReport, hasFindingsAtOrAbove } from "./report.js";
+export { formatReviewReport, reviewProject } from "./review.js";
 export { scanProject } from "./scanner.js";
 export type { DoctorArea, DoctorPriority, DoctorResult } from "./doctor.js";
+export type { ChangedFile, ReviewOptions, ReviewResult } from "./review.js";
 export type { CodeWardConfig, Finding, ScanCounts, ScanOptions, ScanResult, Severity } from "./types.js";

--- a/src/review.ts
+++ b/src/review.ts
@@ -1,0 +1,212 @@
+import { execFile } from "node:child_process";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { scanProject } from "./scanner.js";
+import type { Finding, ScanOptions, ScanResult, Severity } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+const severityOrder: Severity[] = ["high", "medium", "low", "info"];
+
+export interface ReviewOptions {
+  base?: string;
+  head?: string;
+  scanOptions?: ScanOptions;
+}
+
+export interface ChangedFile {
+  status: string;
+  path: string;
+  previousPath?: string;
+}
+
+export interface ReviewResult {
+  tool: ScanResult["tool"];
+  root: string;
+  scannedAt: string;
+  base: string;
+  head: string;
+  changedFiles: ChangedFile[];
+  newFindings: Finding[];
+  counts: ScanResult["counts"];
+}
+
+export async function reviewProject(rootInput: string, options: ReviewOptions = {}): Promise<ReviewResult> {
+  const root = path.resolve(rootInput);
+  const base = options.base ?? (await defaultBaseRef(root));
+  const head = options.head ?? "HEAD";
+  const changedFiles = await getChangedFiles(root, base, head);
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codeward-review-"));
+
+  try {
+    const baseRoot = path.join(tempRoot, "base");
+    const headRoot = path.join(tempRoot, "head");
+    await fs.mkdir(baseRoot);
+    await fs.mkdir(headRoot);
+    await extractGitArchive(root, base, baseRoot);
+    await extractGitArchive(root, head, headRoot);
+
+    const baseResult = await scanProject(baseRoot, options.scanOptions);
+    const headResult = await scanProject(headRoot, options.scanOptions);
+    const baseFingerprints = new Set(baseResult.findings.map(fingerprintFinding));
+    const changedPathSet = new Set(changedFiles.flatMap((file) => [file.path, file.previousPath].filter(Boolean)));
+    const newFindings = headResult.findings
+      .filter((finding) => !baseFingerprints.has(fingerprintFinding(finding)))
+      .filter((finding) => shouldIncludeFinding(finding, changedPathSet))
+      .sort(compareFindings);
+
+    return {
+      tool: headResult.tool,
+      root,
+      scannedAt: headResult.scannedAt,
+      base,
+      head,
+      changedFiles,
+      newFindings,
+      counts: countFindings(newFindings),
+    };
+  } finally {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+export function formatReviewReport(result: ReviewResult): string {
+  const lines: string[] = [];
+  lines.push(`${result.tool.name} Review`);
+  lines.push(`Root: ${result.root}`);
+  lines.push(`Base: ${result.base}`);
+  lines.push(`Head: ${result.head}`);
+  lines.push(`Changed files: ${result.changedFiles.length}`);
+  lines.push(
+    `New findings: ${result.newFindings.length} (${severityOrder
+      .map((severity) => `${severity}: ${result.counts[severity]}`)
+      .join(", ")})`,
+  );
+
+  if (result.changedFiles.length > 0) {
+    lines.push("");
+    lines.push("Changed files:");
+    for (const file of result.changedFiles.slice(0, 20)) {
+      const renameSuffix = file.previousPath ? ` from ${file.previousPath}` : "";
+      lines.push(`- ${file.status} ${file.path}${renameSuffix}`);
+    }
+    if (result.changedFiles.length > 20) {
+      lines.push(`- ... ${result.changedFiles.length - 20} more`);
+    }
+  }
+
+  if (result.newFindings.length === 0) {
+    lines.push("");
+    lines.push("No new CodeWard findings were introduced by this branch.");
+    return lines.join("\n");
+  }
+
+  for (const severity of severityOrder) {
+    const findings = result.newFindings.filter((finding) => finding.severity === severity);
+    if (findings.length === 0) {
+      continue;
+    }
+
+    lines.push("");
+    lines.push(severity.toUpperCase());
+    for (const finding of findings) {
+      lines.push(`- ${finding.id} ${finding.title}${finding.file ? ` (${finding.file})` : ""}`);
+      lines.push(`  ${finding.message}`);
+      lines.push(`  Fix: ${finding.recommendation}`);
+      if (finding.evidence) {
+        lines.push(`  Evidence: ${finding.evidence}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+async function defaultBaseRef(root: string): Promise<string> {
+  for (const candidate of ["origin/main", "main", "origin/master", "master"]) {
+    try {
+      await git(root, ["rev-parse", "--verify", "--quiet", candidate]);
+      return candidate;
+    } catch {
+      // Try the next common default branch name.
+    }
+  }
+  throw new Error("Could not infer a base ref. Pass --base <ref>.");
+}
+
+async function getChangedFiles(root: string, base: string, head: string): Promise<ChangedFile[]> {
+  const { stdout } = await git(root, ["diff", "--name-status", "--diff-filter=ACMRTUXB", `${base}...${head}`]);
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map(parseChangedFile);
+}
+
+function parseChangedFile(line: string): ChangedFile {
+  const [status, firstPath, secondPath] = line.split(/\t+/);
+  if (!status || !firstPath) {
+    throw new Error(`Could not parse git diff entry: ${line}`);
+  }
+  if (status.startsWith("R") || status.startsWith("C")) {
+    return {
+      status,
+      previousPath: firstPath,
+      path: secondPath ?? firstPath,
+    };
+  }
+  return {
+    status,
+    path: firstPath,
+  };
+}
+
+async function extractGitArchive(root: string, ref: string, outputDirectory: string): Promise<void> {
+  const archivePath = path.join(outputDirectory, "archive.tar");
+  await git(root, ["archive", "--format=tar", `--output=${archivePath}`, ref]);
+  await execFileAsync("tar", ["-xf", archivePath, "-C", outputDirectory]);
+  await fs.rm(archivePath, { force: true });
+}
+
+async function git(root: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  try {
+    return await execFileAsync("git", args, { cwd: root, maxBuffer: 10 * 1024 * 1024 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`git ${args.join(" ")} failed: ${message}`);
+  }
+}
+
+function shouldIncludeFinding(finding: Finding, changedPathSet: Set<string | undefined>): boolean {
+  if (!finding.file) {
+    return true;
+  }
+  return changedPathSet.has(finding.file);
+}
+
+function fingerprintFinding(finding: Finding): string {
+  return [finding.id, finding.file ?? "", finding.title, finding.message, finding.evidence ?? ""].join("\0");
+}
+
+function compareFindings(left: Finding, right: Finding): number {
+  const severityDelta = severityOrder.indexOf(left.severity) - severityOrder.indexOf(right.severity);
+  if (severityDelta !== 0) {
+    return severityDelta;
+  }
+  const idDelta = left.id.localeCompare(right.id);
+  if (idDelta !== 0) {
+    return idDelta;
+  }
+  return (left.file ?? "").localeCompare(right.file ?? "");
+}
+
+function countFindings(findings: Finding[]): ScanResult["counts"] {
+  return findings.reduce<ScanResult["counts"]>(
+    (counts, finding) => {
+      counts[finding.severity] += 1;
+      return counts;
+    },
+    { info: 0, low: 0, medium: 0, high: 0 },
+  );
+}

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -1,21 +1,26 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 import {
   buildDoctorResult,
   formatMarkdownReport,
   formatDoctorReport,
+  formatReviewReport,
   formatSarifReport,
   generateAgentContext,
   loadConfig,
+  reviewProject,
   scanProject,
   writeDefaultConfig,
 } from "../dist/index.js";
 
 const fixtureRoot = fileURLToPath(new URL(".", import.meta.url));
+const execFileAsync = promisify(execFile);
 
 test("scanProject reports common AI agent repository risks", async () => {
   const root = await makeTempRepo();
@@ -235,6 +240,69 @@ test("doctor summarizes a complex risky repository by guardrail area", async () 
   assert.match(formatted, /Top priorities:/);
 });
 
+test("reviewProject reports findings introduced by a branch", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, ".github/workflows"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      scripts: {
+        test: "node --test",
+      },
+    }),
+  );
+  await writeFile(path.join(root, "AGENTS.md"), "# Agent Instructions\n\n- Run npm test before merge.\n");
+  await writeFile(path.join(root, "LICENSE"), "MIT");
+  await writeFile(path.join(root, "SECURITY.md"), "# Security\n");
+  await writeFile(path.join(root, "CONTRIBUTING.md"), "# Contributing\n");
+  await writeFile(
+    path.join(root, ".github/workflows/ci.yml"),
+    "name: CI\non: [pull_request]\npermissions:\n  contents: read\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/risky-agent-config"]);
+  await mkdir(path.join(root, ".cursor"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      scripts: {
+        test: "echo \"Error: no test specified\" && exit 1",
+        release: "npm publish && git push",
+      },
+    }),
+  );
+  await writeFile(
+    path.join(root, ".cursor/mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        deploy: {
+          command: "bash",
+          args: ["-lc", "npm publish"],
+        },
+      },
+    }),
+  );
+  await writeFile(path.join(root, ".env.local"), "TOKEN=not-for-tests");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "add risky agent config"]);
+
+  const review = await reviewProject(root, { base: "main", head: "HEAD" });
+  const formatted = formatReviewReport(review);
+  const ids = review.newFindings.map((finding) => finding.id);
+
+  assert.ok(ids.includes("CW004"));
+  assert.ok(ids.includes("CW006"));
+  assert.ok(ids.includes("CW008"));
+  assert.ok(ids.includes("CW009"));
+  assert.match(formatted, /CodeWard Review/);
+  assert.match(formatted, /New findings: 4/);
+  assert.match(formatted, /package.json/);
+});
+
 test("generateAgentContext reflects npm scripts and repository boundaries", async () => {
   const root = await makeTempRepo();
   await writeFile(
@@ -257,6 +325,16 @@ test("generateAgentContext reflects npm scripts and repository boundaries", asyn
 
 async function makeTempRepo() {
   return mkdtemp(path.join(tmpdir(), "codeward-test-"));
+}
+
+async function initGitRepo(root) {
+  await git(root, ["init"]);
+  await git(root, ["config", "user.email", "codeward@example.invalid"]);
+  await git(root, ["config", "user.name", "CodeWard Test"]);
+}
+
+async function git(root, args) {
+  return execFileAsync("git", args, { cwd: root, maxBuffer: 10 * 1024 * 1024 });
 }
 
 void fixtureRoot;


### PR DESCRIPTION
## Summary

- Add `codeward review` to compare base/head git snapshots and report new CodeWard findings introduced by a branch.
- Support text and JSON review output, `--base`, `--head`, `--fail-on`, and config-aware scanning.
- Add a realistic git fixture test that compares a guarded base commit with a risky branch introducing MCP config, `.env.local`, missing tests, and risky package scripts.
- Update README, adoption guide, and roadmap to include the review workflow.

## Validation

- `pnpm test`
- `pnpm build && node dist/cli.js review . --base origin/main --head HEAD --format json`
- `node dist/cli.js scan . --format json`
- `git diff --check`