### PR TITLE
Feat: flag changed risky files in review

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,14 @@ node dist/cli.js scan /path/to/repo
 | `codeward scan . --format sarif --output codeward.sarif` | Generate SARIF for code scanning integrations. |
 | `codeward report . --output CODEWARD_REPORT.md` | Generate a Markdown report for PRs or audits. |
 | `codeward doctor . --format markdown` | Summarize whether the repo is ready for AI-assisted work. |
-| `codeward review . --base origin/main --head HEAD --format markdown` | Show new CodeWard findings introduced by a branch. |
+| `codeward review . --base origin/main --head HEAD --format markdown` | Show new findings and changed risky files introduced by a branch. |
 | `codeward doctor services/offer --workspace-root .` | Scan a monorepo package while using root guardrails. |
 | `codeward context . --write AGENTS.md` | Generate starter agent instructions for the repo. |
 | `codeward init .` | Create a starter `codeward.config.json`. |
 
 For monorepos, pass `--workspace-root` when scanning a package. Package-local checks still use the package directory, while repo-level guardrails such as `AGENTS.md`, `.github/workflows`, `LICENSE`, `SECURITY.md`, and `CONTRIBUTING.md` are read from the workspace root.
+
+`codeward review` compares a branch against a base ref for PR-style workflows. It separates newly introduced findings from risky files that already had findings on the base branch but were modified again, which helps reviewers notice when a PR touches known-dangerous surfaces such as committed `.env` files, MCP configs, or release scripts.
 
 ## What It Checks
 
@@ -206,7 +208,7 @@ Near-term priorities:
 
 - publish the first npm package
 - add a GitHub Action wrapper with PR annotations
-- improve branch-aware `review` output for PR comments and annotations
+- improve branch-aware `review` annotations for GitHub PR comments
 - expand agent instruction detection across Codex, Claude Code, Cursor, Copilot, Gemini, and related surfaces
 - generate rule documentation from scanner metadata
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -83,7 +83,8 @@ async function main(argv: string[]): Promise<number> {
     const output = formatReviewOutput(result, options.format ?? (options.json ? "json" : "text"));
     await printOrWrite(output, options.output);
     const failOn = options.failOn ?? loadedConfig.config.failOn;
-    return failOn && result.newFindings.some((finding) => isAtLeastSeverity(finding.severity, failOn)) ? 1 : 0;
+    const reviewFindings = [...result.newFindings, ...result.changedRiskyFindings];
+    return failOn && reviewFindings.some((finding) => isAtLeastSeverity(finding.severity, failOn)) ? 1 : 0;
   }
 
   if (command === "context") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,5 @@ export { formatMarkdownReport, formatSarifReport, formatTextReport, hasFindingsA
 export { formatMarkdownReviewReport, formatReviewReport, reviewProject } from "./review.js";
 export { scanProject } from "./scanner.js";
 export type { DoctorArea, DoctorPriority, DoctorResult } from "./doctor.js";
-export type { ChangedFile, ReviewOptions, ReviewResult } from "./review.js";
+export type { ChangedFile, ChangedRiskyFinding, ReviewOptions, ReviewResult } from "./review.js";
 export type { CodeWardConfig, Finding, ScanCounts, ScanOptions, ScanResult, Severity } from "./types.js";

--- a/src/review.ts
+++ b/src/review.ts
@@ -21,6 +21,12 @@ export interface ChangedFile {
   previousPath?: string;
 }
 
+export interface ChangedRiskyFinding extends Finding {
+  file: string;
+  status: string;
+  previousPath?: string;
+}
+
 export interface ReviewResult {
   tool: ScanResult["tool"];
   root: string;
@@ -29,7 +35,9 @@ export interface ReviewResult {
   head: string;
   changedFiles: ChangedFile[];
   newFindings: Finding[];
+  changedRiskyFindings: ChangedRiskyFinding[];
   counts: ScanResult["counts"];
+  changedRiskyCounts: ScanResult["counts"];
 }
 
 export async function reviewProject(rootInput: string, options: ReviewOptions = {}): Promise<ReviewResult> {
@@ -63,10 +71,25 @@ export async function reviewProject(rootInput: string, options: ReviewOptions = 
     const baseResult = await scanProject(baseScanRoot, baseScanOptions);
     const headResult = await scanProject(headScanRoot, headScanOptions);
     const baseFingerprints = new Set(baseResult.findings.map(fingerprintFinding));
+    const baseStableKeys = new Set(baseResult.findings.map(stableFindingKey));
     const changedPathSet = buildChangedPathSet(changedFiles, relativeScanRoot);
+    const changedFileMap = buildChangedFileMap(changedFiles, relativeScanRoot);
     const newFindings = headResult.findings
       .filter((finding) => !baseFingerprints.has(fingerprintFinding(finding)))
       .filter((finding) => shouldIncludeFinding(finding, changedPathSet))
+      .sort(compareFindings);
+    const newFingerprints = new Set(newFindings.map(fingerprintFinding));
+    const changedRiskyFindings = headResult.findings
+      .filter((finding): finding is Finding & { file: string } => Boolean(finding.file))
+      .filter((finding) => baseStableKeys.has(stableFindingKey(finding)))
+      .filter((finding) => !newFingerprints.has(fingerprintFinding(finding)))
+      .flatMap((finding) => {
+        const changedFile = changedFileMap.get(finding.file);
+        if (!changedFile) {
+          return [];
+        }
+        return [toChangedRiskyFinding(finding, changedFile)];
+      })
       .sort(compareFindings);
 
     return {
@@ -77,7 +100,9 @@ export async function reviewProject(rootInput: string, options: ReviewOptions = 
       head,
       changedFiles,
       newFindings,
+      changedRiskyFindings,
       counts: countFindings(newFindings),
+      changedRiskyCounts: countFindings(changedRiskyFindings),
     };
   } finally {
     await fs.rm(tempRoot, { recursive: true, force: true });
@@ -96,6 +121,11 @@ export function formatReviewReport(result: ReviewResult): string {
       .map((severity) => `${severity}: ${result.counts[severity]}`)
       .join(", ")})`,
   );
+  lines.push(
+    `Changed risky files: ${result.changedRiskyFindings.length} (${severityOrder
+      .map((severity) => `${severity}: ${result.changedRiskyCounts[severity]}`)
+      .join(", ")})`,
+  );
 
   if (result.changedFiles.length > 0) {
     lines.push("");
@@ -109,23 +139,42 @@ export function formatReviewReport(result: ReviewResult): string {
     }
   }
 
-  if (result.newFindings.length === 0) {
+  if (result.newFindings.length === 0 && result.changedRiskyFindings.length === 0) {
     lines.push("");
-    lines.push("No new CodeWard findings were introduced by this branch.");
+    lines.push("No new CodeWard findings or changed risky files were introduced by this branch.");
     return lines.join("\n");
   }
 
-  for (const severity of severityOrder) {
-    const findings = result.newFindings.filter((finding) => finding.severity === severity);
-    if (findings.length === 0) {
-      continue;
-    }
-
+  if (result.newFindings.length === 0) {
     lines.push("");
-    lines.push(severity.toUpperCase());
-    for (const finding of findings) {
-      lines.push(`- ${finding.id} ${finding.title}${finding.file ? ` (${finding.file})` : ""}`);
-      lines.push(`  ${finding.message}`);
+    lines.push("No new CodeWard findings were introduced by this branch.");
+  } else {
+    for (const severity of severityOrder) {
+      const findings = result.newFindings.filter((finding) => finding.severity === severity);
+      if (findings.length === 0) {
+        continue;
+      }
+
+      lines.push("");
+      lines.push(severity.toUpperCase());
+      for (const finding of findings) {
+        lines.push(`- ${finding.id} ${finding.title}${finding.file ? ` (${finding.file})` : ""}`);
+        lines.push(`  ${finding.message}`);
+        lines.push(`  Fix: ${finding.recommendation}`);
+        if (finding.evidence) {
+          lines.push(`  Evidence: ${finding.evidence}`);
+        }
+      }
+    }
+  }
+
+  if (result.changedRiskyFindings.length > 0) {
+    lines.push("");
+    lines.push("Changed risky files:");
+    for (const finding of result.changedRiskyFindings) {
+      const renameSuffix = finding.previousPath ? ` from ${finding.previousPath}` : "";
+      lines.push(`- ${finding.id} ${finding.title} (${finding.file}, ${finding.status}${renameSuffix})`);
+      lines.push("  Existing finding on base; this file changed in the branch.");
       lines.push(`  Fix: ${finding.recommendation}`);
       if (finding.evidence) {
         lines.push(`  Evidence: ${finding.evidence}`);
@@ -144,6 +193,7 @@ export function formatMarkdownReviewReport(result: ReviewResult): string {
   lines.push(`- Base: \`${escapeMarkdownInline(result.base)}\``);
   lines.push(`- Head: \`${escapeMarkdownInline(result.head)}\``);
   lines.push(`- Changed files: ${result.changedFiles.length}`);
+  lines.push(`- Changed risky files: ${result.changedRiskyFindings.length}`);
   lines.push("");
   lines.push("## New Findings");
   lines.push("");
@@ -167,30 +217,51 @@ export function formatMarkdownReviewReport(result: ReviewResult): string {
   }
 
   lines.push("");
-  if (result.newFindings.length === 0) {
-    lines.push("No new CodeWard findings were introduced by this branch.");
+  if (result.newFindings.length === 0 && result.changedRiskyFindings.length === 0) {
+    lines.push("No new CodeWard findings or changed risky files were introduced by this branch.");
     lines.push("");
     return lines.join("\n");
   }
 
-  lines.push("## Findings");
-  lines.push("");
-  for (const severity of severityOrder) {
-    const findings = result.newFindings.filter((finding) => finding.severity === severity);
-    if (findings.length === 0) {
-      continue;
-    }
-
-    lines.push(`### ${severity.toUpperCase()}`);
+  if (result.newFindings.length === 0) {
+    lines.push("No new CodeWard findings were introduced by this branch.");
     lines.push("");
-    for (const finding of findings) {
-      const fileSuffix = finding.file ? ` (${escapeMarkdownInline(finding.file)})` : "";
-      lines.push(`- \`${finding.id}\` **${escapeMarkdownInline(finding.title)}**${fileSuffix}`);
-      lines.push(`  - Message: ${escapeMarkdownInline(finding.message)}`);
-      lines.push(`  - Fix: ${escapeMarkdownInline(finding.recommendation)}`);
-      if (finding.evidence) {
-        lines.push(`  - Evidence: \`${escapeMarkdownInline(finding.evidence)}\``);
+  } else {
+    lines.push("## Findings");
+    lines.push("");
+    for (const severity of severityOrder) {
+      const findings = result.newFindings.filter((finding) => finding.severity === severity);
+      if (findings.length === 0) {
+        continue;
       }
+
+      lines.push(`### ${severity.toUpperCase()}`);
+      lines.push("");
+      for (const finding of findings) {
+        const fileSuffix = finding.file ? ` (${escapeMarkdownInline(finding.file)})` : "";
+        lines.push(`- \`${finding.id}\` **${escapeMarkdownInline(finding.title)}**${fileSuffix}`);
+        lines.push(`  - Message: ${escapeMarkdownInline(finding.message)}`);
+        lines.push(`  - Fix: ${escapeMarkdownInline(finding.recommendation)}`);
+        if (finding.evidence) {
+          lines.push(`  - Evidence: \`${escapeMarkdownInline(finding.evidence)}\``);
+        }
+      }
+      lines.push("");
+    }
+  }
+
+  if (result.changedRiskyFindings.length > 0) {
+    lines.push("## Changed Risky Files");
+    lines.push("");
+    lines.push("| Rule | Severity | File | Status | Recommendation |");
+    lines.push("| --- | --- | --- | --- | --- |");
+    for (const finding of result.changedRiskyFindings) {
+      const renameSuffix = finding.previousPath ? ` from ${finding.previousPath}` : "";
+      lines.push(
+        `| \`${finding.id}\` | ${finding.severity} | \`${escapeMarkdownCell(finding.file)}\` | \`${escapeMarkdownCell(
+          `${finding.status}${renameSuffix}`,
+        )}\` | ${escapeMarkdownCell(finding.recommendation)} |`,
+      );
     }
     lines.push("");
   }
@@ -260,6 +331,14 @@ function shouldIncludeFinding(finding: Finding, changedPathSet: Set<string | und
   return changedPathSet.has(finding.file);
 }
 
+function toChangedRiskyFinding(finding: Finding & { file: string }, changedFile: ChangedFile): ChangedRiskyFinding {
+  return {
+    ...finding,
+    status: changedFile.status,
+    previousPath: changedFile.previousPath,
+  };
+}
+
 function buildChangedPathSet(changedFiles: ChangedFile[], relativeScanRoot: string): Set<string | undefined> {
   const paths = new Set<string | undefined>();
   for (const file of changedFiles) {
@@ -285,8 +364,42 @@ function addChangedPath(paths: Set<string | undefined>, filePath: string | undef
   }
 }
 
+function buildChangedFileMap(changedFiles: ChangedFile[], relativeScanRoot: string): Map<string, ChangedFile> {
+  const paths = new Map<string, ChangedFile>();
+  for (const file of changedFiles) {
+    addChangedFile(paths, file.path, file, relativeScanRoot);
+    addChangedFile(paths, file.previousPath, file, relativeScanRoot);
+  }
+  return paths;
+}
+
+function addChangedFile(
+  paths: Map<string, ChangedFile>,
+  filePath: string | undefined,
+  changedFile: ChangedFile,
+  relativeScanRoot: string,
+): void {
+  if (!filePath) {
+    return;
+  }
+  paths.set(filePath, changedFile);
+
+  if (!relativeScanRoot) {
+    return;
+  }
+
+  const prefix = `${relativeScanRoot.split(path.sep).join("/")}/`;
+  if (filePath.startsWith(prefix)) {
+    paths.set(filePath.slice(prefix.length), changedFile);
+  }
+}
+
 function fingerprintFinding(finding: Finding): string {
   return [finding.id, finding.file ?? "", finding.title, finding.message, finding.evidence ?? ""].join("\0");
+}
+
+function stableFindingKey(finding: Finding): string {
+  return [finding.id, finding.file ?? "", finding.title].join("\0");
 }
 
 function compareFindings(left: Finding, right: Finding): number {
@@ -313,4 +426,8 @@ function countFindings(findings: Finding[]): ScanResult["counts"] {
 
 function escapeMarkdownInline(value: string): string {
   return value.replaceAll("`", "'");
+}
+
+function escapeMarkdownCell(value: string): string {
+  return escapeMarkdownInline(value).replaceAll("|", "\\|");
 }

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -21,7 +21,7 @@ import {
   writeDefaultConfig,
 } from "../dist/index.js";
 
-const fixtureRoot = fileURLToPath(new URL(".", import.meta.url));
+const cliPath = fileURLToPath(new URL("../dist/cli.js", import.meta.url));
 const execFileAsync = promisify(execFile);
 
 test("scanProject reports common AI agent repository risks", async () => {
@@ -346,6 +346,67 @@ test("reviewProject reports findings introduced by a branch", async () => {
   assert.match(markdown, /`CW009`/);
 });
 
+test("reviewProject reports risky files changed by a branch", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, ".github/workflows"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      scripts: {
+        test: "node --test",
+      },
+    }),
+  );
+  await writeFile(path.join(root, "AGENTS.md"), "# Agent Instructions\n\n- Run npm test before merge.\n");
+  await writeFile(path.join(root, "LICENSE"), "MIT");
+  await writeFile(path.join(root, "SECURITY.md"), "# Security\n");
+  await writeFile(path.join(root, "CONTRIBUTING.md"), "# Contributing\n");
+  await writeFile(
+    path.join(root, ".github/workflows/ci.yml"),
+    "name: CI\non: [pull_request]\npermissions:\n  contents: read\n",
+  );
+  await writeFile(path.join(root, ".env"), "TOKEN=base-value");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/change-env"]);
+  await writeFile(path.join(root, ".env"), "TOKEN=changed-value");
+  await git(root, ["add", ".env"]);
+  await git(root, ["commit", "-m", "change env"]);
+
+  const review = await reviewProject(root, { base: "main", head: "HEAD" });
+  const formatted = formatReviewReport(review);
+  const markdown = formatMarkdownReviewReport(review);
+
+  assert.equal(review.newFindings.length, 0);
+  assert.equal(review.changedRiskyFindings.length, 1);
+  assert.equal(review.changedRiskyCounts.high, 1);
+  assert.equal(review.changedRiskyFindings[0].id, "CW008");
+  assert.equal(review.changedRiskyFindings[0].file, ".env");
+  assert.equal(review.changedRiskyFindings[0].status, "M");
+  assert.match(formatted, /Changed risky files: 1/);
+  assert.match(formatted, /Existing finding on base/);
+  assert.match(markdown, /## Changed Risky Files/);
+  assert.match(markdown, /`CW008`/);
+  await assert.rejects(
+    () =>
+      execFileAsync(process.execPath, [
+        cliPath,
+        "review",
+        root,
+        "--base",
+        "main",
+        "--head",
+        "HEAD",
+        "--fail-on",
+        "high",
+      ]),
+    /Command failed/,
+  );
+});
+
 test("reviewProject uses workspace root guardrails for package branches", async () => {
   const workspaceRoot = await makeTempRepo();
   const packageRoot = path.join(workspaceRoot, "services/offer");
@@ -438,5 +499,3 @@ async function writeWorkspaceGuardrails(root) {
 async function git(root, args) {
   return execFileAsync("git", args, { cwd: root, maxBuffer: 10 * 1024 * 1024 });
 }
-
-void fixtureRoot;


### PR DESCRIPTION
## Summary

- Add `changedRiskyFindings` to branch review results for findings that already existed on the base branch but whose files were modified in the PR.
- Show changed risky files in text, Markdown, and JSON review output, with severity counts and changed-file status.
- Make `codeward review --fail-on` fail for both newly introduced findings and changed risky findings.
- Document the review behavior and move the roadmap item toward PR annotations.

## Validation

- `pnpm test`
- `pnpm scan`
- `git diff --check`
- Real-world read-only check: `/Users/khs/Desktop/inpock-app-client` now reports changed risky files for `.env` and `.env.production` with no new findings.
- Real-world read-only check: `/Users/khs/Desktop/inpock-frontend/services/offer --workspace-root /Users/khs/Desktop/inpock-frontend` reports no new findings or changed risky files for the committed branch diff.
