### PR TITLE
Feat: support workspace root package scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,11 @@ node dist/cli.js scan /path/to/repo
 | `codeward report . --output CODEWARD_REPORT.md` | Generate a Markdown report for PRs or audits. |
 | `codeward doctor . --format markdown` | Summarize whether the repo is ready for AI-assisted work. |
 | `codeward review . --base origin/main --head HEAD --format markdown` | Show new CodeWard findings introduced by a branch. |
+| `codeward doctor services/offer --workspace-root .` | Scan a monorepo package while using root guardrails. |
 | `codeward context . --write AGENTS.md` | Generate starter agent instructions for the repo. |
 | `codeward init .` | Create a starter `codeward.config.json`. |
+
+For monorepos, pass `--workspace-root` when scanning a package. Package-local checks still use the package directory, while repo-level guardrails such as `AGENTS.md`, `.github/workflows`, `LICENSE`, `SECURITY.md`, and `CONTRIBUTING.md` are read from the workspace root.
 
 ## What It Checks
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -33,6 +33,17 @@ Start advisory, then tighten the gate once the findings are understood.
 | 5. High-risk gate | `codeward scan . --fail-on high` | Block obvious risks such as committed env files or unsafe scripts. |
 | 6. Medium-risk gate | `codeward scan . --fail-on medium` | Require stronger agent guidance, tests, and workflow permissions. |
 
+## Monorepos
+
+When scanning a package inside a larger workspace, pass the workspace root so CodeWard can separate package-local risks from repository guardrails:
+
+```sh
+codeward doctor services/offer --workspace-root . --format markdown
+codeward scan services/offer --workspace-root . --json
+```
+
+With `--workspace-root`, CodeWard reads package-local files such as `package.json`, `.env.*`, and MCP config from the package path. It reads repo-level guardrails such as `AGENTS.md`, `.github/workflows`, `LICENSE`, `SECURITY.md`, and `CONTRIBUTING.md` from the workspace root.
+
 ## What To Fix First
 
 Fix high-severity findings before letting an agent work broadly in the repo.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ interface ParsedOptions {
   force: boolean;
   failOn?: Severity;
   maxFiles?: number;
+  workspaceRoot?: string;
   base?: string;
   head?: string;
 }
@@ -43,7 +44,7 @@ async function main(argv: string[]): Promise<number> {
 
   if (command === "scan") {
     const options = parseOptions(rest);
-    const loadedConfig = await loadConfig(options.path, options.config);
+    const loadedConfig = await loadOptionsConfig(options);
     const result = await scanProject(options.path, buildScanOptions(options, loadedConfig));
     const output = formatOutput(result, options.format ?? (options.json ? "json" : "text"));
     await printOrWrite(output, options.output);
@@ -53,7 +54,7 @@ async function main(argv: string[]): Promise<number> {
 
   if (command === "report") {
     const options = parseOptions(rest);
-    const loadedConfig = await loadConfig(options.path, options.config);
+    const loadedConfig = await loadOptionsConfig(options);
     const result = await scanProject(options.path, buildScanOptions(options, loadedConfig));
     const output = formatOutput(result, options.format ?? (options.json ? "json" : "markdown"));
     await printOrWrite(output, options.output);
@@ -63,7 +64,7 @@ async function main(argv: string[]): Promise<number> {
 
   if (command === "doctor") {
     const options = parseOptions(rest);
-    const loadedConfig = await loadConfig(options.path, options.config);
+    const loadedConfig = await loadOptionsConfig(options);
     const result = await scanProject(options.path, buildScanOptions(options, loadedConfig));
     const output = formatDoctorOutput(result, options.format ?? (options.json ? "json" : "text"));
     await printOrWrite(output, options.output);
@@ -73,7 +74,7 @@ async function main(argv: string[]): Promise<number> {
 
   if (command === "review") {
     const options = parseOptions(rest);
-    const loadedConfig = await loadConfig(options.path, options.config);
+    const loadedConfig = await loadOptionsConfig(options);
     const result = await reviewProject(options.path, {
       base: options.base,
       head: options.head,
@@ -159,6 +160,11 @@ function parseOptions(args: string[]): ParsedOptions {
       continue;
     }
 
+    if (arg === "--workspace-root") {
+      options.workspaceRoot = readValue(args, ++index, arg);
+      continue;
+    }
+
     if (arg === "--write") {
       const next = args[index + 1];
       if (next && !next.startsWith("-")) {
@@ -225,14 +231,20 @@ function buildScanOptions(
   configPath?: string;
   ignoreRules?: string[];
   maxFiles?: number;
+  workspaceRoot?: string;
   severityOverrides?: Record<string, Severity>;
 } {
   return {
     configPath: loadedConfig.path,
     ignoreRules: loadedConfig.config.ignoreRules,
     maxFiles: options.maxFiles ?? loadedConfig.config.maxFiles,
+    workspaceRoot: options.workspaceRoot,
     severityOverrides: loadedConfig.config.severity,
   };
+}
+
+async function loadOptionsConfig(options: ParsedOptions): Promise<{ path?: string; config: CodeWardConfig }> {
+  return loadConfig(options.workspaceRoot ?? options.path, options.config);
 }
 
 function formatOutput(result: Awaited<ReturnType<typeof scanProject>>, format: OutputFormat): string {
@@ -317,6 +329,7 @@ Formats:
 
 Examples:
   codeward scan .
+  codeward scan services/offer --workspace-root .
   codeward scan . --format sarif --output codeward.sarif
   codeward scan . --fail-on medium
   codeward report . --output CODEWARD_REPORT.md

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -28,6 +28,7 @@ export interface DoctorPriority {
 export interface DoctorResult {
   tool: ScanResult["tool"];
   root: string;
+  workspaceRoot?: string;
   scannedAt: string;
   filesInspected: number;
   status: DoctorStatus;
@@ -82,6 +83,7 @@ export function buildDoctorResult(result: ScanResult): DoctorResult {
   return {
     tool: result.tool,
     root: result.root,
+    workspaceRoot: result.workspaceRoot,
     scannedAt: result.scannedAt,
     filesInspected: result.filesInspected,
     status: readinessStatus(result.counts),
@@ -104,6 +106,9 @@ export function formatDoctorReport(result: ScanResult): string {
 
   lines.push(`${doctor.tool.name} Doctor`);
   lines.push(`Root: ${doctor.root}`);
+  if (doctor.workspaceRoot) {
+    lines.push(`Workspace root: ${doctor.workspaceRoot}`);
+  }
   lines.push(`Agent readiness: ${doctor.statusLabel}`);
   lines.push(`Files inspected: ${doctor.filesInspected}`);
   lines.push(
@@ -144,6 +149,9 @@ export function formatMarkdownDoctorReport(result: ScanResult): string {
   lines.push("# CodeWard Doctor");
   lines.push("");
   lines.push(`- Root: \`${escapeMarkdownInline(doctor.root)}\``);
+  if (doctor.workspaceRoot) {
+    lines.push(`- Workspace root: \`${escapeMarkdownInline(doctor.workspaceRoot)}\``);
+  }
   lines.push(`- Agent readiness: **${doctor.statusLabel}**`);
   lines.push(`- Files inspected: ${doctor.filesInspected}`);
   lines.push("");

--- a/src/report.ts
+++ b/src/report.ts
@@ -7,6 +7,9 @@ export function formatTextReport(result: ScanResult): string {
   const lines: string[] = [];
   lines.push(`${result.tool.name} ${result.tool.version}`);
   lines.push(`Root: ${result.root}`);
+  if (result.workspaceRoot) {
+    lines.push(`Workspace root: ${result.workspaceRoot}`);
+  }
   lines.push(
     `Findings: ${result.findings.length} (${severityOrder
       .map((severity) => `${severity}: ${result.counts[severity]}`)
@@ -46,6 +49,9 @@ export function formatMarkdownReport(result: ScanResult): string {
   lines.push("");
   lines.push(`Generated: ${result.scannedAt}`);
   lines.push(`Root: \`${result.root}\``);
+  if (result.workspaceRoot) {
+    lines.push(`Workspace root: \`${result.workspaceRoot}\``);
+  }
   lines.push(`Files inspected: ${result.filesInspected}`);
   lines.push("");
   lines.push("## Summary");

--- a/src/review.ts
+++ b/src/review.ts
@@ -34,6 +34,15 @@ export interface ReviewResult {
 
 export async function reviewProject(rootInput: string, options: ReviewOptions = {}): Promise<ReviewResult> {
   const root = path.resolve(rootInput);
+  const workspaceRoot = options.scanOptions?.workspaceRoot
+    ? path.resolve(options.scanOptions.workspaceRoot)
+    : undefined;
+  const archiveSourceRoot = workspaceRoot ?? root;
+  const relativeScanRoot = workspaceRoot ? path.relative(workspaceRoot, root) : "";
+  if (workspaceRoot && (relativeScanRoot.startsWith("..") || path.isAbsolute(relativeScanRoot))) {
+    throw new Error(`Review path must be inside workspace root: ${root}`);
+  }
+
   const base = options.base ?? (await defaultBaseRef(root));
   const head = options.head ?? "HEAD";
   const changedFiles = await getChangedFiles(root, base, head);
@@ -44,13 +53,17 @@ export async function reviewProject(rootInput: string, options: ReviewOptions = 
     const headRoot = path.join(tempRoot, "head");
     await fs.mkdir(baseRoot);
     await fs.mkdir(headRoot);
-    await extractGitArchive(root, base, baseRoot);
-    await extractGitArchive(root, head, headRoot);
+    await extractGitArchive(archiveSourceRoot, base, baseRoot);
+    await extractGitArchive(archiveSourceRoot, head, headRoot);
 
-    const baseResult = await scanProject(baseRoot, options.scanOptions);
-    const headResult = await scanProject(headRoot, options.scanOptions);
+    const baseScanRoot = relativeScanRoot ? path.join(baseRoot, relativeScanRoot) : baseRoot;
+    const headScanRoot = relativeScanRoot ? path.join(headRoot, relativeScanRoot) : headRoot;
+    const baseScanOptions = workspaceRoot ? { ...options.scanOptions, workspaceRoot: baseRoot } : options.scanOptions;
+    const headScanOptions = workspaceRoot ? { ...options.scanOptions, workspaceRoot: headRoot } : options.scanOptions;
+    const baseResult = await scanProject(baseScanRoot, baseScanOptions);
+    const headResult = await scanProject(headScanRoot, headScanOptions);
     const baseFingerprints = new Set(baseResult.findings.map(fingerprintFinding));
-    const changedPathSet = new Set(changedFiles.flatMap((file) => [file.path, file.previousPath].filter(Boolean)));
+    const changedPathSet = buildChangedPathSet(changedFiles, relativeScanRoot);
     const newFindings = headResult.findings
       .filter((finding) => !baseFingerprints.has(fingerprintFinding(finding)))
       .filter((finding) => shouldIncludeFinding(finding, changedPathSet))
@@ -245,6 +258,31 @@ function shouldIncludeFinding(finding: Finding, changedPathSet: Set<string | und
     return true;
   }
   return changedPathSet.has(finding.file);
+}
+
+function buildChangedPathSet(changedFiles: ChangedFile[], relativeScanRoot: string): Set<string | undefined> {
+  const paths = new Set<string | undefined>();
+  for (const file of changedFiles) {
+    addChangedPath(paths, file.path, relativeScanRoot);
+    addChangedPath(paths, file.previousPath, relativeScanRoot);
+  }
+  return paths;
+}
+
+function addChangedPath(paths: Set<string | undefined>, filePath: string | undefined, relativeScanRoot: string): void {
+  if (!filePath) {
+    return;
+  }
+  paths.add(filePath);
+
+  if (!relativeScanRoot) {
+    return;
+  }
+
+  const prefix = `${relativeScanRoot.split(path.sep).join("/")}/`;
+  if (filePath.startsWith(prefix)) {
+    paths.add(filePath.slice(prefix.length));
+  }
 }
 
 function fingerprintFinding(finding: Finding): string {

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from "node:fs";
+import type { Dirent } from "node:fs";
 import path from "node:path";
 import { collectProjectFiles, getFile, getFilesUnder, pathExists } from "./fs.js";
 import { TOOL_NAME, VERSION } from "./version.js";
@@ -31,16 +32,31 @@ export async function scanProject(rootInput: string, options: ScanOptions = {}):
     throw new Error(`CodeWard expected a directory: ${root}`);
   }
 
+  const workspaceRoot = options.workspaceRoot ? path.resolve(options.workspaceRoot) : undefined;
+  if (workspaceRoot) {
+    const workspaceStat = await fs.stat(workspaceRoot);
+    if (!workspaceStat.isDirectory()) {
+      throw new Error(`CodeWard expected a workspace root directory: ${workspaceRoot}`);
+    }
+    const relativeRoot = path.relative(workspaceRoot, root);
+    if (relativeRoot.startsWith("..") || path.isAbsolute(relativeRoot)) {
+      throw new Error(`CodeWard scan path must be inside workspace root: ${root}`);
+    }
+  }
+
   const files = await collectProjectFiles(root, options.maxFiles ?? defaultMaxFiles);
+  const workspaceFiles =
+    workspaceRoot && workspaceRoot !== root ? await collectWorkspaceGuardrailFiles(workspaceRoot) : [];
+  const guardrailFiles = dedupeFiles([...files, ...workspaceFiles]);
   const rawFindings = [
-    ...checkAgentInstructions(files),
-    ...checkInstructionConflicts(files),
-    ...checkSuspiciousInstructionText(files),
-    ...checkMcpConfig(files),
+    ...checkAgentInstructions(guardrailFiles),
+    ...checkInstructionConflicts(guardrailFiles),
+    ...checkSuspiciousInstructionText(guardrailFiles),
+    ...checkMcpConfig(guardrailFiles),
     ...checkPackageScripts(files),
-    ...checkGitHubActions(files),
+    ...checkGitHubActions(guardrailFiles),
     ...checkCommittedEnvFiles(files),
-    ...checkCommunityHealth(files),
+    ...checkCommunityHealth(guardrailFiles),
   ];
   const findings = applyFindingPolicy(rawFindings, options);
 
@@ -50,8 +66,9 @@ export async function scanProject(rootInput: string, options: ScanOptions = {}):
       version: VERSION,
     },
     root,
+    workspaceRoot,
     scannedAt: new Date().toISOString(),
-    filesInspected: files.length,
+    filesInspected: files.length + workspaceFiles.length,
     config:
       options.configPath || options.ignoreRules?.length || Object.keys(options.severityOverrides ?? {}).length
         ? {
@@ -63,6 +80,106 @@ export async function scanProject(rootInput: string, options: ScanOptions = {}):
     findings,
     counts: countFindings(findings),
   };
+}
+
+async function collectWorkspaceGuardrailFiles(workspaceRoot: string): Promise<ProjectFile[]> {
+  const files: ProjectFile[] = [];
+  const candidatePaths = [
+    ...instructionFileNames,
+    ...mcpConfigNames,
+    "LICENSE",
+    "SECURITY.md",
+    "CONTRIBUTING.md",
+  ];
+
+  for (const relativePath of candidatePaths) {
+    const file = await readProjectFileIfPresent(workspaceRoot, relativePath);
+    if (file) {
+      files.push(file);
+    }
+  }
+
+  const cursorRuleRoot = path.join(workspaceRoot, ".cursor/rules");
+  if (await pathExists(cursorRuleRoot)) {
+    files.push(...(await collectTextFilesUnder(workspaceRoot, cursorRuleRoot, /\.(md|mdc)$/i)));
+  }
+
+  const workflowRoot = path.join(workspaceRoot, ".github/workflows");
+  if (await pathExists(workflowRoot)) {
+    files.push(...(await collectTextFilesUnder(workspaceRoot, workflowRoot, /\.(ya?ml)$/i)));
+  }
+
+  return dedupeFiles(files);
+}
+
+async function readProjectFileIfPresent(root: string, relativePath: string): Promise<ProjectFile | undefined> {
+  const absolutePath = path.join(root, relativePath);
+  try {
+    const stat = await fs.stat(absolutePath);
+    if (!stat.isFile()) {
+      return undefined;
+    }
+    return {
+      path: relativePath,
+      absolutePath,
+      size: stat.size,
+      text: await fs.readFile(absolutePath, "utf8"),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+async function collectTextFilesUnder(root: string, directory: string, pattern: RegExp): Promise<ProjectFile[]> {
+  const files: ProjectFile[] = [];
+
+  async function walk(currentDirectory: string): Promise<void> {
+    let entries: Dirent[];
+    try {
+      entries = await fs.readdir(currentDirectory, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+
+    for (const entry of entries) {
+      const absolutePath = path.join(currentDirectory, entry.name);
+      if (entry.isDirectory()) {
+        await walk(absolutePath);
+        continue;
+      }
+      if (!entry.isFile()) {
+        continue;
+      }
+
+      const relativePath = path.relative(root, absolutePath).split(path.sep).join("/");
+      if (!pattern.test(relativePath)) {
+        continue;
+      }
+
+      const stat = await fs.stat(absolutePath);
+      files.push({
+        path: relativePath,
+        absolutePath,
+        size: stat.size,
+        text: await fs.readFile(absolutePath, "utf8"),
+      });
+    }
+  }
+
+  await walk(directory);
+  return files;
+}
+
+function dedupeFiles(files: ProjectFile[]): ProjectFile[] {
+  const seen = new Set<string>();
+  return files.filter((file) => {
+    if (seen.has(file.absolutePath)) {
+      return false;
+    }
+    seen.add(file.absolutePath);
+    return true;
+  });
 }
 
 function countFindings(findings: Finding[]): ScanCounts {

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface ScanResult {
     version: string;
   };
   root: string;
+  workspaceRoot?: string;
   scannedAt: string;
   filesInspected: number;
   config?: {
@@ -39,6 +40,7 @@ export interface ScanResult {
 
 export interface ScanOptions {
   maxFiles?: number;
+  workspaceRoot?: string;
   configPath?: string;
   ignoreRules?: string[];
   severityOverrides?: Record<string, Severity>;

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -96,6 +96,40 @@ test("scanProject stays quiet for a guarded repository", async () => {
   assert.equal(result.findings.length, 0);
 });
 
+test("scanProject uses workspace root guardrails for package scans", async () => {
+  const workspaceRoot = await makeTempRepo();
+  const packageRoot = path.join(workspaceRoot, "services/offer");
+  await mkdir(path.join(workspaceRoot, ".github/workflows"), { recursive: true });
+  await mkdir(packageRoot, { recursive: true });
+  await writeWorkspaceGuardrails(workspaceRoot);
+  await writeFile(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify({
+      scripts: {
+        lint: "next lint",
+        typecheck: "tsc --noEmit",
+      },
+    }),
+  );
+  await writeFile(path.join(packageRoot, ".env.local"), "TOKEN=not-for-tests");
+
+  const packageOnly = await scanProject(packageRoot);
+  const packageOnlyIds = packageOnly.findings.map((finding) => finding.id);
+  assert.ok(packageOnlyIds.includes("CW001"));
+  assert.ok(packageOnlyIds.includes("CW007"));
+  assert.ok(packageOnlyIds.includes("CW011"));
+
+  const withWorkspaceRoot = await scanProject(packageRoot, { workspaceRoot });
+  const ids = withWorkspaceRoot.findings.map((finding) => finding.id);
+
+  assert.equal(withWorkspaceRoot.workspaceRoot, workspaceRoot);
+  assert.equal(ids.includes("CW001"), false);
+  assert.equal(ids.includes("CW007"), false);
+  assert.equal(ids.includes("CW011"), false);
+  assert.ok(ids.includes("CW006"));
+  assert.ok(ids.includes("CW008"));
+});
+
 test("formatMarkdownReport includes a useful summary", async () => {
   const root = await makeTempRepo();
   const result = await scanProject(root);
@@ -312,6 +346,53 @@ test("reviewProject reports findings introduced by a branch", async () => {
   assert.match(markdown, /`CW009`/);
 });
 
+test("reviewProject uses workspace root guardrails for package branches", async () => {
+  const workspaceRoot = await makeTempRepo();
+  const packageRoot = path.join(workspaceRoot, "services/offer");
+  await initGitRepo(workspaceRoot);
+  await mkdir(packageRoot, { recursive: true });
+  await writeWorkspaceGuardrails(workspaceRoot);
+  await writeFile(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify({
+      scripts: {
+        test: "node --test",
+      },
+    }),
+  );
+  await git(workspaceRoot, ["add", "."]);
+  await git(workspaceRoot, ["commit", "-m", "base"]);
+  await git(workspaceRoot, ["branch", "-M", "main"]);
+
+  await git(workspaceRoot, ["switch", "-c", "feature/package-risk"]);
+  await writeFile(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify({
+      scripts: {
+        typecheck: "tsc --noEmit",
+      },
+    }),
+  );
+  await writeFile(path.join(packageRoot, ".env.local"), "TOKEN=not-for-tests");
+  await git(workspaceRoot, ["add", "."]);
+  await git(workspaceRoot, ["commit", "-m", "add package risk"]);
+
+  const review = await reviewProject(packageRoot, {
+    base: "main",
+    head: "HEAD",
+    scanOptions: {
+      workspaceRoot,
+    },
+  });
+  const ids = review.newFindings.map((finding) => finding.id);
+
+  assert.ok(ids.includes("CW006"));
+  assert.ok(ids.includes("CW008"));
+  assert.equal(ids.includes("CW001"), false);
+  assert.equal(ids.includes("CW007"), false);
+  assert.equal(ids.includes("CW011"), false);
+});
+
 test("generateAgentContext reflects npm scripts and repository boundaries", async () => {
   const root = await makeTempRepo();
   await writeFile(
@@ -340,6 +421,18 @@ async function initGitRepo(root) {
   await git(root, ["init"]);
   await git(root, ["config", "user.email", "codeward@example.invalid"]);
   await git(root, ["config", "user.name", "CodeWard Test"]);
+}
+
+async function writeWorkspaceGuardrails(root) {
+  await mkdir(path.join(root, ".github/workflows"), { recursive: true });
+  await writeFile(path.join(root, "AGENTS.md"), "# Agent Instructions\n\n- Run package validation before merge.\n");
+  await writeFile(path.join(root, "LICENSE"), "MIT");
+  await writeFile(path.join(root, "SECURITY.md"), "# Security\n");
+  await writeFile(path.join(root, "CONTRIBUTING.md"), "# Contributing\n");
+  await writeFile(
+    path.join(root, ".github/workflows/ci.yml"),
+    "name: CI\non: [pull_request]\npermissions:\n  contents: read\n",
+  );
 }
 
 async function git(root, args) {


### PR DESCRIPTION
## Summary

- Add `--workspace-root` so monorepo package scans can use root-level guardrails without scanning the entire workspace as package-local risk.
- Keep package-local checks focused on the package path while reading agent instructions, MCP config, CI workflows, and community health files from the workspace root.
- Make `review` workspace-root aware by comparing archived base/head workspace snapshots and mapping workspace-relative changes back to package-relative findings.
- Show workspace root in text/Markdown/JSON scan and doctor outputs.
- Add monorepo package scan and branch review fixture tests.

## Real-world check

Tested against `/Users/khs/Desktop/inpock-frontend/services/offer` with `--workspace-root /Users/khs/Desktop/inpock-frontend`. The previous package-scan noise for missing agent instructions and missing CI disappeared, while package-local `.env.*`, missing test script, and root workflow permission findings remained visible.

## Validation

- `pnpm test`
- `pnpm build && node dist/cli.js doctor /Users/khs/Desktop/inpock-frontend/services/offer --workspace-root /Users/khs/Desktop/inpock-frontend --format markdown`
- `node dist/cli.js review /Users/khs/Desktop/inpock-frontend/services/offer --workspace-root /Users/khs/Desktop/inpock-frontend --base origin/main --head HEAD --format markdown`
- `node dist/cli.js scan . --format json`
- `git diff --check`