### PR TITLE
Feat: add change readiness eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ CodeWard gives maintainers a quick first line of defense:
 - Can package scripts publish, push, merge, or run risky shell pipelines?
 - Are workflows using broad permissions or risky triggers?
 - Is there a real test command for agent-made changes?
+- Does an AI-assisted change explain its intent, risk, and verification evidence?
 
 ## Quick Demo
 
@@ -113,6 +114,7 @@ node dist/cli.js scan /path/to/repo
 | `codeward report . --output CODEWARD_REPORT.md` | Generate a Markdown report for PRs or audits. |
 | `codeward doctor . --format markdown` | Summarize whether the repo is ready for AI-assisted work. |
 | `codeward review . --base origin/main --head HEAD --format markdown` | Show new findings and changed risky files introduced by a branch. |
+| `codeward eval . --base origin/main --head HEAD --pr-body-file pr-body.md` | Score change readiness across intent, risk, tests, and review size. |
 | `codeward github-action . --mode review --base origin/main --head HEAD` | Generate GitHub Action annotations, step summary, and PR comment body. |
 | `codeward test-plan . --base origin/main --head HEAD --include-working-tree` | Suggest domain test scenarios for changed files. |
 | `codeward doctor services/offer --workspace-root .` | Scan a monorepo package while using root guardrails. |
@@ -124,6 +126,8 @@ For monorepos, pass `--workspace-root` when scanning a package. Package-local ch
 `codeward review` compares a branch against a base ref for PR-style workflows. It separates newly introduced findings from risky files that already had findings on the base branch but were modified again, which helps reviewers notice when a PR touches known-dangerous surfaces such as committed `.env` files, MCP configs, or release scripts.
 
 `codeward test-plan` turns changed file paths into a review-ready domain test checklist. Add `--include-working-tree` for local, uncommitted changes while iterating.
+
+`codeward eval` scores whether a branch has enough validation evidence, changed-test coverage, intent capture, risk explanation, domain verification paths, and reviewable size. In GitHub Actions, CodeWard can read the pull request body from the event payload and append the evaluation to the PR comment.
 
 ## What It Checks
 
@@ -148,6 +152,7 @@ The first release focuses on high-signal checks that are useful across many repo
 See [docs/rules.md](docs/rules.md) for the rule catalog.
 See [docs/ecosystem.md](docs/ecosystem.md) for the agent ecosystem surfaces CodeWard tracks.
 See [docs/api-contracts.md](docs/api-contracts.md) for the API contract source-of-truth check.
+See [docs/eval.md](docs/eval.md) for the change readiness evaluation.
 
 ## Configuration
 
@@ -197,7 +202,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-The PR comment can include suggested domain tests for changed files. For rollout guidance, see [docs/adoption.md](docs/adoption.md) and [docs/github-action.md](docs/github-action.md).
+The PR comment can include suggested domain tests and a verification readiness evaluation for changed files. For rollout guidance, see [docs/adoption.md](docs/adoption.md) and [docs/github-action.md](docs/github-action.md).
 
 ## Where CodeWard Fits
 
@@ -220,6 +225,7 @@ Near-term priorities:
 - publish a versioned GitHub Action release tag
 - improve branch-aware `review` changed-line locations
 - improve generated domain test plans with framework-specific test skeletons
+- expand `eval` into repository-specific verification manifests and taste rubrics
 - continue expanding agent surface detection across Codex, Claude Code, Cursor, Copilot, Gemini, and related tools
 - generate rule documentation from scanner metadata
 

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,12 @@ inputs:
   test-plan-file:
     description: Markdown test plan file path.
     default: codeward-test-plan.md
+  eval:
+    description: Append a verification readiness evaluation to reports and PR comments.
+    default: "true"
+  eval-file:
+    description: Markdown verification readiness evaluation file path.
+    default: codeward-eval.md
   annotations:
     description: Emit GitHub workflow annotations.
     default: "true"
@@ -61,6 +67,9 @@ outputs:
   test-plan-file:
     description: Markdown test plan file path.
     value: ${{ steps.codeward.outputs.test-plan-file }}
+  eval-file:
+    description: Markdown verification readiness evaluation file path.
+    value: ${{ steps.codeward.outputs.eval-file }}
   exit-code:
     description: CodeWard exit code before the comment step ran.
     value: ${{ steps.codeward.outputs.exit-code }}
@@ -106,6 +115,11 @@ runs:
         else
           args+=(--no-test-plan)
         fi
+        if [ "${{ inputs.eval }}" = "true" ]; then
+          args+=(--eval --eval-file "${{ inputs.eval-file }}")
+        else
+          args+=(--no-eval)
+        fi
 
         node "$GITHUB_ACTION_PATH/dist/cli.js" "${args[@]}"
         codeward_exit_code=$?
@@ -113,6 +127,7 @@ runs:
         echo "report-file=${{ inputs.report-file }}" >> "$GITHUB_OUTPUT"
         echo "comment-file=${{ inputs.comment-file }}" >> "$GITHUB_OUTPUT"
         echo "test-plan-file=${{ inputs.test-plan-file }}" >> "$GITHUB_OUTPUT"
+        echo "eval-file=${{ inputs.eval-file }}" >> "$GITHUB_OUTPUT"
         exit 0
 
     - name: Comment on pull request

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -30,10 +30,11 @@ Start advisory, then tighten the gate once the findings are understood.
 | 2. Doctor | `codeward doctor . --format markdown` | Get an agent-readiness summary by guardrail area. |
 | 3. Review | `codeward review . --base origin/main --head HEAD --format markdown` | See new findings introduced by the branch. |
 | 4. Test plan | `codeward test-plan . --base origin/main --head HEAD --include-working-tree` | Suggest domain test scenarios for changed and local files. |
-| 5. PR Action | `uses: IvoryCanvas/codeward@main` | Add annotations, a step summary, a test plan, and a sticky PR comment. |
-| 6. Report | `codeward report . --output CODEWARD_REPORT.md` | Share a readable audit artifact in a PR or maintainer discussion. |
-| 7. High-risk gate | `codeward scan . --fail-on high` | Block obvious risks such as committed env files or unsafe scripts. |
-| 8. Medium-risk gate | `codeward scan . --fail-on medium` | Require stronger agent guidance, tests, and workflow permissions. |
+| 5. Eval | `codeward eval . --base origin/main --head HEAD --pr-body-file pr-body.md` | Score intent capture, risk explanation, test evidence, and review size. |
+| 6. PR Action | `uses: IvoryCanvas/codeward@main` | Add annotations, a step summary, a test plan, eval, and a sticky PR comment. |
+| 7. Report | `codeward report . --output CODEWARD_REPORT.md` | Share a readable audit artifact in a PR or maintainer discussion. |
+| 8. High-risk gate | `codeward scan . --fail-on high` | Block obvious risks such as committed env files or unsafe scripts. |
+| 9. Medium-risk gate | `codeward scan . --fail-on medium` | Require stronger agent guidance, tests, and workflow permissions. |
 
 ## Monorepos
 
@@ -89,6 +90,16 @@ jobs:
 When the repository is stable, consider `--fail-on medium`.
 
 For all inputs, see [github-action.md](github-action.md).
+
+## Change Readiness Eval
+
+Use `codeward eval` when an AI-assisted branch looks plausible but reviewers need a faster way to decide what still needs human attention:
+
+```sh
+codeward eval . --base origin/main --head HEAD --pr-body-file pr-body.md --format markdown
+```
+
+The eval report scores validation commands, changed-test coverage, intent capture, risk explanation, generated domain test scenarios, and review size. A low score does not mean the code is wrong; it means the branch is expensive or risky to verify.
 
 ## Interpreting Findings
 

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -1,0 +1,47 @@
+# CodeWard Eval
+
+`codeward eval` scores whether a branch is ready for human review in an AI-assisted workflow.
+
+It does not try to prove that the code is correct. Instead, it checks whether reviewers have enough evidence to trust, challenge, and verify the change without absorbing unnecessary cognitive load.
+
+## Usage
+
+```sh
+codeward eval . --base origin/main --head HEAD --format markdown
+codeward eval . --base origin/main --head HEAD --pr-body-file pr-body.md
+codeward eval services/offer --workspace-root . --base origin/main --head HEAD --include-working-tree
+```
+
+The GitHub Action can append the same report to the PR comment. On pull request events it reads the PR body from `GITHUB_EVENT_PATH`.
+
+## Gates
+
+Each gate is scored from `0` to `2`.
+
+| Gate | What it checks |
+| --- | --- |
+| Validation commands | The package exposes a real test command and supporting commands such as typecheck, lint, build, or e2e. |
+| Changed test coverage | Source changes are paired with changed test files, or at least a runnable test command exists. |
+| Intent capture | The PR body, decision docs, or PR template capture the problem, rationale, context, alternatives, or tradeoffs. |
+| Risk explanation | Risky surfaces such as config, workflows, API contracts, auth, billing, migrations, and env files include risk or rollback context. |
+| Domain test plan | Changed files can be mapped to focused domain verification scenarios. |
+| Review size | The branch is small enough to review without unnecessary verification tax. |
+
+## Ratings
+
+| Rating | Meaning |
+| --- | --- |
+| `strong` | The branch has clear verification evidence and should be easy to review. |
+| `ready` | The branch is probably reviewable, with some follow-up still useful. |
+| `needs-work` | Reviewers should ask for more tests, context, risk notes, or a smaller diff. |
+| `high-risk` | The branch is expensive or risky to verify; add evidence before relying on it. |
+
+## Why This Exists
+
+AI-assisted code often looks plausible before it is truly understood. That creates verification tax, cognitive debt, and intent debt:
+
+- verification tax: humans must spend extra time proving the generated result is safe
+- cognitive debt: reviewers receive more code than they can meaningfully understand
+- intent debt: the reason for a change disappears into a prompt or chat session
+
+`codeward eval` turns those risks into a small, static, explainable checklist that can run locally or in CI.

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -7,6 +7,7 @@ The action writes:
 - a Markdown report file
 - a sticky PR comment body
 - an optional suggested domain test plan
+- an optional verification readiness evaluation
 - GitHub workflow annotations
 - a GitHub step summary
 
@@ -71,6 +72,8 @@ While CodeWard is pre-release, use `IvoryCanvas/codeward@main`; pin to a version
 | `comment-file` | `codeward-pr-comment.md` | PR comment body output path. |
 | `test-plan` | `true` | Append suggested domain tests for changed files. |
 | `test-plan-file` | `codeward-test-plan.md` | Markdown test plan output path. |
+| `eval` | `true` | Append a verification readiness evaluation. |
+| `eval-file` | `codeward-eval.md` | Markdown evaluation output path. |
 | `annotations` | `true` | Emit GitHub workflow annotations. |
 | `step-summary` | `true` | Append the report to the GitHub step summary. |
 | `comment` | `true` | Create or update a sticky pull request comment. |
@@ -81,5 +84,6 @@ While CodeWard is pre-release, use `IvoryCanvas/codeward@main`; pin to a version
 - Set `pull-requests: write` only when PR comments are enabled.
 - Set `comment: false` for advisory runs that should only use annotations and step summaries.
 - Set `test-plan: false` when the PR comment should contain only CodeWard findings.
+- Set `eval: false` when the PR comment should not include readiness scoring.
 - Pass `github-token: ${{ secrets.GITHUB_TOKEN }}` when `comment` is enabled.
 - CodeWard still does not execute scanned project code; the action only installs and builds CodeWard itself before scanning the checked-out repository.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,18 +7,21 @@ CodeWard starts as a local CLI for repo-level AI agent readiness. The project ca
 - Keep the scanner fast, static, and easy to understand.
 - Make the first public npm release.
 - Improve README, adoption docs, and sample output so new maintainers can try CodeWard quickly.
+- Keep `eval` explainable enough that maintainers trust the score and know what to fix.
 
 ## Next
 
 - Publish a versioned GitHub Action release tag.
 - Improve `doctor` output with clearer scoring and remediation grouping.
 - Improve `review` output for changed-line locations.
+- Expand `eval` with repository-specific verification manifests and configurable taste rubrics.
 - Continue expanding agent surface detection across Codex, Claude Code, Cursor, GitHub Copilot, Gemini, and related tools.
 - Generate rule documentation from scanner metadata.
 
 ## Later
 
 - Policy packs for open source, startup teams, and security-sensitive repositories.
+- A memory or lessons workflow that captures repeated review feedback into durable agent instructions.
 - VS Code and Cursor extension surfaces.
 - Maintainer dashboard for repeated AI-assisted PR risks.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { loadConfig, writeDefaultConfig } from "./config.js";
 import { generateAgentContext } from "./context.js";
 import { buildDoctorResult, formatDoctorReport, formatMarkdownDoctorReport } from "./doctor.js";
+import { evaluateChangeReadiness, formatEvalReport, formatMarkdownEvalReport } from "./eval.js";
 import { runGitHubAction } from "./github.js";
 import { formatMarkdownReport, formatSarifReport, formatTextReport, hasFindingsAtOrAbove } from "./report.js";
 import { formatMarkdownReviewReport, formatReviewReport, reviewProject } from "./review.js";
@@ -37,6 +38,9 @@ interface ParsedOptions {
   stepSummary?: boolean;
   testPlan?: boolean;
   testPlanFile?: string;
+  evaluation?: boolean;
+  evalFile?: string;
+  prBodyFile?: string;
   includeWorkingTree?: boolean;
 }
 
@@ -113,9 +117,26 @@ async function main(argv: string[]): Promise<number> {
       stepSummary: options.stepSummary,
       testPlan: options.testPlan,
       testPlanFile: options.testPlanFile,
+      evaluation: options.evaluation,
+      evalFile: options.evalFile,
+      prBodyFile: options.prBodyFile,
       includeWorkingTree: options.includeWorkingTree,
     });
     return result.exitCode;
+  }
+
+  if (command === "eval") {
+    const options = parseOptions(rest);
+    const result = await evaluateChangeReadiness(options.path, {
+      base: options.base,
+      head: options.head,
+      workspaceRoot: options.workspaceRoot,
+      includeWorkingTree: options.includeWorkingTree,
+      prBodyFile: options.prBodyFile,
+    });
+    const output = formatEvalOutput(result, options.format ?? (options.json ? "json" : "markdown"));
+    await printOrWrite(output, options.output);
+    return 0;
   }
 
   if (command === "test-plan") {
@@ -264,6 +285,16 @@ function parseOptions(args: string[]): ParsedOptions {
       continue;
     }
 
+    if (arg === "--eval-file") {
+      options.evalFile = readValue(args, ++index, arg);
+      continue;
+    }
+
+    if (arg === "--pr-body-file") {
+      options.prBodyFile = readValue(args, ++index, arg);
+      continue;
+    }
+
     if (arg === "--no-annotations") {
       options.annotations = false;
       continue;
@@ -281,6 +312,16 @@ function parseOptions(args: string[]): ParsedOptions {
 
     if (arg === "--no-test-plan") {
       options.testPlan = false;
+      continue;
+    }
+
+    if (arg === "--eval") {
+      options.evaluation = true;
+      continue;
+    }
+
+    if (arg === "--no-eval") {
+      options.evaluation = false;
       continue;
     }
 
@@ -390,6 +431,19 @@ function formatTestPlanOutput(result: Awaited<ReturnType<typeof generateTestPlan
   return formatMarkdownTestPlan(result);
 }
 
+function formatEvalOutput(result: Awaited<ReturnType<typeof evaluateChangeReadiness>>, format: OutputFormat): string {
+  if (format === "json") {
+    return `${JSON.stringify(result, null, 2)}\n`;
+  }
+  if (format === "markdown") {
+    return formatMarkdownEvalReport(result);
+  }
+  if (format !== "text") {
+    throw new Error(`Eval supports text, json, or markdown output, not ${format}`);
+  }
+  return formatEvalReport(result);
+}
+
 async function printOrWrite(output: string, outputPath?: string): Promise<void> {
   if (outputPath) {
     const resolvedOutputPath = path.resolve(outputPath);
@@ -426,6 +480,7 @@ Usage:
   codeward report [path] [--format <format>] [--output <file>] [--fail-on <severity>]
   codeward doctor [path] [--format <format>] [--output <file>] [--fail-on <severity>]
   codeward review [path] [--base <ref>] [--head <ref>] [--format <format>] [--fail-on <severity>]
+  codeward eval [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--pr-body-file <file>] [--format <format>]
   codeward github-action [path] [--mode auto|scan|review] [--base <ref>] [--head <ref>] [--fail-on <severity>]
   codeward test-plan [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--format <format>] [--output <file>]
   codeward context [path] [--write [file]] [--force]
@@ -445,6 +500,7 @@ Examples:
   codeward report . --output CODEWARD_REPORT.md
   codeward doctor .
   codeward review . --base origin/main --head HEAD
+  codeward eval . --base origin/main --head HEAD --pr-body-file pr-body.md
   codeward github-action . --mode review --base origin/main --head HEAD --fail-on high
   codeward test-plan . --base origin/main --head HEAD
   codeward test-plan services/offer --workspace-root . --base origin/main --head HEAD --include-working-tree

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -1,0 +1,633 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { generateTestPlan } from "./test-plan.js";
+import type { TestPlanChangedFile, TestPlanItem, TestPlanOptions } from "./test-plan.js";
+import { TOOL_NAME, VERSION } from "./version.js";
+
+export type EvalCheckStatus = "pass" | "warn" | "fail";
+export type EvalRating = "strong" | "ready" | "needs-work" | "high-risk";
+
+export interface EvalOptions extends TestPlanOptions {
+  prBody?: string;
+  prBodyFile?: string;
+}
+
+export interface EvalCheck {
+  id: string;
+  title: string;
+  status: EvalCheckStatus;
+  score: number;
+  maxScore: number;
+  reason: string;
+  evidence: string[];
+  recommendation: string;
+}
+
+export interface EvalResult {
+  tool: {
+    name: string;
+    version: string;
+  };
+  root: string;
+  workspaceRoot?: string;
+  generatedAt: string;
+  base: string;
+  head: string;
+  includeWorkingTree: boolean;
+  score: number;
+  maxScore: number;
+  rating: EvalRating;
+  changedFiles: TestPlanChangedFile[];
+  suggestedCommands: string[];
+  testPlanItems: TestPlanItem[];
+  checks: EvalCheck[];
+  recommendations: string[];
+}
+
+export async function evaluateChangeReadiness(rootInput: string, options: EvalOptions = {}): Promise<EvalResult> {
+  const testPlan = await generateTestPlan(rootInput, options);
+  const prBody = normalizeText(options.prBody ?? (await readPrBodyFile(options.prBodyFile)));
+  const checks = [
+    scoreValidationCommands(testPlan.suggestedCommands),
+    scoreChangedTestCoverage(testPlan.changedFiles, testPlan.suggestedCommands),
+    await scoreIntentCapture(testPlan.root, testPlan.workspaceRoot, testPlan.changedFiles, prBody),
+    scoreRiskExplanation(testPlan.changedFiles, prBody),
+    scoreDomainTestPlan(testPlan.changedFiles, testPlan.items),
+    scoreReviewSize(testPlan.changedFiles),
+  ];
+  const score = checks.reduce((total, check) => total + check.score, 0);
+  const maxScore = checks.reduce((total, check) => total + check.maxScore, 0);
+
+  return {
+    tool: {
+      name: TOOL_NAME,
+      version: VERSION,
+    },
+    root: testPlan.root,
+    workspaceRoot: testPlan.workspaceRoot,
+    generatedAt: new Date().toISOString(),
+    base: testPlan.base,
+    head: testPlan.head,
+    includeWorkingTree: testPlan.includeWorkingTree,
+    score,
+    maxScore,
+    rating: ratingForScore(score, maxScore),
+    changedFiles: testPlan.changedFiles,
+    suggestedCommands: testPlan.suggestedCommands,
+    testPlanItems: testPlan.items,
+    checks,
+    recommendations: buildRecommendations(checks),
+  };
+}
+
+export function formatEvalReport(result: EvalResult): string {
+  const lines: string[] = [];
+  lines.push(`${result.tool.name} Eval`);
+  lines.push(`Root: ${result.root}`);
+  if (result.workspaceRoot) {
+    lines.push(`Workspace root: ${result.workspaceRoot}`);
+  }
+  lines.push(`Base: ${result.base}`);
+  lines.push(`Head: ${result.head}`);
+  if (result.includeWorkingTree) {
+    lines.push("Includes working tree changes: yes");
+  }
+  lines.push(`Score: ${result.score}/${result.maxScore} (${result.rating})`);
+  lines.push(`Changed files: ${result.changedFiles.length}`);
+  lines.push("");
+
+  for (const check of result.checks) {
+    lines.push(`${check.status.toUpperCase()} ${check.title}: ${check.score}/${check.maxScore}`);
+    lines.push(`  ${check.reason}`);
+    for (const evidence of check.evidence) {
+      lines.push(`  Evidence: ${evidence}`);
+    }
+    if (check.status !== "pass") {
+      lines.push(`  Fix: ${check.recommendation}`);
+    }
+  }
+
+  if (result.recommendations.length > 0) {
+    lines.push("");
+    lines.push("Recommendations:");
+    for (const recommendation of result.recommendations) {
+      lines.push(`- ${recommendation}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function formatMarkdownEvalReport(result: EvalResult): string {
+  const lines: string[] = [];
+  lines.push("# CodeWard Eval");
+  lines.push("");
+  lines.push(`- Root: \`${escapeMarkdownInline(result.root)}\``);
+  if (result.workspaceRoot) {
+    lines.push(`- Workspace root: \`${escapeMarkdownInline(result.workspaceRoot)}\``);
+  }
+  lines.push(`- Base: \`${escapeMarkdownInline(result.base)}\``);
+  lines.push(`- Head: \`${escapeMarkdownInline(result.head)}\``);
+  if (result.includeWorkingTree) {
+    lines.push("- Includes working tree changes: yes");
+  }
+  lines.push(`- Score: **${result.score}/${result.maxScore}** (${result.rating})`);
+  lines.push(`- Changed files: ${result.changedFiles.length}`);
+  lines.push("");
+  lines.push("## Verification Gates");
+  lines.push("");
+  lines.push("| Gate | Status | Score | Reason |");
+  lines.push("| --- | --- | ---: | --- |");
+  for (const check of result.checks) {
+    lines.push(
+      `| ${escapeMarkdownCell(check.title)} | ${check.status} | ${check.score}/${check.maxScore} | ${escapeMarkdownCell(
+        check.reason,
+      )} |`,
+    );
+  }
+
+  lines.push("");
+  lines.push("## Evidence");
+  lines.push("");
+  for (const check of result.checks) {
+    lines.push(`### ${escapeMarkdownInline(check.title)}`);
+    lines.push("");
+    if (check.evidence.length === 0) {
+      lines.push("- No direct evidence found.");
+    } else {
+      for (const evidence of check.evidence) {
+        lines.push(`- ${escapeMarkdownInline(evidence)}`);
+      }
+    }
+    if (check.status !== "pass") {
+      lines.push(`- Recommendation: ${escapeMarkdownInline(check.recommendation)}`);
+    }
+    lines.push("");
+  }
+
+  if (result.recommendations.length > 0) {
+    lines.push("## Recommendations");
+    lines.push("");
+    for (const recommendation of result.recommendations) {
+      lines.push(`- ${escapeMarkdownInline(recommendation)}`);
+    }
+    lines.push("");
+  }
+
+  if (result.suggestedCommands.length > 0) {
+    lines.push("## Suggested Commands");
+    lines.push("");
+    for (const command of result.suggestedCommands) {
+      lines.push(`- \`${escapeMarkdownInline(command)}\``);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+async function readPrBodyFile(prBodyFile: string | undefined): Promise<string | undefined> {
+  if (!prBodyFile) {
+    return undefined;
+  }
+  return fs.readFile(path.resolve(prBodyFile), "utf8");
+}
+
+function scoreValidationCommands(commands: string[]): EvalCheck {
+  const hasTest = commands.some((command) =>
+    /\b(test|vitest|jest|playwright|node --test|pytest|go test)\b/i.test(command),
+  );
+  const hasSupport = commands.some((command) => /\b(typecheck|lint|build|check|e2e)\b/i.test(command));
+  if (hasTest && hasSupport) {
+    return check(
+      "validation-commands",
+      "Validation commands",
+      "pass",
+      2,
+      "Test and supporting validation commands are available.",
+      commands,
+    );
+  }
+  if (commands.length > 0) {
+    return check(
+      "validation-commands",
+      "Validation commands",
+      "warn",
+      1,
+      "Some validation commands are available, but the branch lacks a balanced test plus support command set.",
+      commands,
+      "Add or document a default test command plus a typecheck, lint, build, or e2e command.",
+    );
+  }
+  return check(
+    "validation-commands",
+    "Validation commands",
+    "fail",
+    0,
+    "No usable validation command was detected.",
+    [],
+    "Add a real package test script or document the validation command agents should run.",
+  );
+}
+
+function scoreChangedTestCoverage(files: TestPlanChangedFile[], commands: string[]): EvalCheck {
+  const sourceFiles = files.filter((file) => isSourceFile(file.path));
+  const testFiles = files.filter((file) => isTestFile(file.path));
+  if (sourceFiles.length === 0) {
+    return check(
+      "changed-test-coverage",
+      "Changed test coverage",
+      "pass",
+      2,
+      "No source files changed, so changed-test coverage is not required.",
+      files.slice(0, 6).map((file) => file.path),
+    );
+  }
+  if (testFiles.length > 0) {
+    return check(
+      "changed-test-coverage",
+      "Changed test coverage",
+      "pass",
+      2,
+      "Source changes are paired with changed test files.",
+      testFiles.map((file) => file.path),
+    );
+  }
+  if (commands.some((command) => /\btest\b/i.test(command))) {
+    return check(
+      "changed-test-coverage",
+      "Changed test coverage",
+      "warn",
+      1,
+      "Source files changed without changed test files, but a test command is available.",
+      sourceFiles.slice(0, 6).map((file) => file.path),
+      "Add focused tests for the changed behavior or explain why existing coverage is sufficient.",
+    );
+  }
+  return check(
+    "changed-test-coverage",
+    "Changed test coverage",
+    "fail",
+    0,
+    "Source files changed without changed test files or a detected test command.",
+    sourceFiles.slice(0, 6).map((file) => file.path),
+    "Add focused tests and a runnable test command before relying on the branch.",
+  );
+}
+
+async function scoreIntentCapture(
+  root: string,
+  workspaceRoot: string | undefined,
+  files: TestPlanChangedFile[],
+  prBody: string,
+): Promise<EvalCheck> {
+  const intentEvidence = intentEvidenceFromText(prBody);
+  if (intentEvidence.length >= 2) {
+    return check(
+      "intent-capture",
+      "Intent capture",
+      "pass",
+      2,
+      "The PR body captures intent, context, or tradeoffs.",
+      intentEvidence.slice(0, 4),
+    );
+  }
+
+  const documentationFiles = files.filter((file) => isIntentDocumentationFile(file.path)).map((file) => file.path);
+  if (documentationFiles.length > 0) {
+    return check(
+      "intent-capture",
+      "Intent capture",
+      "warn",
+      1,
+      "Documentation changed, but the PR body does not clearly capture intent.",
+      documentationFiles.slice(0, 6),
+      "Summarize the problem, chosen approach, rejected alternatives, and tradeoffs in the PR body.",
+    );
+  }
+
+  const template = await findPullRequestTemplate(root, workspaceRoot);
+  if (template) {
+    return check(
+      "intent-capture",
+      "Intent capture",
+      "warn",
+      1,
+      "A pull request template exists, but no intent-rich PR body was detected.",
+      [template],
+      "Fill the PR template with context, rationale, tradeoffs, and validation evidence.",
+    );
+  }
+
+  if (files.length === 0) {
+    return check("intent-capture", "Intent capture", "pass", 2, "No changed files were detected.", []);
+  }
+
+  return check(
+    "intent-capture",
+    "Intent capture",
+    "fail",
+    0,
+    "No PR body, decision document, or pull request template captured the reason for the change.",
+    [],
+    "Add an intent note that explains the problem, why this approach was chosen, and what tradeoffs reviewers should know.",
+  );
+}
+
+function scoreRiskExplanation(files: TestPlanChangedFile[], prBody: string): EvalCheck {
+  const riskyFiles = files.filter((file) => isRiskyChangeFile(file.path)).map((file) => file.path);
+  if (riskyFiles.length === 0) {
+    return check(
+      "risk-explanation",
+      "Risk explanation",
+      "pass",
+      2,
+      "No high-risk change surfaces were detected.",
+      files.slice(0, 6).map((file) => file.path),
+    );
+  }
+
+  const riskEvidence = riskEvidenceFromText(prBody);
+  if (riskEvidence.length > 0) {
+    return check(
+      "risk-explanation",
+      "Risk explanation",
+      "pass",
+      2,
+      "Risky surfaces changed and the PR body includes risk or rollback context.",
+      [...riskyFiles.slice(0, 4), ...riskEvidence.slice(0, 2)],
+    );
+  }
+
+  if (prBody.trim().length > 0) {
+    return check(
+      "risk-explanation",
+      "Risk explanation",
+      "warn",
+      1,
+      "Risky surfaces changed, but the PR body does not clearly discuss risk, rollback, compatibility, or migration impact.",
+      riskyFiles.slice(0, 6),
+      "Add risk, rollback, migration, compatibility, or security notes for the changed risky surfaces.",
+    );
+  }
+
+  return check(
+    "risk-explanation",
+    "Risk explanation",
+    "fail",
+    0,
+    "Risky surfaces changed without a detected risk explanation.",
+    riskyFiles.slice(0, 6),
+    "Add a PR risk section before merging changes to config, workflow, API, auth, billing, migration, or environment surfaces.",
+  );
+}
+
+function scoreDomainTestPlan(files: TestPlanChangedFile[], items: TestPlanItem[]): EvalCheck {
+  if (files.length === 0) {
+    return check("domain-test-plan", "Domain test plan", "pass", 2, "No changed files were detected.", []);
+  }
+  if (items.some((item) => item.title !== "Changed-file smoke path")) {
+    return check(
+      "domain-test-plan",
+      "Domain test plan",
+      "pass",
+      2,
+      "Changed files map to specialized domain test scenarios.",
+      items.map((item) => item.title),
+    );
+  }
+  if (items.length > 0) {
+    return check(
+      "domain-test-plan",
+      "Domain test plan",
+      "warn",
+      1,
+      "Only a generic smoke path could be inferred for this change.",
+      items.map((item) => item.title),
+      "Add a domain-owned path, API contract, state, UI, or configuration hint so reviewers can verify the right behavior.",
+    );
+  }
+  return check(
+    "domain-test-plan",
+    "Domain test plan",
+    "fail",
+    0,
+    "No test plan could be inferred.",
+    [],
+    "Add enough change context for CodeWard to suggest a domain verification path.",
+  );
+}
+
+function scoreReviewSize(files: TestPlanChangedFile[]): EvalCheck {
+  if (files.length <= 10) {
+    return check(
+      "review-size",
+      "Review size",
+      "pass",
+      2,
+      "The changed-file set is small enough for focused review.",
+      [`${files.length} changed files`],
+    );
+  }
+  if (files.length <= 30) {
+    return check(
+      "review-size",
+      "Review size",
+      "warn",
+      1,
+      "The changed-file set is moderately large and may increase verification tax.",
+      [`${files.length} changed files`],
+      "Split unrelated changes or add stronger intent, risk, and validation notes.",
+    );
+  }
+  return check(
+    "review-size",
+    "Review size",
+    "fail",
+    0,
+    "The changed-file set is large enough to create substantial cognitive load.",
+    [`${files.length} changed files`],
+    "Split the branch or add a reviewer guide that separates independent verification paths.",
+  );
+}
+
+function check(
+  id: string,
+  title: string,
+  status: EvalCheckStatus,
+  score: number,
+  reason: string,
+  evidence: string[],
+  recommendation = "No action needed.",
+): EvalCheck {
+  return {
+    id,
+    title,
+    status,
+    score,
+    maxScore: 2,
+    reason,
+    evidence,
+    recommendation,
+  };
+}
+
+function buildRecommendations(checks: EvalCheck[]): string[] {
+  return checks
+    .filter((check) => check.status !== "pass")
+    .map((check) => check.recommendation)
+    .filter((recommendation, index, recommendations) => recommendations.indexOf(recommendation) === index);
+}
+
+function ratingForScore(score: number, maxScore: number): EvalRating {
+  const ratio = maxScore === 0 ? 1 : score / maxScore;
+  if (ratio >= 0.85) {
+    return "strong";
+  }
+  if (ratio >= 0.7) {
+    return "ready";
+  }
+  if (ratio >= 0.45) {
+    return "needs-work";
+  }
+  return "high-risk";
+}
+
+function intentEvidenceFromText(text: string): string[] {
+  return evidenceFromText(text, [
+    "why",
+    "because",
+    "rationale",
+    "intent",
+    "context",
+    "tradeoff",
+    "decision",
+    "alternative",
+    "문제",
+    "이유",
+    "의도",
+    "맥락",
+    "결정",
+    "대안",
+    "트레이드오프",
+  ]);
+}
+
+function riskEvidenceFromText(text: string): string[] {
+  return evidenceFromText(text, [
+    "risk",
+    "rollback",
+    "migration",
+    "compatibility",
+    "breaking",
+    "security",
+    "impact",
+    "위험",
+    "리스크",
+    "롤백",
+    "마이그레이션",
+    "호환",
+    "보안",
+    "영향",
+  ]);
+}
+
+function evidenceFromText(text: string, keywords: string[]): string[] {
+  if (!text.trim()) {
+    return [];
+  }
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return lines
+    .filter((line) => keywords.some((keyword) => line.toLowerCase().includes(keyword.toLowerCase())))
+    .slice(0, 6);
+}
+
+function isSourceFile(filePath: string): boolean {
+  return (
+    /\.(?:[cm]?[jt]sx?|vue|svelte|py|rb|go|rs|java|kt|swift|cs)$/i.test(filePath) &&
+    !isTestFile(filePath) &&
+    !/(?:^|\/)(dist|build|coverage|vendor)\//i.test(filePath)
+  );
+}
+
+function isTestFile(filePath: string): boolean {
+  return /(?:^|\/)(__tests__|tests?|specs?|e2e)\/|(\.|-)(test|spec)\.[cm]?[jt]sx?$/i.test(filePath);
+}
+
+function isIntentDocumentationFile(filePath: string): boolean {
+  return /(?:^|\/)(docs|adr|adrs|decisions?|rfcs?|proposals?)\/|(?:adr|decision|rfc|proposal|design|intent).*\.md$/i.test(
+    filePath,
+  );
+}
+
+function isRiskyChangeFile(filePath: string): boolean {
+  const riskyDirectory =
+    /(?:^|\/)(\.github\/workflows|migrations?|schema|prisma|db|database|auth|billing|payment|permissions?|security|config|configs)\//i;
+  const riskyFile =
+    /(?:action\.ya?ml|package\.json|pnpm-lock\.yaml|yarn\.lock|package-lock\.json|\.env|config|workflow|openapi|swagger|graphql|proto)/i;
+  return riskyDirectory.test(filePath) || riskyFile.test(filePath);
+}
+
+async function findPullRequestTemplate(root: string, workspaceRoot: string | undefined): Promise<string | undefined> {
+  for (const baseRoot of [root, workspaceRoot].filter((value): value is string => Boolean(value))) {
+    const directCandidates = [
+      ".github/pull_request_template.md",
+      ".github/PULL_REQUEST_TEMPLATE.md",
+      "docs/pull_request_template.md",
+    ];
+    for (const candidate of directCandidates) {
+      const resolved = path.join(baseRoot, candidate);
+      if (await exists(resolved)) {
+        return displayPath(root, workspaceRoot, baseRoot, resolved, candidate);
+      }
+    }
+
+    const templateDirectory = path.join(baseRoot, ".github/PULL_REQUEST_TEMPLATE");
+    try {
+      const entries = await fs.readdir(templateDirectory);
+      const template = entries.find((entry) => entry.endsWith(".md"));
+      if (template) {
+        const resolved = path.join(templateDirectory, template);
+        return displayPath(root, workspaceRoot, baseRoot, resolved, `.github/PULL_REQUEST_TEMPLATE/${template}`);
+      }
+    } catch {
+      // No template directory in this root.
+    }
+  }
+  return undefined;
+}
+
+function displayPath(
+  root: string,
+  workspaceRoot: string | undefined,
+  baseRoot: string,
+  filePath: string,
+  fallback: string,
+): string {
+  const displayRoot = workspaceRoot && baseRoot === workspaceRoot ? workspaceRoot : root;
+  return path.relative(displayRoot, filePath) || fallback;
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeText(value: string | undefined): string {
+  return value?.replaceAll("\0", "").trim() ?? "";
+}
+
+function escapeMarkdownInline(value: string): string {
+  return value.replaceAll("`", "'");
+}
+
+function escapeMarkdownCell(value: string): string {
+  return escapeMarkdownInline(value).replaceAll("|", "\\|").replace(/\s+/g, " ").trim();
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import { evaluateChangeReadiness, formatMarkdownEvalReport } from "./eval.js";
 import { formatMarkdownReport } from "./report.js";
 import { formatMarkdownReviewReport, reviewProject } from "./review.js";
 import { scanProject } from "./scanner.js";
@@ -22,6 +23,10 @@ export interface GitHubActionOptions {
   stepSummaryPath?: string;
   testPlan?: boolean;
   testPlanFile?: string;
+  evaluation?: boolean;
+  evalFile?: string;
+  prBody?: string;
+  prBodyFile?: string;
   includeWorkingTree?: boolean;
 }
 
@@ -30,6 +35,7 @@ export interface GitHubActionResult {
   reportFile: string;
   commentFile: string;
   testPlanFile?: string;
+  evalFile?: string;
   findingCount: number;
   failedFindingCount: number;
   exitCode: number;
@@ -43,6 +49,7 @@ export async function runGitHubAction(rootInput: string, options: GitHubActionOp
   const reportFile = path.resolve(options.reportFile ?? "codeward-report.md");
   const commentFile = path.resolve(options.commentFile ?? "codeward-pr-comment.md");
   const testPlanFile = options.testPlan ? path.resolve(options.testPlanFile ?? "codeward-test-plan.md") : undefined;
+  const evalFile = options.evaluation ? path.resolve(options.evalFile ?? "codeward-eval.md") : undefined;
 
   const result =
     mode === "review"
@@ -58,12 +65,31 @@ export async function runGitHubAction(rootInput: string, options: GitHubActionOp
         }),
       )
     : undefined;
-  const markdown = testPlanMarkdown ? `${result.markdown.trim()}\n\n---\n\n${testPlanMarkdown.trim()}\n` : result.markdown;
+  const evalMarkdown = options.evaluation
+    ? formatMarkdownEvalReport(
+        await evaluateChangeReadiness(rootInput, {
+          base: options.base,
+          head: options.head,
+          workspaceRoot: options.scanOptions?.workspaceRoot,
+          includeWorkingTree: options.includeWorkingTree,
+          prBody: options.prBody ?? (await readPullRequestBody()),
+          prBodyFile: options.prBodyFile,
+        }),
+      )
+    : undefined;
+  const markdown = [result.markdown, testPlanMarkdown, evalMarkdown]
+    .filter((section): section is string => Boolean(section))
+    .map((section) => section.trim())
+    .join("\n\n---\n\n")
+    .concat("\n");
 
   await fs.writeFile(reportFile, markdown, "utf8");
   await fs.writeFile(commentFile, buildCommentBody(markdown), "utf8");
   if (testPlanFile && testPlanMarkdown) {
     await fs.writeFile(testPlanFile, testPlanMarkdown, "utf8");
+  }
+  if (evalFile && evalMarkdown) {
+    await fs.writeFile(evalFile, evalMarkdown, "utf8");
   }
 
   if (options.stepSummary !== false) {
@@ -79,12 +105,16 @@ export async function runGitHubAction(rootInput: string, options: GitHubActionOp
   if (testPlanFile) {
     console.log(`CodeWard test plan: ${testPlanFile}`);
   }
+  if (evalFile) {
+    console.log(`CodeWard eval: ${evalFile}`);
+  }
 
   return {
     mode,
     reportFile,
     commentFile,
     testPlanFile,
+    evalFile,
     findingCount: result.findings.length,
     failedFindingCount: result.failedFindings.length,
     exitCode: result.failedFindings.length > 0 ? 1 : 0,
@@ -211,6 +241,23 @@ function escapeAnnotationMessage(value: string): string {
 
 function escapeAnnotationProperty(value: string): string {
   return escapeAnnotationMessage(value).replaceAll(":", "%3A").replaceAll(",", "%2C");
+}
+
+async function readPullRequestBody(): Promise<string | undefined> {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) {
+    return undefined;
+  }
+  try {
+    const event = JSON.parse(await fs.readFile(eventPath, "utf8")) as {
+      pull_request?: {
+        body?: string | null;
+      };
+    };
+    return event.pull_request?.body ?? undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export function githubCommentMarker(): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,14 @@
 export { defaultConfig, loadConfig, writeDefaultConfig } from "./config.js";
 export { generateAgentContext } from "./context.js";
 export { buildDoctorResult, formatDoctorReport, formatMarkdownDoctorReport } from "./doctor.js";
+export { evaluateChangeReadiness, formatEvalReport, formatMarkdownEvalReport } from "./eval.js";
 export { githubCommentMarker, runGitHubAction } from "./github.js";
 export { formatMarkdownReport, formatSarifReport, formatTextReport, hasFindingsAtOrAbove } from "./report.js";
 export { formatMarkdownReviewReport, formatReviewReport, reviewProject } from "./review.js";
 export { scanProject } from "./scanner.js";
 export { formatMarkdownTestPlan, generateTestPlan } from "./test-plan.js";
 export type { DoctorArea, DoctorPriority, DoctorResult } from "./doctor.js";
+export type { EvalCheck, EvalCheckStatus, EvalOptions, EvalRating, EvalResult } from "./eval.js";
 export type { GitHubActionMode, GitHubActionOptions, GitHubActionResult } from "./github.js";
 export type { ChangedFile, ChangedRiskyFinding, ReviewOptions, ReviewResult } from "./review.js";
 export type { TestPlanChangedFile, TestPlanItem, TestPlanOptions, TestPlanResult } from "./test-plan.js";

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -8,6 +8,8 @@ import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 import {
   buildDoctorResult,
+  evaluateChangeReadiness,
+  formatMarkdownEvalReport,
   formatMarkdownReport,
   formatDoctorReport,
   formatMarkdownDoctorReport,
@@ -409,6 +411,73 @@ test("generateTestPlan scopes monorepo changes to the requested package", async 
   assert.match(localMarkdown, /Includes working tree changes: yes/);
 });
 
+test("evaluateChangeReadiness scores intent, risk, and verification evidence", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src/features/billing/api"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      packageManager: "pnpm@10.32.1",
+      scripts: {
+        test: "node --test",
+        typecheck: "tsc --noEmit",
+      },
+    }),
+  );
+  await writeFile(path.join(root, "src/features/billing/api/client.ts"), "export const endpoint = '/billing';\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/billing-contract"]);
+  await writeFile(path.join(root, "src/features/billing/api/client.ts"), "export const endpoint = '/billing/v2';\n");
+  await writeFile(path.join(root, "src/features/billing/api/client.test.ts"), "import './client.js';\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "update billing contract"]);
+
+  const result = await evaluateChangeReadiness(root, {
+    base: "main",
+    head: "HEAD",
+    prBody: [
+      "문제: billing API contract changed for settlement retries.",
+      "이유: old clients could not distinguish retryable failures.",
+      "Risk: API compatibility is preserved for existing callers.",
+      "Rollback: switch endpoint mapping back to /billing.",
+    ].join("\n"),
+  });
+  const markdown = formatMarkdownEvalReport(result);
+
+  assert.equal(result.rating, "strong");
+  assert.equal(result.score, result.maxScore);
+  assert.equal(result.checks.find((check) => check.id === "intent-capture")?.status, "pass");
+  assert.equal(result.checks.find((check) => check.id === "risk-explanation")?.status, "pass");
+  assert.match(markdown, /# CodeWard Eval/);
+  assert.match(markdown, /Verification Gates/);
+});
+
+test("evaluateChangeReadiness flags missing intent and risk context", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src/auth"), { recursive: true });
+  await writeFile(path.join(root, "src/auth/session.ts"), "export const timeout = 5;\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/session-timeout"]);
+  await writeFile(path.join(root, "src/auth/session.ts"), "export const timeout = 10;\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "change session timeout"]);
+
+  const result = await evaluateChangeReadiness(root, { base: "main", head: "HEAD" });
+
+  assert.equal(result.rating, "high-risk");
+  assert.equal(result.checks.find((check) => check.id === "validation-commands")?.status, "fail");
+  assert.equal(result.checks.find((check) => check.id === "intent-capture")?.status, "fail");
+  assert.equal(result.checks.find((check) => check.id === "risk-explanation")?.status, "fail");
+});
+
 test("formatMarkdownReport includes a useful summary", async () => {
   const root = await makeTempRepo();
   const result = await scanProject(root);
@@ -719,6 +788,7 @@ test("github-action command writes PR artifacts before failing", async () => {
   const reportFile = path.join(root, "codeward-report.md");
   const commentFile = path.join(root, "codeward-pr-comment.md");
   const testPlanFile = path.join(root, "codeward-test-plan.md");
+  const evalFile = path.join(root, "codeward-eval.md");
   const summaryFile = path.join(root, "codeward-step-summary.md");
 
   await assert.rejects(
@@ -744,6 +814,9 @@ test("github-action command writes PR artifacts before failing", async () => {
           "--test-plan",
           "--test-plan-file",
           testPlanFile,
+          "--eval",
+          "--eval-file",
+          evalFile,
         ],
         {
           env: {
@@ -758,15 +831,19 @@ test("github-action command writes PR artifacts before failing", async () => {
   const report = await readFile(reportFile, "utf8");
   const comment = await readFile(commentFile, "utf8");
   const testPlan = await readFile(testPlanFile, "utf8");
+  const evaluation = await readFile(evalFile, "utf8");
   const summary = await readFile(summaryFile, "utf8");
 
   assert.match(report, /# CodeWard Review/);
   assert.match(report, /## Changed Risky Files/);
   assert.match(report, /# CodeWard Test Plan/);
+  assert.match(report, /# CodeWard Eval/);
   assert.match(comment, /<!-- codeward-pr-comment -->/);
   assert.match(comment, /Generated by CodeWard/);
   assert.match(comment, /# CodeWard Test Plan/);
+  assert.match(comment, /# CodeWard Eval/);
   assert.match(testPlan, /# CodeWard Test Plan/);
+  assert.match(evaluation, /# CodeWard Eval/);
   assert.match(summary, /# CodeWard Review/);
 });
 


### PR DESCRIPTION
## Summary
- add `codeward eval` to score change readiness across validation, tests, intent capture, risk explanation, domain test planning, and review size
- append optional eval reports to GitHub Action artifacts, PR comments, and step summaries
- document eval as a verification layer for AI-assisted changes

## Tests
- `pnpm test`
- `pnpm scan`
- `git diff --check`
- generated `/tmp/codeward-eval.md` for this branch with a PR body fixture
- generated `/tmp/codeward-offer-eval.md` and GitHub Action-style `/tmp` artifacts against `/Users/khs/Desktop/inpock-frontend/services/offer` with `--include-working-tree`

## Notes
This is the first static version of the verification-readiness layer. It does not judge code correctness; it checks whether reviewers have enough intent, risk, and validation evidence to trust the change.