### PR TITLE
Feat: add unified verify command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,17 @@
 [![CI](https://github.com/IvoryCanvas/codeward/actions/workflows/ci.yml/badge.svg)](https://github.com/IvoryCanvas/codeward/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**Repo-level preflight checks before AI coding agents touch your code.**
+**A no-token verification layer for AI-assisted pull requests.**
 
-CodeWard scans the repository surface that AI coding agents rely on: agent instructions, MCP configuration, agent settings and hooks, API contract source-of-truth signals, local environment files, package scripts, GitHub Actions permissions, community health files, and validation signals.
+CodeWard checks whether an AI-assisted change is safe and reviewable before merge. It combines repo guardrail scanning, branch review, domain test planning, and verification-readiness scoring into one CLI and GitHub Action.
 
 It is built for teams using Codex, Claude Code, Cursor, GitHub Copilot coding agent, MCP-powered tools, or any workflow where an agent can read, edit, test, commit, or open pull requests.
 
 CodeWard is intentionally small:
 
 - static by default: it does not execute scanned project code
-- repo-focused: it checks the guardrails around the code, not general style
+- no-token by default: it does not call an LLM API
+- verification-focused: it tells reviewers what evidence is missing, not how to style code
 - CI-friendly: text, JSON, Markdown, and SARIF output are supported
 - explainable: every finding includes a concrete fix
 
@@ -46,10 +47,40 @@ CodeWard gives maintainers a quick first line of defense:
 ## Quick Demo
 
 ```sh
-codeward scan .
+codeward verify . --base origin/main --head HEAD --pr-body-file pr-body.md
 ```
 
-Example output from a risky repository:
+Example output from an AI-assisted PR:
+
+```txt
+CodeWard Verify
+Readiness: 6/12 (needs-work)
+Changed files: 5
+New findings: 0
+Changed risky files: 0
+
+Verification gates:
+- WARN Validation commands: package has typecheck/lint/build, but no test command
+- FAIL Changed test coverage: source changed without changed tests
+- WARN Intent capture: PR template exists, but no intent-rich PR body was detected
+- FAIL Risk explanation: domain config changed without risk or rollback context
+
+Suggested domain tests:
+- Campaign workflow regression
+- User-facing UI states
+- Domain configuration and variants
+
+Suggested commands:
+- pnpm run typecheck
+- pnpm run lint
+- pnpm run build
+```
+
+For a repository baseline before broad agent use, run:
+
+```sh
+codeward scan .
+```
 
 ```txt
 CodeWard 0.1.0
@@ -57,32 +88,7 @@ Findings: 6 (high: 3, medium: 2, low: 1, info: 0)
 
 HIGH
 - CW003 Suspicious agent instruction text (AGENTS.md)
-  Instruction file contains text that matches a suspicious instruction override pattern.
-  Fix: Remove untrusted instruction text or move examples into clearly fenced documentation that agents should not follow.
-
-- CW009 Risky package script (package.json)
-  The "release" script can publish, push, or merge changes.
-  Fix: Keep publish, push, merge, and destructive scripts outside default agent workflows or gate them with maintainer-only release processes.
-
-- CW008 Committed environment file (.env)
-  A local environment file appears to be present in the repository.
-  Fix: Remove committed environment files, rotate any exposed secrets, and keep only safe examples such as .env.example.
-```
-
-For a readiness view, use `doctor`:
-
-```sh
-codeward doctor .
-```
-
-```txt
-CodeWard Doctor
-Agent readiness: High risk
-
-Guardrail areas:
-- [review] Agent instructions: Agent guidance needs attention before broad agent use. (CW003)
-- [review] Validation: Agents do not have a clear default validation command. (CW006)
-- [review] Repository automation: Local environment files or risky scripts need maintainer review. (CW008, CW009)
+  Fix: Remove untrusted instruction text or move examples into clearly fenced documentation.
 ```
 
 ## Install
@@ -114,6 +120,7 @@ node dist/cli.js scan /path/to/repo
 | `codeward report . --output CODEWARD_REPORT.md` | Generate a Markdown report for PRs or audits. |
 | `codeward doctor . --format markdown` | Summarize whether the repo is ready for AI-assisted work. |
 | `codeward review . --base origin/main --head HEAD --format markdown` | Show new findings and changed risky files introduced by a branch. |
+| `codeward verify . --base origin/main --head HEAD --pr-body-file pr-body.md` | Combine review findings, readiness scoring, domain tests, and next actions. |
 | `codeward eval . --base origin/main --head HEAD --pr-body-file pr-body.md` | Score change readiness across intent, risk, tests, and review size. |
 | `codeward github-action . --mode review --base origin/main --head HEAD` | Generate GitHub Action annotations, step summary, and PR comment body. |
 | `codeward test-plan . --base origin/main --head HEAD --include-working-tree` | Suggest domain test scenarios for changed files. |
@@ -124,6 +131,8 @@ node dist/cli.js scan /path/to/repo
 For monorepos, pass `--workspace-root` when scanning a package. Package-local checks still use the package directory, while repo-level guardrails such as `AGENTS.md`, `.github/workflows`, `LICENSE`, `SECURITY.md`, and `CONTRIBUTING.md` are read from the workspace root.
 
 `codeward review` compares a branch against a base ref for PR-style workflows. It separates newly introduced findings from risky files that already had findings on the base branch but were modified again, which helps reviewers notice when a PR touches known-dangerous surfaces such as committed `.env` files, MCP configs, or release scripts.
+
+`codeward verify` is the easiest PR-facing command. It combines `review`, `test-plan`, and `eval` into one report with review findings, readiness gates, suggested domain tests, suggested commands, and next actions.
 
 `codeward test-plan` turns changed file paths into a review-ready domain test checklist. Add `--include-working-tree` for local, uncommitted changes while iterating.
 
@@ -152,6 +161,7 @@ The first release focuses on high-signal checks that are useful across many repo
 See [docs/rules.md](docs/rules.md) for the rule catalog.
 See [docs/ecosystem.md](docs/ecosystem.md) for the agent ecosystem surfaces CodeWard tracks.
 See [docs/api-contracts.md](docs/api-contracts.md) for the API contract source-of-truth check.
+See [docs/verify.md](docs/verify.md) for the combined PR verification report.
 See [docs/eval.md](docs/eval.md) for the change readiness evaluation.
 
 ## Configuration

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -28,13 +28,14 @@ Start advisory, then tighten the gate once the findings are understood.
 | --- | --- | --- |
 | 1. Baseline | `codeward scan .` | See current repo-level AI agent risks without blocking work. |
 | 2. Doctor | `codeward doctor . --format markdown` | Get an agent-readiness summary by guardrail area. |
-| 3. Review | `codeward review . --base origin/main --head HEAD --format markdown` | See new findings introduced by the branch. |
-| 4. Test plan | `codeward test-plan . --base origin/main --head HEAD --include-working-tree` | Suggest domain test scenarios for changed and local files. |
-| 5. Eval | `codeward eval . --base origin/main --head HEAD --pr-body-file pr-body.md` | Score intent capture, risk explanation, test evidence, and review size. |
-| 6. PR Action | `uses: IvoryCanvas/codeward@main` | Add annotations, a step summary, a test plan, eval, and a sticky PR comment. |
-| 7. Report | `codeward report . --output CODEWARD_REPORT.md` | Share a readable audit artifact in a PR or maintainer discussion. |
-| 8. High-risk gate | `codeward scan . --fail-on high` | Block obvious risks such as committed env files or unsafe scripts. |
-| 9. Medium-risk gate | `codeward scan . --fail-on medium` | Require stronger agent guidance, tests, and workflow permissions. |
+| 3. Verify | `codeward verify . --base origin/main --head HEAD --pr-body-file pr-body.md` | Combine review findings, readiness score, suggested domain tests, and next actions. |
+| 4. Review | `codeward review . --base origin/main --head HEAD --format markdown` | See new findings introduced by the branch. |
+| 5. Test plan | `codeward test-plan . --base origin/main --head HEAD --include-working-tree` | Suggest domain test scenarios for changed and local files. |
+| 6. Eval | `codeward eval . --base origin/main --head HEAD --pr-body-file pr-body.md` | Score intent capture, risk explanation, test evidence, and review size. |
+| 7. PR Action | `uses: IvoryCanvas/codeward@main` | Add annotations, a step summary, a test plan, eval, and a sticky PR comment. |
+| 8. Report | `codeward report . --output CODEWARD_REPORT.md` | Share a readable audit artifact in a PR or maintainer discussion. |
+| 9. High-risk gate | `codeward scan . --fail-on high` | Block obvious risks such as committed env files or unsafe scripts. |
+| 10. Medium-risk gate | `codeward scan . --fail-on medium` | Require stronger agent guidance, tests, and workflow permissions. |
 
 ## Monorepos
 
@@ -92,6 +93,12 @@ When the repository is stable, consider `--fail-on medium`.
 For all inputs, see [github-action.md](github-action.md).
 
 ## Change Readiness Eval
+
+For the most useful PR-facing report, start with `verify`:
+
+```sh
+codeward verify . --base origin/main --head HEAD --pr-body-file pr-body.md --format markdown
+```
 
 Use `codeward eval` when an AI-assisted branch looks plausible but reviewers need a faster way to decide what still needs human attention:
 

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -4,9 +4,12 @@
 
 It does not try to prove that the code is correct. Instead, it checks whether reviewers have enough evidence to trust, challenge, and verify the change without absorbing unnecessary cognitive load.
 
+For a complete PR-facing report that also includes CodeWard review findings and suggested domain tests, use `codeward verify`.
+
 ## Usage
 
 ```sh
+codeward verify . --base origin/main --head HEAD --pr-body-file pr-body.md
 codeward eval . --base origin/main --head HEAD --format markdown
 codeward eval . --base origin/main --head HEAD --pr-body-file pr-body.md
 codeward eval services/offer --workspace-root . --base origin/main --head HEAD --include-working-tree

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,6 +7,7 @@ CodeWard starts as a local CLI for repo-level AI agent readiness. The project ca
 - Keep the scanner fast, static, and easy to understand.
 - Make the first public npm release.
 - Improve README, adoption docs, and sample output so new maintainers can try CodeWard quickly.
+- Make `verify` the best first-run experience for AI-assisted PRs.
 - Keep `eval` explainable enough that maintainers trust the score and know what to fix.
 
 ## Next

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -1,0 +1,32 @@
+# CodeWard Verify
+
+`codeward verify` is the PR-facing entry point for CodeWard.
+
+It combines:
+
+- `review`: new CodeWard findings and changed risky files introduced by a branch
+- `eval`: verification-readiness gates for intent, risk, tests, and review size
+- `test-plan`: domain-oriented scenarios inferred from changed files
+
+## Usage
+
+```sh
+codeward verify . --base origin/main --head HEAD --format markdown
+codeward verify . --base origin/main --head HEAD --pr-body-file pr-body.md
+codeward verify services/offer --workspace-root . --base origin/main --head HEAD --include-working-tree
+```
+
+Use `--fail-on high` or `--fail-on medium` to fail on CodeWard review findings at or above a severity threshold. Readiness scoring stays advisory in the first release.
+
+## Output
+
+The report answers the questions reviewers usually ask after an AI-assisted PR appears:
+
+- Did this branch introduce new repo-level AI risks?
+- Did it touch files that already had risky findings?
+- Does the PR explain its intent, risk, rollback, or validation evidence?
+- Which domain scenarios should be tested?
+- Which commands should the author or reviewer run?
+- Is the diff small enough to review without excessive verification tax?
+
+`verify` is intentionally static and no-token by default. It does not execute project code and does not send source code to an LLM service.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import { formatMarkdownReviewReport, formatReviewReport, reviewProject } from ".
 import { scanProject } from "./scanner.js";
 import { isAtLeastSeverity, isSeverity } from "./severity.js";
 import { formatMarkdownTestPlan, generateTestPlan } from "./test-plan.js";
+import { formatMarkdownVerifyReport, formatVerifyReport, verifyChange } from "./verify.js";
 import type { CodeWardConfig } from "./types.js";
 import type { Severity } from "./types.js";
 import { VERSION } from "./version.js";
@@ -99,6 +100,23 @@ async function main(argv: string[]): Promise<number> {
     await printOrWrite(output, options.output);
     const failOn = options.failOn ?? loadedConfig.config.failOn;
     const reviewFindings = [...result.newFindings, ...result.changedRiskyFindings];
+    return failOn && reviewFindings.some((finding) => isAtLeastSeverity(finding.severity, failOn)) ? 1 : 0;
+  }
+
+  if (command === "verify") {
+    const options = parseOptions(rest);
+    const loadedConfig = await loadOptionsConfig(options);
+    const result = await verifyChange(options.path, {
+      base: options.base,
+      head: options.head,
+      scanOptions: buildScanOptions(options, loadedConfig),
+      includeWorkingTree: options.includeWorkingTree,
+      prBodyFile: options.prBodyFile,
+    });
+    const output = formatVerifyOutput(result, options.format ?? (options.json ? "json" : "markdown"));
+    await printOrWrite(output, options.output);
+    const failOn = options.failOn ?? loadedConfig.config.failOn;
+    const reviewFindings = [...result.review.newFindings, ...result.review.changedRiskyFindings];
     return failOn && reviewFindings.some((finding) => isAtLeastSeverity(finding.severity, failOn)) ? 1 : 0;
   }
 
@@ -444,6 +462,19 @@ function formatEvalOutput(result: Awaited<ReturnType<typeof evaluateChangeReadin
   return formatEvalReport(result);
 }
 
+function formatVerifyOutput(result: Awaited<ReturnType<typeof verifyChange>>, format: OutputFormat): string {
+  if (format === "json") {
+    return `${JSON.stringify(result, null, 2)}\n`;
+  }
+  if (format === "markdown") {
+    return formatMarkdownVerifyReport(result);
+  }
+  if (format !== "text") {
+    throw new Error(`Verify supports text, json, or markdown output, not ${format}`);
+  }
+  return formatVerifyReport(result);
+}
+
 async function printOrWrite(output: string, outputPath?: string): Promise<void> {
   if (outputPath) {
     const resolvedOutputPath = path.resolve(outputPath);
@@ -480,6 +511,7 @@ Usage:
   codeward report [path] [--format <format>] [--output <file>] [--fail-on <severity>]
   codeward doctor [path] [--format <format>] [--output <file>] [--fail-on <severity>]
   codeward review [path] [--base <ref>] [--head <ref>] [--format <format>] [--fail-on <severity>]
+  codeward verify [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--pr-body-file <file>] [--fail-on <severity>]
   codeward eval [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--pr-body-file <file>] [--format <format>]
   codeward github-action [path] [--mode auto|scan|review] [--base <ref>] [--head <ref>] [--fail-on <severity>]
   codeward test-plan [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--format <format>] [--output <file>]
@@ -500,6 +532,7 @@ Examples:
   codeward report . --output CODEWARD_REPORT.md
   codeward doctor .
   codeward review . --base origin/main --head HEAD
+  codeward verify . --base origin/main --head HEAD --pr-body-file pr-body.md
   codeward eval . --base origin/main --head HEAD --pr-body-file pr-body.md
   codeward github-action . --mode review --base origin/main --head HEAD --fail-on high
   codeward test-plan . --base origin/main --head HEAD

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,11 @@ export { formatMarkdownReport, formatSarifReport, formatTextReport, hasFindingsA
 export { formatMarkdownReviewReport, formatReviewReport, reviewProject } from "./review.js";
 export { scanProject } from "./scanner.js";
 export { formatMarkdownTestPlan, generateTestPlan } from "./test-plan.js";
+export { formatMarkdownVerifyReport, formatVerifyReport, verifyChange } from "./verify.js";
 export type { DoctorArea, DoctorPriority, DoctorResult } from "./doctor.js";
 export type { EvalCheck, EvalCheckStatus, EvalOptions, EvalRating, EvalResult } from "./eval.js";
 export type { GitHubActionMode, GitHubActionOptions, GitHubActionResult } from "./github.js";
 export type { ChangedFile, ChangedRiskyFinding, ReviewOptions, ReviewResult } from "./review.js";
 export type { TestPlanChangedFile, TestPlanItem, TestPlanOptions, TestPlanResult } from "./test-plan.js";
 export type { CodeWardConfig, Finding, ScanCounts, ScanOptions, ScanResult, Severity } from "./types.js";
+export type { VerifyOptions, VerifyResult } from "./verify.js";

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -1,0 +1,210 @@
+import { evaluateChangeReadiness } from "./eval.js";
+import type { EvalOptions, EvalResult } from "./eval.js";
+import { reviewProject } from "./review.js";
+import type { ReviewResult } from "./review.js";
+import type { Finding, ScanOptions } from "./types.js";
+import { TOOL_NAME, VERSION } from "./version.js";
+
+export interface VerifyOptions extends EvalOptions {
+  scanOptions?: ScanOptions;
+}
+
+export interface VerifyResult {
+  tool: {
+    name: string;
+    version: string;
+  };
+  root: string;
+  workspaceRoot?: string;
+  generatedAt: string;
+  base: string;
+  head: string;
+  review: ReviewResult;
+  evaluation: EvalResult;
+  recommendations: string[];
+}
+
+export async function verifyChange(rootInput: string, options: VerifyOptions = {}): Promise<VerifyResult> {
+  const scanOptions = options.workspaceRoot
+    ? { ...options.scanOptions, workspaceRoot: options.workspaceRoot }
+    : options.scanOptions;
+  const review = await reviewProject(rootInput, {
+    base: options.base,
+    head: options.head,
+    scanOptions,
+  });
+  const evaluation = await evaluateChangeReadiness(rootInput, {
+    base: options.base,
+    head: options.head,
+    workspaceRoot: options.workspaceRoot ?? scanOptions?.workspaceRoot,
+    includeWorkingTree: options.includeWorkingTree,
+    prBody: options.prBody,
+    prBodyFile: options.prBodyFile,
+  });
+
+  return {
+    tool: {
+      name: TOOL_NAME,
+      version: VERSION,
+    },
+    root: evaluation.root,
+    workspaceRoot: evaluation.workspaceRoot,
+    generatedAt: new Date().toISOString(),
+    base: evaluation.base,
+    head: evaluation.head,
+    review,
+    evaluation,
+    recommendations: buildRecommendations(review, evaluation),
+  };
+}
+
+export function formatVerifyReport(result: VerifyResult): string {
+  const lines: string[] = [];
+  lines.push(`${result.tool.name} Verify`);
+  lines.push(`Root: ${result.root}`);
+  if (result.workspaceRoot) {
+    lines.push(`Workspace root: ${result.workspaceRoot}`);
+  }
+  lines.push(`Base: ${result.base}`);
+  lines.push(`Head: ${result.head}`);
+  lines.push(`Readiness: ${result.evaluation.score}/${result.evaluation.maxScore} (${result.evaluation.rating})`);
+  lines.push(`Changed files: ${result.evaluation.changedFiles.length}`);
+  lines.push(`New findings: ${result.review.newFindings.length}`);
+  lines.push(`Changed risky files: ${result.review.changedRiskyFindings.length}`);
+
+  lines.push("");
+  lines.push("Verification gates:");
+  for (const check of result.evaluation.checks) {
+    lines.push(`- ${check.status.toUpperCase()} ${check.title}: ${check.score}/${check.maxScore} - ${check.reason}`);
+  }
+
+  if (result.evaluation.testPlanItems.length > 0) {
+    lines.push("");
+    lines.push("Suggested domain tests:");
+    for (const item of result.evaluation.testPlanItems) {
+      lines.push(`- ${item.title}: ${item.checks[0]}`);
+    }
+  }
+
+  if (result.evaluation.suggestedCommands.length > 0) {
+    lines.push("");
+    lines.push("Suggested commands:");
+    for (const command of result.evaluation.suggestedCommands) {
+      lines.push(`- ${command}`);
+    }
+  }
+
+  if (result.recommendations.length > 0) {
+    lines.push("");
+    lines.push("Next actions:");
+    for (const recommendation of result.recommendations) {
+      lines.push(`- ${recommendation}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function formatMarkdownVerifyReport(result: VerifyResult): string {
+  const lines: string[] = [];
+  lines.push("# CodeWard Verify");
+  lines.push("");
+  lines.push(`- Root: \`${escapeMarkdownInline(result.root)}\``);
+  if (result.workspaceRoot) {
+    lines.push(`- Workspace root: \`${escapeMarkdownInline(result.workspaceRoot)}\``);
+  }
+  lines.push(`- Base: \`${escapeMarkdownInline(result.base)}\``);
+  lines.push(`- Head: \`${escapeMarkdownInline(result.head)}\``);
+  if (result.evaluation.includeWorkingTree) {
+    lines.push("- Includes working tree changes: yes");
+  }
+  lines.push(`- Readiness: **${result.evaluation.score}/${result.evaluation.maxScore}** (${result.evaluation.rating})`);
+  lines.push(`- Changed files: ${result.evaluation.changedFiles.length}`);
+  lines.push(`- New findings: ${result.review.newFindings.length}`);
+  lines.push(`- Changed risky files: ${result.review.changedRiskyFindings.length}`);
+  lines.push("");
+
+  lines.push("## Verification Gates");
+  lines.push("");
+  lines.push("| Gate | Status | Score | Reason |");
+  lines.push("| --- | --- | ---: | --- |");
+  for (const check of result.evaluation.checks) {
+    lines.push(
+      `| ${escapeMarkdownCell(check.title)} | ${check.status} | ${check.score}/${check.maxScore} | ${escapeMarkdownCell(
+        check.reason,
+      )} |`,
+    );
+  }
+  lines.push("");
+
+  lines.push("## Review Findings");
+  lines.push("");
+  if (result.review.newFindings.length === 0 && result.review.changedRiskyFindings.length === 0) {
+    lines.push("No new CodeWard findings or changed risky files were introduced by this branch.");
+  } else {
+    for (const finding of [...result.review.newFindings, ...result.review.changedRiskyFindings].slice(0, 12)) {
+      const fileSuffix = finding.file ? ` (${escapeMarkdownInline(finding.file)})` : "";
+      lines.push(`- \`${finding.id}\` **${escapeMarkdownInline(finding.title)}**${fileSuffix}`);
+      lines.push(`  - ${escapeMarkdownInline(finding.message)}`);
+      lines.push(`  - Fix: ${escapeMarkdownInline(finding.recommendation)}`);
+    }
+  }
+  lines.push("");
+
+  if (result.evaluation.testPlanItems.length > 0) {
+    lines.push("## Suggested Domain Tests");
+    lines.push("");
+    for (const [index, item] of result.evaluation.testPlanItems.entries()) {
+      lines.push(`### ${index + 1}. ${escapeMarkdownInline(item.title)}`);
+      lines.push("");
+      lines.push(item.reason);
+      lines.push("");
+      lines.push("Checks:");
+      for (const check of item.checks) {
+        lines.push(`- ${escapeMarkdownInline(check)}`);
+      }
+      lines.push("");
+    }
+  }
+
+  if (result.evaluation.suggestedCommands.length > 0) {
+    lines.push("## Suggested Commands");
+    lines.push("");
+    for (const command of result.evaluation.suggestedCommands) {
+      lines.push(`- \`${escapeMarkdownInline(command)}\``);
+    }
+    lines.push("");
+  }
+
+  if (result.recommendations.length > 0) {
+    lines.push("## Next Actions");
+    lines.push("");
+    for (const recommendation of result.recommendations) {
+      lines.push(`- ${escapeMarkdownInline(recommendation)}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function buildRecommendations(review: ReviewResult, evaluation: EvalResult): string[] {
+  return [
+    ...reviewRecommendations(review),
+    ...evaluation.recommendations,
+  ].filter((recommendation, index, recommendations) => recommendations.indexOf(recommendation) === index);
+}
+
+function reviewRecommendations(review: ReviewResult): string[] {
+  return [...review.newFindings, ...review.changedRiskyFindings]
+    .map((finding: Finding) => finding.recommendation)
+    .filter((recommendation, index, recommendations) => recommendations.indexOf(recommendation) === index);
+}
+
+function escapeMarkdownInline(value: string): string {
+  return value.replaceAll("`", "'");
+}
+
+function escapeMarkdownCell(value: string): string {
+  return escapeMarkdownInline(value).replaceAll("|", "\\|").replace(/\s+/g, " ").trim();
+}

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -15,6 +15,7 @@ import {
   formatMarkdownDoctorReport,
   formatMarkdownReviewReport,
   formatMarkdownTestPlan,
+  formatMarkdownVerifyReport,
   formatReviewReport,
   formatSarifReport,
   generateAgentContext,
@@ -22,6 +23,7 @@ import {
   loadConfig,
   reviewProject,
   scanProject,
+  verifyChange,
   writeDefaultConfig,
 } from "../dist/index.js";
 
@@ -476,6 +478,54 @@ test("evaluateChangeReadiness flags missing intent and risk context", async () =
   assert.equal(result.checks.find((check) => check.id === "validation-commands")?.status, "fail");
   assert.equal(result.checks.find((check) => check.id === "intent-capture")?.status, "fail");
   assert.equal(result.checks.find((check) => check.id === "risk-explanation")?.status, "fail");
+});
+
+test("verifyChange combines review findings, readiness, and domain tests", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src/features/campaign/api"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      packageManager: "pnpm@10.32.1",
+      scripts: {
+        test: "node --test",
+        typecheck: "tsc --noEmit",
+      },
+    }),
+  );
+  await writeFile(path.join(root, "AGENTS.md"), "# Agent Instructions\n\n- Run pnpm test before merge.\n");
+  await writeFile(path.join(root, "LICENSE"), "MIT");
+  await writeFile(path.join(root, "SECURITY.md"), "# Security\n");
+  await writeFile(path.join(root, "CONTRIBUTING.md"), "# Contributing\n");
+  await writeFile(path.join(root, "src/features/campaign/api/client.ts"), "export const endpoint = '/campaigns';\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/campaign-api"]);
+  await writeFile(path.join(root, "src/features/campaign/api/client.ts"), "export const endpoint = '/campaigns/v2';\n");
+  await writeFile(path.join(root, "src/features/campaign/api/client.test.ts"), "import './client.js';\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "update campaign api"]);
+
+  const result = await verifyChange(root, {
+    base: "main",
+    head: "HEAD",
+    prBody: [
+      "문제: campaign API path changed for the new flow.",
+      "이유: the old path cannot represent the v2 campaign state.",
+      "Risk: API compatibility is maintained by keeping callers typed.",
+      "Rollback: switch endpoint back to /campaigns.",
+    ].join("\n"),
+  });
+  const markdown = formatMarkdownVerifyReport(result);
+
+  assert.equal(result.evaluation.rating, "strong");
+  assert.equal(result.review.newFindings.length, 0);
+  assert.match(markdown, /# CodeWard Verify/);
+  assert.match(markdown, /Campaign workflow regression/);
+  assert.match(markdown, /Verification Gates/);
 });
 
 test("formatMarkdownReport includes a useful summary", async () => {


### PR DESCRIPTION
## Summary
- add `codeward verify` as the PR-facing command that combines review findings, readiness gates, domain test scenarios, suggested commands, and next actions
- update README first-run demo around the no-token verification layer positioning
- document `verify` and add coverage for the combined report

## Tests
- `pnpm test`
- `pnpm scan`
- `git diff --check`
- generated `/tmp/codeward-verify.md` for this branch
- generated `/tmp/codeward-offer-verify.md` against `/Users/khs/Desktop/inpock-frontend/services/offer` with `--include-working-tree`

## Notes
This is meant to make CodeWard easier to understand in the first 15 seconds: one command answers what changed, what is risky, what to test, and what evidence is missing.