### PR TITLE
Feat: add Markdown readiness outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ node dist/cli.js scan /path/to/repo
 | `codeward scan . --json` | Print machine-readable JSON for custom automation. |
 | `codeward scan . --format sarif --output codeward.sarif` | Generate SARIF for code scanning integrations. |
 | `codeward report . --output CODEWARD_REPORT.md` | Generate a Markdown report for PRs or audits. |
-| `codeward doctor .` | Summarize whether the repo is ready for AI-assisted work. |
-| `codeward review . --base origin/main --head HEAD` | Show new CodeWard findings introduced by a branch. |
+| `codeward doctor . --format markdown` | Summarize whether the repo is ready for AI-assisted work. |
+| `codeward review . --base origin/main --head HEAD --format markdown` | Show new CodeWard findings introduced by a branch. |
 | `codeward context . --write AGENTS.md` | Generate starter agent instructions for the repo. |
 | `codeward init .` | Create a starter `codeward.config.json`. |
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -27,8 +27,8 @@ Start advisory, then tighten the gate once the findings are understood.
 | Phase | Command | Goal |
 | --- | --- | --- |
 | 1. Baseline | `codeward scan .` | See current repo-level AI agent risks without blocking work. |
-| 2. Doctor | `codeward doctor .` | Get an agent-readiness summary by guardrail area. |
-| 3. Review | `codeward review . --base origin/main --head HEAD` | See new findings introduced by the branch. |
+| 2. Doctor | `codeward doctor . --format markdown` | Get an agent-readiness summary by guardrail area. |
+| 3. Review | `codeward review . --base origin/main --head HEAD --format markdown` | See new findings introduced by the branch. |
 | 4. Report | `codeward report . --output CODEWARD_REPORT.md` | Share a readable audit artifact in a PR or maintainer discussion. |
 | 5. High-risk gate | `codeward scan . --fail-on high` | Block obvious risks such as committed env files or unsafe scripts. |
 | 6. Medium-risk gate | `codeward scan . --fail-on medium` | Require stronger agent guidance, tests, and workflow permissions. |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,9 +3,9 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { loadConfig, writeDefaultConfig } from "./config.js";
 import { generateAgentContext } from "./context.js";
-import { buildDoctorResult, formatDoctorReport } from "./doctor.js";
+import { buildDoctorResult, formatDoctorReport, formatMarkdownDoctorReport } from "./doctor.js";
 import { formatMarkdownReport, formatSarifReport, formatTextReport, hasFindingsAtOrAbove } from "./report.js";
-import { formatReviewReport, reviewProject } from "./review.js";
+import { formatMarkdownReviewReport, formatReviewReport, reviewProject } from "./review.js";
 import { scanProject } from "./scanner.js";
 import { isAtLeastSeverity, isSeverity } from "./severity.js";
 import type { CodeWardConfig } from "./types.js";
@@ -252,8 +252,11 @@ function formatDoctorOutput(result: Awaited<ReturnType<typeof scanProject>>, for
   if (format === "json") {
     return `${JSON.stringify(buildDoctorResult(result), null, 2)}\n`;
   }
+  if (format === "markdown") {
+    return formatMarkdownDoctorReport(result);
+  }
   if (format !== "text") {
-    throw new Error(`Doctor supports text or json output, not ${format}`);
+    throw new Error(`Doctor supports text, json, or markdown output, not ${format}`);
   }
   return formatDoctorReport(result);
 }
@@ -262,8 +265,11 @@ function formatReviewOutput(result: Awaited<ReturnType<typeof reviewProject>>, f
   if (format === "json") {
     return `${JSON.stringify(result, null, 2)}\n`;
   }
+  if (format === "markdown") {
+    return formatMarkdownReviewReport(result);
+  }
   if (format !== "text") {
-    throw new Error(`Review supports text or json output, not ${format}`);
+    throw new Error(`Review supports text, json, or markdown output, not ${format}`);
   }
   return formatReviewReport(result);
 }
@@ -298,8 +304,8 @@ Guardrails for AI coding agents and the code they change.
 Usage:
   codeward scan [path] [--format <format>] [--fail-on <severity>] [--max-files <n>]
   codeward report [path] [--format <format>] [--output <file>] [--fail-on <severity>]
-  codeward doctor [path] [--json] [--output <file>] [--fail-on <severity>]
-  codeward review [path] [--base <ref>] [--head <ref>] [--json] [--fail-on <severity>]
+  codeward doctor [path] [--format <format>] [--output <file>] [--fail-on <severity>]
+  codeward review [path] [--base <ref>] [--head <ref>] [--format <format>] [--fail-on <severity>]
   codeward context [path] [--write [file]] [--force]
   codeward init [path] [--write <file>] [--force]
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -137,6 +137,51 @@ export function formatDoctorReport(result: ScanResult): string {
   return lines.join("\n");
 }
 
+export function formatMarkdownDoctorReport(result: ScanResult): string {
+  const doctor = buildDoctorResult(result);
+  const lines: string[] = [];
+
+  lines.push("# CodeWard Doctor");
+  lines.push("");
+  lines.push(`- Root: \`${escapeMarkdownInline(doctor.root)}\``);
+  lines.push(`- Agent readiness: **${doctor.statusLabel}**`);
+  lines.push(`- Files inspected: ${doctor.filesInspected}`);
+  lines.push("");
+  lines.push("## Summary");
+  lines.push("");
+  lines.push("| Severity | Count |");
+  lines.push("| --- | ---: |");
+  for (const severity of severityOrder) {
+    lines.push(`| ${severity} | ${doctor.counts[severity]} |`);
+  }
+  lines.push("");
+  lines.push("## Guardrail Areas");
+  lines.push("");
+  lines.push("| Status | Area | Details |");
+  lines.push("| --- | --- | --- |");
+  for (const area of doctor.areas) {
+    const ruleSuffix = area.ruleIds.length > 0 ? ` (${area.ruleIds.map((id) => `\`${id}\``).join(", ")})` : "";
+    lines.push(`| ${area.status} | ${escapeMarkdownTableCell(area.name)} | ${escapeMarkdownTableCell(area.message)}${ruleSuffix} |`);
+  }
+  lines.push("");
+  lines.push("## Top Priorities");
+  lines.push("");
+
+  if (doctor.topPriorities.length === 0) {
+    lines.push("No immediate action. Your repository looks ready for a first-pass AI agent workflow.");
+    lines.push("");
+    return lines.join("\n");
+  }
+
+  for (const priority of doctor.topPriorities) {
+    const fileSuffix = priority.file ? ` in \`${escapeMarkdownInline(priority.file)}\`` : "";
+    lines.push(`- \`${priority.id}\` **${priority.severity}**${fileSuffix}: ${priority.recommendation}`);
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
 function buildArea(area: AreaDefinition, findings: Finding[]): DoctorArea {
   const matchedRuleIds = [
     ...new Set(findings.filter((finding) => area.ruleIds.includes(finding.id)).map((finding) => finding.id)),
@@ -194,4 +239,12 @@ function sortFindings(findings: Finding[]): Finding[] {
 
 function sumCounts(counts: ScanCounts): number {
   return severityOrder.reduce((sum, severity) => sum + counts[severity], 0);
+}
+
+function escapeMarkdownInline(value: string): string {
+  return value.replaceAll("`", "'");
+}
+
+function escapeMarkdownTableCell(value: string): string {
+  return escapeMarkdownInline(value).replaceAll("|", "\\|");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 export { defaultConfig, loadConfig, writeDefaultConfig } from "./config.js";
 export { generateAgentContext } from "./context.js";
-export { buildDoctorResult, formatDoctorReport } from "./doctor.js";
+export { buildDoctorResult, formatDoctorReport, formatMarkdownDoctorReport } from "./doctor.js";
 export { formatMarkdownReport, formatSarifReport, formatTextReport, hasFindingsAtOrAbove } from "./report.js";
-export { formatReviewReport, reviewProject } from "./review.js";
+export { formatMarkdownReviewReport, formatReviewReport, reviewProject } from "./review.js";
 export { scanProject } from "./scanner.js";
 export type { DoctorArea, DoctorPriority, DoctorResult } from "./doctor.js";
 export type { ChangedFile, ReviewOptions, ReviewResult } from "./review.js";

--- a/src/review.ts
+++ b/src/review.ts
@@ -123,6 +123,68 @@ export function formatReviewReport(result: ReviewResult): string {
   return lines.join("\n");
 }
 
+export function formatMarkdownReviewReport(result: ReviewResult): string {
+  const lines: string[] = [];
+  lines.push("# CodeWard Review");
+  lines.push("");
+  lines.push(`- Root: \`${escapeMarkdownInline(result.root)}\``);
+  lines.push(`- Base: \`${escapeMarkdownInline(result.base)}\``);
+  lines.push(`- Head: \`${escapeMarkdownInline(result.head)}\``);
+  lines.push(`- Changed files: ${result.changedFiles.length}`);
+  lines.push("");
+  lines.push("## New Findings");
+  lines.push("");
+  lines.push("| Severity | Count |");
+  lines.push("| --- | ---: |");
+  for (const severity of severityOrder) {
+    lines.push(`| ${severity} | ${result.counts[severity]} |`);
+  }
+
+  if (result.changedFiles.length > 0) {
+    lines.push("");
+    lines.push("## Changed Files");
+    lines.push("");
+    for (const file of result.changedFiles.slice(0, 20)) {
+      const renameSuffix = file.previousPath ? ` from \`${escapeMarkdownInline(file.previousPath)}\`` : "";
+      lines.push(`- \`${file.status}\` \`${escapeMarkdownInline(file.path)}\`${renameSuffix}`);
+    }
+    if (result.changedFiles.length > 20) {
+      lines.push(`- ... ${result.changedFiles.length - 20} more`);
+    }
+  }
+
+  lines.push("");
+  if (result.newFindings.length === 0) {
+    lines.push("No new CodeWard findings were introduced by this branch.");
+    lines.push("");
+    return lines.join("\n");
+  }
+
+  lines.push("## Findings");
+  lines.push("");
+  for (const severity of severityOrder) {
+    const findings = result.newFindings.filter((finding) => finding.severity === severity);
+    if (findings.length === 0) {
+      continue;
+    }
+
+    lines.push(`### ${severity.toUpperCase()}`);
+    lines.push("");
+    for (const finding of findings) {
+      const fileSuffix = finding.file ? ` (${escapeMarkdownInline(finding.file)})` : "";
+      lines.push(`- \`${finding.id}\` **${escapeMarkdownInline(finding.title)}**${fileSuffix}`);
+      lines.push(`  - Message: ${escapeMarkdownInline(finding.message)}`);
+      lines.push(`  - Fix: ${escapeMarkdownInline(finding.recommendation)}`);
+      if (finding.evidence) {
+        lines.push(`  - Evidence: \`${escapeMarkdownInline(finding.evidence)}\``);
+      }
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
 async function defaultBaseRef(root: string): Promise<string> {
   for (const candidate of ["origin/main", "main", "origin/master", "master"]) {
     try {
@@ -209,4 +271,8 @@ function countFindings(findings: Finding[]): ScanResult["counts"] {
     },
     { info: 0, low: 0, medium: 0, high: 0 },
   );
+}
+
+function escapeMarkdownInline(value: string): string {
+  return value.replaceAll("`", "'");
 }

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -10,6 +10,8 @@ import {
   buildDoctorResult,
   formatMarkdownReport,
   formatDoctorReport,
+  formatMarkdownDoctorReport,
+  formatMarkdownReviewReport,
   formatReviewReport,
   formatSarifReport,
   generateAgentContext,
@@ -228,6 +230,7 @@ test("doctor summarizes a complex risky repository by guardrail area", async () 
   const result = await scanProject(root);
   const doctor = buildDoctorResult(result);
   const formatted = formatDoctorReport(result);
+  const markdown = formatMarkdownDoctorReport(result);
 
   assert.equal(doctor.status, "high-risk");
   assert.equal(doctor.areas.find((area) => area.name === "Agent instructions")?.status, "review");
@@ -238,6 +241,8 @@ test("doctor summarizes a complex risky repository by guardrail area", async () 
   assert.match(formatted, /Agent readiness: High risk/);
   assert.match(formatted, /\[review\] MCP configuration/);
   assert.match(formatted, /Top priorities:/);
+  assert.match(markdown, /# CodeWard Doctor/);
+  assert.match(markdown, /## Guardrail Areas/);
 });
 
 test("reviewProject reports findings introduced by a branch", async () => {
@@ -292,6 +297,7 @@ test("reviewProject reports findings introduced by a branch", async () => {
 
   const review = await reviewProject(root, { base: "main", head: "HEAD" });
   const formatted = formatReviewReport(review);
+  const markdown = formatMarkdownReviewReport(review);
   const ids = review.newFindings.map((finding) => finding.id);
 
   assert.ok(ids.includes("CW004"));
@@ -301,6 +307,9 @@ test("reviewProject reports findings introduced by a branch", async () => {
   assert.match(formatted, /CodeWard Review/);
   assert.match(formatted, /New findings: 4/);
   assert.match(formatted, /package.json/);
+  assert.match(markdown, /# CodeWard Review/);
+  assert.match(markdown, /## Findings/);
+  assert.match(markdown, /`CW009`/);
 });
 
 test("generateAgentContext reflects npm scripts and repository boundaries", async () => {


### PR DESCRIPTION
## Summary

- Add Markdown output for `codeward doctor` so readiness summaries can be pasted into PRs or docs.
- Add Markdown output for `codeward review` so branch risk summaries are ready for future PR comments.
- Keep text and JSON output unchanged.
- Update README/adoption docs and tests for the new formats.

## Validation

- `pnpm test`
- `pnpm build && node dist/cli.js doctor . --format markdown`
- `node dist/cli.js review . --base origin/main --head HEAD --format markdown`
- `node dist/cli.js scan . --format json`
- `git diff --check`