### PR TITLE
Feat: detect documentation-only API contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Repo-level preflight checks before AI coding agents touch your code.**
 
-CodeWard scans the repository surface that AI coding agents rely on: agent instructions, MCP configuration, agent settings and hooks, local environment files, package scripts, GitHub Actions permissions, community health files, and validation signals.
+CodeWard scans the repository surface that AI coding agents rely on: agent instructions, MCP configuration, agent settings and hooks, API contract source-of-truth signals, local environment files, package scripts, GitHub Actions permissions, community health files, and validation signals.
 
 It is built for teams using Codex, Claude Code, Cursor, GitHub Copilot coding agent, MCP-powered tools, or any workflow where an agent can read, edit, test, commit, or open pull requests.
 
@@ -36,6 +36,7 @@ CodeWard gives maintainers a quick first line of defense:
 - Is there clear guidance for agents?
 - Are MCP configs safe enough to inspect?
 - Are committed agent settings or hooks able to run risky commands?
+- Are API endpoints documented only in prose, without a machine-readable contract source?
 - Did a local `.env` file slip into the repo?
 - Can package scripts publish, push, merge, or run risky shell pipelines?
 - Are workflows using broad permissions or risky triggers?
@@ -138,9 +139,11 @@ The first release focuses on high-signal checks that are useful across many repo
 | `CW010` | medium | Broad workflow permissions or risky workflow triggers. |
 | `CW011` | low | Missing community health files. |
 | `CW012` | medium/high | Risky committed agent settings, hooks, or broad shell permissions. |
+| `CW013` | low | API endpoints documented only in prose without a contract source. |
 
 See [docs/rules.md](docs/rules.md) for the rule catalog.
 See [docs/ecosystem.md](docs/ecosystem.md) for the agent ecosystem surfaces CodeWard tracks.
+See [docs/api-contracts.md](docs/api-contracts.md) for the API contract source-of-truth check.
 
 ## Configuration
 

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -1,0 +1,30 @@
+# API Contract Source Of Truth
+
+Frontend and backend teams often coordinate through API documents. That works best when the document is generated from a single contract source, not hand-maintained separately from code and client types.
+
+CodeWard looks for a narrow drift signal:
+
+- Markdown or text docs that list HTTP endpoints in a method-plus-path form
+- No machine-readable API contract source in the repository
+
+When both are true, CodeWard reports `CW013`.
+
+## Accepted Contract Sources
+
+CodeWard currently treats these as machine-readable contract sources:
+
+- OpenAPI or Swagger: `openapi.yaml`, `openapi.yml`, `openapi.json`, `swagger.yaml`, `swagger.yml`, `swagger.json`
+- AsyncAPI: `asyncapi.yaml`, `asyncapi.yml`, `asyncapi.json`
+- Protocol Buffers: `*.proto`, `buf.yaml`, `buf.gen.yaml`
+- GraphQL SDL: `*.graphql`, `*.graphqls`, `schema.graphql`, `schema.graphqls`
+
+## Why It Matters
+
+AI coding agents can edit frontend clients, backend handlers, tests, and docs in the same pull request. If the API contract exists only as prose, agents and reviewers have a harder time knowing which representation is authoritative.
+
+Prefer one source of truth that can generate docs, validation, mock servers, or client types. This keeps API design review close to the code and reduces drift between documentation and implementation.
+
+## References
+
+- [Why frontend developers design APIs](https://blog.gangnamunni.com/post/saas-why-do-frontend-developers-design-api)
+- [Single source of truth](https://ko.wikipedia.org/wiki/%EB%8B%A8%EC%9D%BC_%EC%A7%84%EC%8B%A4_%EA%B3%B5%EA%B8%89%EC%9B%90)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -18,6 +18,7 @@ Rule behavior can be tuned in `codeward.config.json`. See [configuration.md](con
 | `CW010` | medium | GitHub Actions workflow grants broad permissions or uses risky triggers. |
 | `CW011` | low | Community health files are missing. |
 | `CW012` | medium/high | Committed agent settings define risky hooks or broad shell permissions. |
+| `CW013` | low | API endpoints are documented only in prose without a machine-readable contract source. |
 
 ## Rule Design
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -72,6 +72,12 @@ const areaDefinitions: AreaDefinition[] = [
     reviewMessage: "Local environment files or risky scripts need maintainer review.",
   },
   {
+    name: "API contracts",
+    ruleIds: ["CW013"],
+    okMessage: "No documentation-only API contract drift signal was detected.",
+    reviewMessage: "API contract documentation may need a machine-readable source of truth.",
+  },
+  {
     name: "Community health",
     ruleIds: ["CW011"],
     okMessage: "Core contributor and security files are present.",

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -65,6 +65,7 @@ export async function scanProject(rootInput: string, options: ScanOptions = {}):
     ...checkMcpConfig(guardrailFiles),
     ...checkAgentSettings(guardrailFiles),
     ...checkPackageScripts(files),
+    ...checkApiContractSource(files),
     ...checkGitHubActions(guardrailFiles),
     ...checkCommittedEnvFiles(files),
     ...checkCommunityHealth(guardrailFiles),
@@ -786,6 +787,68 @@ function classifyShellPermission(
   }
 
   return undefined;
+}
+
+function checkApiContractSource(files: ProjectFile[]): Finding[] {
+  const proseApiDocs = files.filter(isProseApiDoc);
+  if (proseApiDocs.length === 0 || hasMachineReadableApiContract(files)) {
+    return [];
+  }
+
+  const evidence = proseApiDocs
+    .slice(0, 3)
+    .map((file) => file.path)
+    .join(", ");
+
+  return [
+    finding({
+      id: "CW013",
+      title: "Documentation-only API contract",
+      severity: "low",
+      file: proseApiDocs[0].path,
+      message:
+        "API endpoints appear to be documented in prose, but no machine-readable contract source was found.",
+      recommendation:
+        "Choose a single source of truth for API contracts, such as OpenAPI, protobuf, GraphQL SDL, AsyncAPI, or another IDL that can generate docs and client types.",
+      evidence,
+    }),
+  ];
+}
+
+function isProseApiDoc(file: ProjectFile): boolean {
+  if (!file.text || !/\.(md|mdx|txt)$/i.test(file.path)) {
+    return false;
+  }
+
+  const basename = path.basename(file.path).toLowerCase();
+  const pathSignal = /(?:^|[-_/])(api|apis|endpoint|endpoints|contract|swagger|openapi)(?:[-_.]|$)/i.test(file.path);
+  if (!pathSignal && !/\bapi\b/i.test(basename)) {
+    return false;
+  }
+
+  return /\b(GET|POST|PUT|PATCH|DELETE)\s+\/[A-Za-z0-9_/{:.-]+/.test(file.text);
+}
+
+function hasMachineReadableApiContract(files: ProjectFile[]): boolean {
+  return files.some((file) => {
+    const basename = path.basename(file.path).toLowerCase();
+    const extension = path.extname(file.path).toLowerCase();
+
+    if (["buf.yaml", "buf.gen.yaml", "asyncapi.yaml", "asyncapi.yml", "asyncapi.json"].includes(basename)) {
+      return true;
+    }
+    if (/^openapi\.(json|ya?ml)$/i.test(basename) || /^swagger\.(json|ya?ml)$/i.test(basename)) {
+      return true;
+    }
+    if (extension === ".proto" || extension === ".graphql" || extension === ".graphqls") {
+      return true;
+    }
+    if (/schema\.graphqls?$/i.test(file.path)) {
+      return true;
+    }
+
+    return false;
+  });
 }
 
 function checkGitHubActions(files: ProjectFile[]): Finding[] {

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -227,6 +227,90 @@ test("scanProject reports risky agent settings hooks and MCP servers", async () 
   assert.equal(benignPermissionFinding, undefined);
 });
 
+test("scanProject reports documentation-only API contracts", async () => {
+  const root = await makeTempRepo();
+  await mkdir(path.join(root, "docs"), { recursive: true });
+  await mkdir(path.join(root, ".github/workflows"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      scripts: {
+        test: "node --test",
+      },
+    }),
+  );
+  await writeFile(path.join(root, "AGENTS.md"), "# Agent Instructions\n\n- Run npm test before merge.\n");
+  await writeFile(path.join(root, "LICENSE"), "MIT");
+  await writeFile(path.join(root, "SECURITY.md"), "# Security\n");
+  await writeFile(path.join(root, "CONTRIBUTING.md"), "# Contributing\n");
+  await writeFile(
+    path.join(root, ".github/workflows/ci.yml"),
+    "name: CI\non: [pull_request]\npermissions:\n  contents: read\n",
+  );
+  await writeFile(
+    path.join(root, "docs/api.md"),
+    [
+      "# API",
+      "",
+      "GET /v1/offers",
+      "POST /v1/offers",
+      "",
+      "Responses are documented here for frontend integration.",
+    ].join("\n"),
+  );
+
+  const result = await scanProject(root);
+  const finding = result.findings.find((item) => item.id === "CW013");
+  const doctor = buildDoctorResult(result);
+
+  assert.equal(finding?.severity, "low");
+  assert.equal(finding?.file, "docs/api.md");
+  assert.equal(doctor.areas.find((area) => area.name === "API contracts")?.status, "review");
+});
+
+test("scanProject accepts machine-readable API contract sources", async () => {
+  const root = await makeTempRepo();
+  await mkdir(path.join(root, "docs"), { recursive: true });
+  await mkdir(path.join(root, ".github/workflows"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      scripts: {
+        test: "node --test",
+      },
+    }),
+  );
+  await writeFile(path.join(root, "AGENTS.md"), "# Agent Instructions\n\n- Run npm test before merge.\n");
+  await writeFile(path.join(root, "LICENSE"), "MIT");
+  await writeFile(path.join(root, "SECURITY.md"), "# Security\n");
+  await writeFile(path.join(root, "CONTRIBUTING.md"), "# Contributing\n");
+  await writeFile(
+    path.join(root, ".github/workflows/ci.yml"),
+    "name: CI\non: [pull_request]\npermissions:\n  contents: read\n",
+  );
+  await writeFile(path.join(root, "docs/api.md"), "# API\n\nGET /v1/offers\nPOST /v1/offers\n");
+  await writeFile(
+    path.join(root, "openapi.yaml"),
+    [
+      "openapi: 3.1.0",
+      "info:",
+      "  title: Offers",
+      "  version: 1.0.0",
+      "paths:",
+      "  /v1/offers:",
+      "    get:",
+      "      responses:",
+      "        '200':",
+      "          description: ok",
+    ].join("\n"),
+  );
+
+  const result = await scanProject(root);
+  const ids = result.findings.map((item) => item.id);
+
+  assert.equal(ids.includes("CW013"), false);
+});
+
 test("formatMarkdownReport includes a useful summary", async () => {
   const root = await makeTempRepo();
   const result = await scanProject(root);


### PR DESCRIPTION
## Summary

- Add `CW013` for documentation-only API contracts when endpoint prose exists without OpenAPI, Swagger, AsyncAPI, protobuf, buf, or GraphQL SDL sources.
- Group the signal under a new `API contracts` doctor area.
- Document the source-of-truth rationale and accepted contract sources.

## Context

- Inspired by frontend/API design and single-source-of-truth discussions: API docs are most useful when generated from an authoritative contract rather than maintained as separate prose.
- The rule is intentionally low severity and conservative: it only fires when endpoint-like prose docs are present and no machine-readable contract source is found.

## Validation

- `pnpm test`
- `pnpm scan`
- `git diff --check`
- Read-only scan: `/Users/khs/Desktop/inpock-frontend/services/offer --workspace-root /Users/khs/Desktop/inpock-frontend` produced no new `CW013` noise.
- Read-only scan: `/Users/khs/Desktop/inpock-app-client` produced no new `CW013` noise.
