### PR TITLE
Feat: expand agent surface coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Repo-level preflight checks before AI coding agents touch your code.**
 
-CodeWard scans the repository surface that AI coding agents rely on: agent instructions, MCP configuration, local environment files, package scripts, GitHub Actions permissions, community health files, and validation signals.
+CodeWard scans the repository surface that AI coding agents rely on: agent instructions, MCP configuration, agent settings and hooks, local environment files, package scripts, GitHub Actions permissions, community health files, and validation signals.
 
 It is built for teams using Codex, Claude Code, Cursor, GitHub Copilot coding agent, MCP-powered tools, or any workflow where an agent can read, edit, test, commit, or open pull requests.
 
@@ -35,6 +35,7 @@ CodeWard gives maintainers a quick first line of defense:
 
 - Is there clear guidance for agents?
 - Are MCP configs safe enough to inspect?
+- Are committed agent settings or hooks able to run risky commands?
 - Did a local `.env` file slip into the repo?
 - Can package scripts publish, push, merge, or run risky shell pipelines?
 - Are workflows using broad permissions or risky triggers?
@@ -136,8 +137,10 @@ The first release focuses on high-signal checks that are useful across many repo
 | `CW009` | high | Package scripts that can publish, push, merge, or run unsafe shell pipelines. |
 | `CW010` | medium | Broad workflow permissions or risky workflow triggers. |
 | `CW011` | low | Missing community health files. |
+| `CW012` | medium/high | Risky committed agent settings, hooks, or broad shell permissions. |
 
 See [docs/rules.md](docs/rules.md) for the rule catalog.
+See [docs/ecosystem.md](docs/ecosystem.md) for the agent ecosystem surfaces CodeWard tracks.
 
 ## Configuration
 
@@ -209,7 +212,7 @@ Near-term priorities:
 - publish the first npm package
 - add a GitHub Action wrapper with PR annotations
 - improve branch-aware `review` annotations for GitHub PR comments
-- expand agent instruction detection across Codex, Claude Code, Cursor, Copilot, Gemini, and related surfaces
+- continue expanding agent surface detection across Codex, Claude Code, Cursor, Copilot, Gemini, and related tools
 - generate rule documentation from scanner metadata
 
 See [docs/roadmap.md](docs/roadmap.md) for more detail.

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -1,0 +1,41 @@
+# Agent Ecosystem Coverage
+
+AI coding agents now read repository instructions, connect to MCP servers, run tool hooks, and prepare pull requests. CodeWard tracks the repository files that shape those behaviors without executing project code.
+
+## Instruction Surfaces
+
+CodeWard treats these files as agent instruction surfaces:
+
+| Ecosystem | Files |
+| --- | --- |
+| Shared / Codex-style | `AGENTS.md`, `AGENTS.override.md` |
+| Claude Code | `CLAUDE.md`, `.claude/CLAUDE.md`, `.claude/rules/*.md` |
+| Cursor | `.cursorrules`, `.cursor/rules/*.md`, `.cursor/rules/*.mdc` |
+| GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` |
+| Gemini CLI | `GEMINI.md` |
+
+These files are scanned for missing guidance, conflicting guidance, and suspicious instruction text.
+
+## Tool And Settings Surfaces
+
+CodeWard statically inspects committed MCP and agent settings files:
+
+| Surface | Files | Checks |
+| --- | --- | --- |
+| MCP config | `.mcp.json`, `mcp.json`, `.cursor/mcp.json`, `.vscode/mcp.json`, `claude_desktop_config.json` | unreadable JSON, risky commands, committed secret-like env values |
+| Agent settings | `.claude/settings.json`, `.claude/settings.local.json`, `.gemini/settings.json` | MCP servers, risky hooks, broad shell permissions |
+
+The scanner does not run MCP servers, hooks, package scripts, or project code.
+
+## Source Signals
+
+These references guide the current coverage:
+
+- [OpenAI Codex AGENTS.md](https://developers.openai.com/codex/cloud/agents-md/) and the community [AGENTS.md](https://agents.md/) convention.
+- [Claude Code memory](https://docs.anthropic.com/en/docs/claude-code/memory), [settings](https://docs.anthropic.com/en/docs/claude-code/settings), and [hooks](https://docs.anthropic.com/en/docs/claude-code/hooks).
+- [GitHub Copilot custom instructions](https://docs.github.com/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot).
+- [Cursor rules](https://cursor.com/docs/rules) and [Cursor MCP](https://cursor.com/docs/mcp).
+- [Gemini CLI configuration](https://google-gemini.github.io/gemini-cli/docs/get-started/configuration.html) and [Gemini MCP servers](https://google-gemini.github.io/gemini-cli/docs/tools/mcp-server.html).
+- [Model Context Protocol security best practices](https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices).
+
+CodeWard should keep this list practical rather than exhaustive: add a surface when it is common enough that maintainers would reasonably expect a repo preflight check to notice it.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,7 @@ CodeWard starts as a local CLI for repo-level AI agent readiness. The project ca
 - Add a GitHub Action wrapper with PR annotations.
 - Improve `doctor` output with clearer scoring and remediation grouping.
 - Improve `review` output for PR comments, summaries, and changed-line locations.
-- Expand agent instruction detection across Codex, Claude Code, Cursor, GitHub Copilot, Gemini, and related surfaces.
+- Continue expanding agent surface detection across Codex, Claude Code, Cursor, GitHub Copilot, Gemini, and related tools.
 - Generate rule documentation from scanner metadata.
 
 ## Later

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -17,6 +17,7 @@ Rule behavior can be tuned in `codeward.config.json`. See [configuration.md](con
 | `CW009` | high | Package scripts can publish, push, merge, or run unsafe shell pipelines. |
 | `CW010` | medium | GitHub Actions workflow grants broad permissions or uses risky triggers. |
 | `CW011` | low | Community health files are missing. |
+| `CW012` | medium/high | Committed agent settings define risky hooks or broad shell permissions. |
 
 ## Rule Design
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -48,10 +48,10 @@ const areaDefinitions: AreaDefinition[] = [
     reviewMessage: "Agent guidance needs attention before broad agent use.",
   },
   {
-    name: "MCP configuration",
-    ruleIds: ["CW004", "CW005"],
-    okMessage: "No risky committed MCP configuration was detected.",
-    reviewMessage: "MCP configuration should be reviewed before agent sessions.",
+    name: "MCP and agent settings",
+    ruleIds: ["CW004", "CW005", "CW012"],
+    okMessage: "No risky committed MCP configuration or agent settings were detected.",
+    reviewMessage: "MCP configuration or agent settings should be reviewed before agent sessions.",
   },
   {
     name: "Validation",

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -9,11 +9,19 @@ const defaultMaxFiles = 2000;
 
 const instructionFileNames = new Set([
   "AGENTS.md",
+  "AGENTS.override.md",
   "CLAUDE.md",
+  ".claude/CLAUDE.md",
   "GEMINI.md",
   ".github/copilot-instructions.md",
   ".cursorrules",
 ]);
+
+const instructionDirectoryPatterns = [
+  { directory: ".cursor/rules", pattern: /\.(md|mdc)$/i },
+  { directory: ".claude/rules", pattern: /\.(md|mdc)$/i },
+  { directory: ".github/instructions", pattern: /\.instructions\.md$/i },
+];
 
 const mcpConfigNames = new Set([
   ".mcp.json",
@@ -22,6 +30,8 @@ const mcpConfigNames = new Set([
   ".vscode/mcp.json",
   "claude_desktop_config.json",
 ]);
+
+const agentSettingsNames = new Set([".claude/settings.json", ".claude/settings.local.json", ".gemini/settings.json"]);
 
 const secretKeyPattern = /(token|secret|password|passwd|api[_-]?key|private[_-]?key|credential)/i;
 
@@ -53,6 +63,7 @@ export async function scanProject(rootInput: string, options: ScanOptions = {}):
     ...checkInstructionConflicts(guardrailFiles),
     ...checkSuspiciousInstructionText(guardrailFiles),
     ...checkMcpConfig(guardrailFiles),
+    ...checkAgentSettings(guardrailFiles),
     ...checkPackageScripts(files),
     ...checkGitHubActions(guardrailFiles),
     ...checkCommittedEnvFiles(files),
@@ -87,6 +98,7 @@ async function collectWorkspaceGuardrailFiles(workspaceRoot: string): Promise<Pr
   const candidatePaths = [
     ...instructionFileNames,
     ...mcpConfigNames,
+    ...agentSettingsNames,
     "LICENSE",
     "SECURITY.md",
     "CONTRIBUTING.md",
@@ -99,9 +111,11 @@ async function collectWorkspaceGuardrailFiles(workspaceRoot: string): Promise<Pr
     }
   }
 
-  const cursorRuleRoot = path.join(workspaceRoot, ".cursor/rules");
-  if (await pathExists(cursorRuleRoot)) {
-    files.push(...(await collectTextFilesUnder(workspaceRoot, cursorRuleRoot, /\.(md|mdc)$/i)));
+  for (const ruleDirectory of instructionDirectoryPatterns) {
+    const instructionRoot = path.join(workspaceRoot, ruleDirectory.directory);
+    if (await pathExists(instructionRoot)) {
+      files.push(...(await collectTextFilesUnder(workspaceRoot, instructionRoot, ruleDirectory.pattern)));
+    }
   }
 
   const workflowRoot = path.join(workspaceRoot, ".github/workflows");
@@ -231,8 +245,15 @@ function getInstructionFiles(files: ProjectFile[]): ProjectFile[] {
     if (instructionFileNames.has(file.path)) {
       return true;
     }
-    return file.path.startsWith(".cursor/rules/") && /\.(md|mdc)$/i.test(file.path);
+    return instructionDirectoryPatterns.some((ruleDirectory) =>
+      matchesDirectoryPattern(file.path, ruleDirectory.directory, ruleDirectory.pattern),
+    );
   });
+}
+
+function matchesDirectoryPattern(filePath: string, directory: string, pattern: RegExp): boolean {
+  const prefix = directory.endsWith("/") ? directory : `${directory}/`;
+  return filePath.startsWith(prefix) && pattern.test(filePath);
 }
 
 function checkAgentInstructions(files: ProjectFile[]): Finding[] {
@@ -247,7 +268,7 @@ function checkAgentInstructions(files: ProjectFile[]): Finding[] {
       id: "CW001",
       title: "Missing agent instructions",
       severity: "medium",
-      message: "No AGENTS.md, CLAUDE.md, Cursor rules, or Copilot instruction file was found.",
+      message: "No AGENTS.md, Claude, Cursor, Copilot, or Gemini instruction file was found.",
       recommendation:
         "Add AGENTS.md or an equivalent agent instruction file with build, test, review, and repository boundary rules.",
     }),
@@ -380,13 +401,16 @@ function checkSuspiciousInstructionText(files: ProjectFile[]): Finding[] {
 
 function checkMcpConfig(files: ProjectFile[]): Finding[] {
   const findings: Finding[] = [];
-  const configs = files.filter((file) => mcpConfigNames.has(file.path) && file.text);
+  const configs = files.filter((file) => (mcpConfigNames.has(file.path) || agentSettingsNames.has(file.path)) && file.text);
 
   for (const config of configs) {
     let parsed: unknown;
     try {
       parsed = JSON.parse(config.text!);
     } catch {
+      if (!mcpConfigNames.has(config.path)) {
+        continue;
+      }
       findings.push(
         finding({
           id: "CW004",
@@ -400,7 +424,43 @@ function checkMcpConfig(files: ProjectFile[]): Finding[] {
       continue;
     }
 
-    inspectMcpValue(parsed, config.path, "$", findings);
+    if (mcpConfigNames.has(config.path)) {
+      inspectMcpValue(parsed, config.path, "$", findings);
+      continue;
+    }
+
+    if (isRecord(parsed) && parsed.mcpServers) {
+      inspectMcpValue(parsed.mcpServers, config.path, "$.mcpServers", findings);
+    }
+  }
+
+  return findings;
+}
+
+function checkAgentSettings(files: ProjectFile[]): Finding[] {
+  const findings: Finding[] = [];
+  const settingsFiles = files.filter((file) => agentSettingsNames.has(file.path) && file.text);
+
+  for (const settingsFile of settingsFiles) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(settingsFile.text!);
+    } catch {
+      findings.push(
+        finding({
+          id: "CW012",
+          title: "Unreadable agent settings",
+          severity: "medium",
+          file: settingsFile.path,
+          message: "Agent settings could not be parsed as JSON.",
+          recommendation: "Fix the JSON syntax so agent hooks, permissions, and tool configuration can be inspected.",
+        }),
+      );
+      continue;
+    }
+
+    inspectAgentHooks(parsed, settingsFile.path, findings);
+    inspectAgentPermissions(parsed, settingsFile.path, findings);
   }
 
   return findings;
@@ -459,6 +519,79 @@ function inspectMcpValue(value: unknown, file: string, location: string, finding
 
   for (const [key, child] of Object.entries(record)) {
     inspectMcpValue(child, file, `${location}.${key}`, findings);
+  }
+}
+
+function inspectAgentHooks(value: unknown, file: string, findings: Finding[]): void {
+  if (!isRecord(value) || !value.hooks) {
+    return;
+  }
+
+  inspectHookValue(value.hooks, file, "$.hooks", findings);
+}
+
+function inspectHookValue(value: unknown, file: string, location: string, findings: Finding[]): void {
+  if (!value || typeof value !== "object") {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => inspectHookValue(item, file, `${location}[${index}]`, findings));
+    return;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.command === "string") {
+    const risk = classifyHookRisk(record.command);
+    if (risk) {
+      findings.push(
+        finding({
+          id: "CW012",
+          title: "Risky agent hook command",
+          severity: risk.severity,
+          file,
+          message: risk.message,
+          recommendation:
+            "Keep agent hooks narrow, auditable, and non-destructive; avoid hooks that publish, push, merge, remove files, or exfiltrate secrets.",
+          evidence: `${location}.command=${redact(record.command)}`,
+        }),
+      );
+    }
+  }
+
+  for (const [key, child] of Object.entries(record)) {
+    inspectHookValue(child, file, `${location}.${key}`, findings);
+  }
+}
+
+function inspectAgentPermissions(value: unknown, file: string, findings: Finding[]): void {
+  if (!isRecord(value) || !isRecord(value.permissions)) {
+    return;
+  }
+
+  const allowList = value.permissions.allow;
+  if (!Array.isArray(allowList)) {
+    return;
+  }
+
+  for (const [index, item] of allowList.entries()) {
+    const risk = typeof item === "string" ? classifyShellPermission(item) : undefined;
+    if (!risk) {
+      continue;
+    }
+
+    findings.push(
+      finding({
+        id: "CW012",
+        title: risk.title,
+        severity: risk.severity,
+        file,
+        message: risk.message,
+        recommendation:
+          "Replace broad Bash allow rules with specific, read-only commands and keep destructive operations behind explicit maintainer review.",
+        evidence: `$.permissions.allow[${index}]=${redact(item)}`,
+      }),
+    );
   }
 }
 
@@ -595,6 +728,66 @@ function classifyScriptRisk(script: string): { severity: Severity; message: stri
   return undefined;
 }
 
+function classifyHookRisk(command: string): { severity: Severity; message: string } | undefined {
+  const scriptRisk = classifyScriptRisk(command);
+  if (scriptRisk) {
+    return {
+      severity: scriptRisk.severity,
+      message: `Agent hook ${scriptRisk.message}`,
+    };
+  }
+
+  if (/\b(?:sudo|chmod\s+777)\b/i.test(command)) {
+    return { severity: "high", message: "Agent hook contains a privileged or broad permission command." };
+  }
+
+  if (/\b(?:curl|wget|nc|ncat|scp|rsync)\b.{0,120}\b(?:secret|token|credential|private[_-]?key|\.env)\b/i.test(command)) {
+    return { severity: "high", message: "Agent hook appears able to exfiltrate secrets or local environment data." };
+  }
+
+  if (/\b(?:cat|printenv|env)\b.{0,80}\b(?:secret|token|credential|private[_-]?key|\.env)\b/i.test(command)) {
+    return { severity: "high", message: "Agent hook appears to print or expose secret-like data." };
+  }
+
+  return undefined;
+}
+
+function classifyShellPermission(
+  value: string,
+): { title: string; severity: Severity; message: string } | undefined {
+  const match = value.match(/^Bash\((.*)\)$/i);
+  if (!match) {
+    return undefined;
+  }
+
+  const commandPattern = match[1].trim();
+  if (commandPattern === "*") {
+    return {
+      title: "Broad agent shell permission",
+      severity: "medium",
+      message: "Agent settings allow any Bash command.",
+    };
+  }
+
+  if (classifyScriptRisk(commandPattern)) {
+    return {
+      title: "Risky agent shell permission",
+      severity: "high",
+      message: "Agent settings allow risky publish, push, merge, destructive, or pipe-to-shell command patterns.",
+    };
+  }
+
+  if (/\b(?:sudo|chmod\s+777)\b/i.test(commandPattern)) {
+    return {
+      title: "Risky agent shell permission",
+      severity: "high",
+      message: "Agent settings allow privileged or broad permission command patterns.",
+    };
+  }
+
+  return undefined;
+}
+
 function checkGitHubActions(files: ProjectFile[]): Finding[] {
   const workflowFiles = getFilesUnder(files, ".github/workflows").filter((file) => /\.(ya?ml)$/i.test(file.path));
 
@@ -704,11 +897,20 @@ function redact(value: string): string {
     .slice(0, 180);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
 export async function hasAgentInstructions(root: string): Promise<boolean> {
   for (const fileName of instructionFileNames) {
     if (await pathExists(path.join(root, fileName))) {
       return true;
     }
   }
-  return pathExists(path.join(root, ".cursor/rules"));
+  for (const ruleDirectory of instructionDirectoryPatterns) {
+    if (await pathExists(path.join(root, ruleDirectory.directory))) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -130,6 +130,103 @@ test("scanProject uses workspace root guardrails for package scans", async () =>
   assert.ok(ids.includes("CW008"));
 });
 
+test("scanProject recognizes modern agent instruction surfaces", async () => {
+  const root = await makeTempRepo();
+  await mkdir(path.join(root, ".github/instructions"), { recursive: true });
+  await mkdir(path.join(root, ".claude/rules"), { recursive: true });
+  await mkdir(path.join(root, ".github/workflows"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      scripts: {
+        test: "node --test",
+      },
+    }),
+  );
+  await writeFile(
+    path.join(root, ".github/instructions/review.instructions.md"),
+    "# Review Instructions\n\nRun `npm test` before merge.\n",
+  );
+  await writeFile(path.join(root, ".claude/rules/typescript.md"), "# TypeScript\n\nPrefer small changes.\n");
+  await writeFile(path.join(root, "LICENSE"), "MIT");
+  await writeFile(path.join(root, "SECURITY.md"), "# Security\n");
+  await writeFile(path.join(root, "CONTRIBUTING.md"), "# Contributing\n");
+  await writeFile(
+    path.join(root, ".github/workflows/ci.yml"),
+    "name: CI\non: [pull_request]\npermissions:\n  contents: read\n",
+  );
+
+  const result = await scanProject(root);
+  const ids = result.findings.map((finding) => finding.id);
+
+  assert.equal(ids.includes("CW001"), false);
+});
+
+test("scanProject reports risky agent settings hooks and MCP servers", async () => {
+  const root = await makeTempRepo();
+  await mkdir(path.join(root, ".claude"), { recursive: true });
+  await mkdir(path.join(root, ".gemini"), { recursive: true });
+  await mkdir(path.join(root, ".github/workflows"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      scripts: {
+        test: "node --test",
+      },
+    }),
+  );
+  await writeFile(path.join(root, "AGENTS.md"), "# Agent Instructions\n\n- Run npm test before merge.\n");
+  await writeFile(path.join(root, "LICENSE"), "MIT");
+  await writeFile(path.join(root, "SECURITY.md"), "# Security\n");
+  await writeFile(path.join(root, "CONTRIBUTING.md"), "# Contributing\n");
+  await writeFile(
+    path.join(root, ".github/workflows/ci.yml"),
+    "name: CI\non: [pull_request]\npermissions:\n  contents: read\n",
+  );
+  await writeFile(
+    path.join(root, ".claude/settings.json"),
+    JSON.stringify({
+      permissions: {
+        allow: ["Bash(*)", "Bash(pnpm test:*)"],
+      },
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: "Write",
+            hooks: [
+              {
+                type: "command",
+                command: "npm publish && git push",
+              },
+            ],
+          },
+        ],
+      },
+    }),
+  );
+  await writeFile(
+    path.join(root, ".gemini/settings.json"),
+    JSON.stringify({
+      mcpServers: {
+        unsafe: {
+          command: "bash",
+          args: ["-lc", "npm publish"],
+        },
+      },
+    }),
+  );
+
+  const result = await scanProject(root);
+  const ids = result.findings.map((finding) => finding.id);
+  const hookFinding = result.findings.find((finding) => finding.id === "CW012" && finding.title.includes("hook"));
+  const benignPermissionFinding = result.findings.find((finding) => finding.evidence?.includes("pnpm test"));
+
+  assert.ok(ids.includes("CW004"));
+  assert.ok(ids.includes("CW012"));
+  assert.equal(hookFinding?.severity, "high");
+  assert.equal(benignPermissionFinding, undefined);
+});
+
 test("formatMarkdownReport includes a useful summary", async () => {
   const root = await makeTempRepo();
   const result = await scanProject(root);
@@ -268,12 +365,12 @@ test("doctor summarizes a complex risky repository by guardrail area", async () 
 
   assert.equal(doctor.status, "high-risk");
   assert.equal(doctor.areas.find((area) => area.name === "Agent instructions")?.status, "review");
-  assert.equal(doctor.areas.find((area) => area.name === "MCP configuration")?.status, "review");
+  assert.equal(doctor.areas.find((area) => area.name === "MCP and agent settings")?.status, "review");
   assert.equal(doctor.areas.find((area) => area.name === "Repository automation")?.status, "review");
   assert.ok(doctor.topPriorities.length <= 5);
   assert.match(formatted, /CodeWard Doctor/);
   assert.match(formatted, /Agent readiness: High risk/);
-  assert.match(formatted, /\[review\] MCP configuration/);
+  assert.match(formatted, /\[review\] MCP and agent settings/);
   assert.match(formatted, /Top priorities:/);
   assert.match(markdown, /# CodeWard Doctor/);
   assert.match(markdown, /## Guardrail Areas/);


### PR DESCRIPTION
## Summary

- Expand agent instruction detection for Codex-style `AGENTS.override.md`, Claude Code `.claude/CLAUDE.md` and `.claude/rules`, and GitHub Copilot `.github/instructions/*.instructions.md`.
- Inspect committed `.claude/settings*.json` and `.gemini/settings.json` for MCP servers, risky hooks, and truly broad/risky Bash permissions.
- Add `CW012` for risky agent settings and group it with MCP/settings readiness in `doctor`.
- Add `docs/ecosystem.md` to document current agent surfaces and source signals.

## Validation

- `pnpm test`
- `pnpm scan`
- `git diff --check`
- Read-only scan: `/Users/khs/Desktop/inpock-frontend/services/offer --workspace-root /Users/khs/Desktop/inpock-frontend` keeps existing findings and does not flag normal Claude `Bash(pnpm test:*)`-style permissions.
- Read-only scan: `/Users/khs/Desktop/inpock-app-client` keeps the expected existing findings.
