### PR TITLE
Feat: broaden validation command discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ CodeWard is intentionally small:
 - static by default: it does not execute scanned project code
 - no-token by default: it does not call an LLM API
 - verification-focused: it tells reviewers what evidence is missing, not how to style code
+- ecosystem-aware: it suggests validation commands for JavaScript/TypeScript, Python, Go, Rust, Gradle, and Maven projects
 - CI-friendly: text, JSON, Markdown, and SARIF output are supported
 - explainable: every finding includes a concrete fix
 
@@ -134,7 +135,7 @@ For monorepos, pass `--workspace-root` when scanning a package. Package-local ch
 
 `codeward verify` is the easiest PR-facing command. It combines `review`, `test-plan`, and `eval` into one report with review findings, readiness gates, suggested domain tests, suggested commands, and next actions.
 
-`codeward test-plan` turns changed file paths into a review-ready domain test checklist. Add `--include-working-tree` for local, uncommitted changes while iterating.
+`codeward test-plan` turns changed file paths into a review-ready domain test checklist. It also discovers common validation commands from `package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, Gradle files, and Maven `pom.xml`. Add `--include-working-tree` for local, uncommitted changes while iterating.
 
 `codeward eval` scores whether a branch has enough validation evidence, changed-test coverage, intent capture, risk explanation, domain verification paths, and reviewable size. In GitHub Actions, CodeWard can read the pull request body from the event payload and append the evaluation to the PR comment.
 

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -23,7 +23,7 @@ Each gate is scored from `0` to `2`.
 
 | Gate | What it checks |
 | --- | --- |
-| Validation commands | The package exposes a real test command and supporting commands such as typecheck, lint, build, or e2e. |
+| Validation commands | The project exposes a real test command and supporting commands such as typecheck, lint, build, e2e, tox, Ruff, mypy, `go vet`, clippy, or Maven verify. |
 | Changed test coverage | Source changes are paired with changed test files, or at least a runnable test command exists. |
 | Intent capture | The PR body, decision docs, or PR template capture the problem, rationale, context, alternatives, or tradeoffs. |
 | Risk explanation | Risky surfaces such as config, workflows, API contracts, auth, billing, migrations, and env files include risk or rollback context. |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,6 +9,7 @@ CodeWard starts as a local CLI for repo-level AI agent readiness. The project ca
 - Improve README, adoption docs, and sample output so new maintainers can try CodeWard quickly.
 - Make `verify` the best first-run experience for AI-assisted PRs.
 - Keep `eval` explainable enough that maintainers trust the score and know what to fix.
+- Keep expanding the fixture matrix beyond JavaScript so validation advice works for Python, Go, Rust, and JVM repositories.
 
 ## Next
 
@@ -16,6 +17,7 @@ CodeWard starts as a local CLI for repo-level AI agent readiness. The project ca
 - Improve `doctor` output with clearer scoring and remediation grouping.
 - Improve `review` output for changed-line locations.
 - Expand `eval` with repository-specific verification manifests and configurable taste rubrics.
+- Add language-specific domain patterns for backend services, CLIs, libraries, mobile apps, and infrastructure repositories.
 - Continue expanding agent surface detection across Codex, Claude Code, Cursor, GitHub Copilot, Gemini, and related tools.
 - Generate rule documentation from scanner metadata.
 

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -8,6 +8,14 @@ It combines:
 - `eval`: verification-readiness gates for intent, risk, tests, and review size
 - `test-plan`: domain-oriented scenarios inferred from changed files
 
+Suggested commands are discovered statically from common project files:
+
+- JavaScript/TypeScript: usable `package.json` scripts for test, typecheck, lint, build, and e2e
+- Python: pytest, tox, Ruff, and mypy signals from `pyproject.toml`, pytest config, `tox.ini`, `uv.lock`, or Poetry files
+- Go: `go test`, `go vet`, and `golangci-lint` when `go.mod` or golangci config exists
+- Rust: `cargo test`, `cargo clippy`, and `cargo build` when `Cargo.toml` exists
+- JVM: Gradle wrapper, Gradle build files, or Maven `pom.xml`
+
 ## Usage
 
 ```sh

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -194,10 +194,8 @@ async function readPrBodyFile(prBodyFile: string | undefined): Promise<string | 
 }
 
 function scoreValidationCommands(commands: string[]): EvalCheck {
-  const hasTest = commands.some((command) =>
-    /\b(test|vitest|jest|playwright|node --test|pytest|go test)\b/i.test(command),
-  );
-  const hasSupport = commands.some((command) => /\b(typecheck|lint|build|check|e2e)\b/i.test(command));
+  const hasTest = commands.some(isTestCommand);
+  const hasSupport = commands.some(isSupportingValidationCommand);
   if (hasTest && hasSupport) {
     return check(
       "validation-commands",
@@ -228,6 +226,16 @@ function scoreValidationCommands(commands: string[]): EvalCheck {
     [],
     "Add a real package test script or document the validation command agents should run.",
   );
+}
+
+function isTestCommand(command: string): boolean {
+  return /\b(?:test|vitest|jest|playwright|node --test|pytest|tox|go test|cargo test|gradle test|mvn test)\b/i.test(
+    command,
+  );
+}
+
+function isSupportingValidationCommand(command: string): boolean {
+  return /\b(?:typecheck|lint|build|check|e2e|go vet|ruff|mypy|clippy|mvn verify)\b/i.test(command);
 }
 
 function scoreChangedTestCoverage(files: TestPlanChangedFile[], commands: string[]): EvalCheck {
@@ -554,7 +562,14 @@ function isSourceFile(filePath: string): boolean {
 }
 
 function isTestFile(filePath: string): boolean {
-  return /(?:^|\/)(__tests__|tests?|specs?|e2e)\/|(\.|-)(test|spec)\.[cm]?[jt]sx?$/i.test(filePath);
+  return (
+    /(?:^|\/)(__tests__|tests?|specs?|e2e)\//i.test(filePath) ||
+    /(\.|-)(test|spec)\.[cm]?[jt]sx?$/i.test(filePath) ||
+    /(?:^|\/)test_[^/]+\.py$/i.test(filePath) ||
+    /(?:^|\/)[^/]+_test\.(?:py|go)$/i.test(filePath) ||
+    /(?:^|\/)[^/]+(?:Test|Tests|Spec)\.(?:java|kt|cs|swift)$/i.test(filePath) ||
+    /(?:^|\/)[^/]+_(?:test|spec)\.rs$/i.test(filePath)
+  );
 }
 
 function isIntentDocumentationFile(filePath: string): boolean {
@@ -567,7 +582,7 @@ function isRiskyChangeFile(filePath: string): boolean {
   const riskyDirectory =
     /(?:^|\/)(\.github\/workflows|migrations?|schema|prisma|db|database|auth|billing|payment|permissions?|security|config|configs)\//i;
   const riskyFile =
-    /(?:action\.ya?ml|package\.json|pnpm-lock\.yaml|yarn\.lock|package-lock\.json|\.env|config|workflow|openapi|swagger|graphql|proto)/i;
+    /(?:action\.ya?ml|package\.json|pnpm-lock\.yaml|yarn\.lock|package-lock\.json|pyproject\.toml|requirements\.txt|go\.mod|go\.sum|Cargo\.toml|Cargo\.lock|pom\.xml|build\.gradle|gradle\.properties|\.env|config|workflow|openapi|swagger|graphql|proto)/i;
   return riskyDirectory.test(filePath) || riskyFile.test(filePath);
 }
 

--- a/src/test-plan.ts
+++ b/src/test-plan.ts
@@ -278,7 +278,7 @@ function buildStateItem(files: string[]): TestPlanItem | undefined {
 
 function buildConfigItem(files: string[]): TestPlanItem | undefined {
   const matched = files.filter((file) =>
-    /(?:package\.json|pnpm-lock\.yaml|yarn\.lock|package-lock\.json|vite|webpack|babel|tsconfig|next\.config|app\.config|eas\.json|docker|env)/i.test(
+    /(?:package\.json|pnpm-lock\.yaml|yarn\.lock|package-lock\.json|pyproject\.toml|requirements\.txt|go\.mod|go\.sum|Cargo\.toml|Cargo\.lock|pom\.xml|build\.gradle|gradle\.properties|vite|webpack|babel|tsconfig|next\.config|app\.config|eas\.json|docker|env)/i.test(
       file,
     ),
   );
@@ -298,7 +298,7 @@ function buildConfigItem(files: string[]): TestPlanItem | undefined {
 }
 
 function buildTestCoverageItem(files: string[]): TestPlanItem | undefined {
-  const matched = files.filter((file) => /(?:^|\/)(__tests__|tests?|specs?)\/|(\.|-)(test|spec)\.[cm]?[jt]sx?$/i.test(file));
+  const matched = files.filter((file) => isTestLikeFile(file));
   if (matched.length === 0) {
     return undefined;
   }
@@ -315,6 +315,17 @@ function buildTestCoverageItem(files: string[]): TestPlanItem | undefined {
 }
 
 async function discoverSuggestedCommands(root: string, workspaceRoot: string | undefined): Promise<string[]> {
+  const commandGroups = await Promise.all([
+    discoverJavaScriptCommands(root, workspaceRoot),
+    discoverPythonCommands(root),
+    discoverGoCommands(root),
+    discoverRustCommands(root),
+    discoverJvmCommands(root),
+  ]);
+  return uniqueCommands(commandGroups.flat());
+}
+
+async function discoverJavaScriptCommands(root: string, workspaceRoot: string | undefined): Promise<string[]> {
   const packageJsonPath = path.join(root, "package.json");
   let parsed: { packageManager?: string; scripts?: Record<string, string> };
   try {
@@ -331,6 +342,91 @@ async function discoverSuggestedCommands(root: string, workspaceRoot: string | u
   return preferredScripts
     .filter((script) => isUsableScript(parsed.scripts?.[script]))
     .map((script) => (script === "test" ? `${packageManager} test` : `${packageManager} run ${script}`));
+}
+
+async function discoverPythonCommands(root: string): Promise<string[]> {
+  const pyproject = await readTextIfExists(path.join(root, "pyproject.toml"));
+  const hasPythonMarker =
+    Boolean(pyproject) ||
+    (await hasAnyFile(root, [
+      "requirements.txt",
+      "setup.py",
+      "setup.cfg",
+      "tox.ini",
+      "pytest.ini",
+      "uv.lock",
+      "poetry.lock",
+      "Pipfile",
+    ]));
+  if (!hasPythonMarker) {
+    return [];
+  }
+
+  const runner = await detectPythonRunner(root, pyproject);
+  const commands: string[] = [];
+  const hasToxSignal = await exists(path.join(root, "tox.ini"));
+  const hasPytestSignal =
+    /\bpytest\b|\[tool\.pytest/i.test(pyproject ?? "") ||
+    (await exists(path.join(root, "pytest.ini"))) ||
+    (await hasDirectory(path.join(root, "tests")));
+  const hasRuffSignal = /\[tool\.ruff/i.test(pyproject ?? "") || (await hasAnyFile(root, ["ruff.toml", ".ruff.toml"]));
+  const hasMypySignal = /\[tool\.mypy/i.test(pyproject ?? "") || (await hasAnyFile(root, ["mypy.ini", ".mypy.ini"]));
+
+  if (hasToxSignal) {
+    commands.push(withRunner(runner, "tox"));
+  }
+  if (hasPytestSignal) {
+    commands.push(withRunner(runner, "pytest"));
+  }
+  if (hasRuffSignal) {
+    commands.push(withRunner(runner, "ruff check ."));
+  }
+  if (hasMypySignal) {
+    commands.push(withRunner(runner, "mypy ."));
+  }
+
+  return commands;
+}
+
+async function detectPythonRunner(root: string, pyproject: string | undefined): Promise<string | undefined> {
+  if (await exists(path.join(root, "uv.lock"))) {
+    return "uv run";
+  }
+  if (/\[tool\.poetry/i.test(pyproject ?? "") || (await exists(path.join(root, "poetry.lock")))) {
+    return "poetry run";
+  }
+  return undefined;
+}
+
+async function discoverGoCommands(root: string): Promise<string[]> {
+  if (!(await exists(path.join(root, "go.mod")))) {
+    return [];
+  }
+  const commands = ["go test ./...", "go vet ./..."];
+  if (await hasAnyFile(root, [".golangci.yml", ".golangci.yaml", "golangci.yml", "golangci.yaml"])) {
+    commands.push("golangci-lint run");
+  }
+  return commands;
+}
+
+async function discoverRustCommands(root: string): Promise<string[]> {
+  if (!(await exists(path.join(root, "Cargo.toml")))) {
+    return [];
+  }
+  return ["cargo test", "cargo clippy --all-targets --all-features", "cargo build"];
+}
+
+async function discoverJvmCommands(root: string): Promise<string[]> {
+  if (await exists(path.join(root, "gradlew"))) {
+    return ["./gradlew test", "./gradlew build"];
+  }
+  if (await hasAnyFile(root, ["build.gradle", "build.gradle.kts", "settings.gradle", "settings.gradle.kts"])) {
+    return ["gradle test", "gradle build"];
+  }
+  if (await exists(path.join(root, "pom.xml"))) {
+    return ["mvn test", "mvn verify"];
+  }
+  return [];
 }
 
 async function detectPackageManager(
@@ -382,6 +478,51 @@ async function existsInRoots(fileName: string, root: string, workspaceRoot: stri
 
 function isUsableScript(script: string | undefined): boolean {
   return Boolean(script && !/no test specified|exit\s+1/i.test(script));
+}
+
+async function hasAnyFile(root: string, fileNames: string[]): Promise<boolean> {
+  for (const fileName of fileNames) {
+    if (await exists(path.join(root, fileName))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function hasDirectory(directoryPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(directoryPath);
+    return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function readTextIfExists(filePath: string): Promise<string | undefined> {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function withRunner(runner: string | undefined, command: string): string {
+  return runner ? `${runner} ${command}` : command;
+}
+
+function uniqueCommands(commands: string[]): string[] {
+  return commands.filter((command, index) => commands.indexOf(command) === index);
+}
+
+function isTestLikeFile(filePath: string): boolean {
+  return (
+    /(?:^|\/)(__tests__|tests?|specs?|e2e)\//i.test(filePath) ||
+    /(\.|-)(test|spec)\.[cm]?[jt]sx?$/i.test(filePath) ||
+    /(?:^|\/)test_[^/]+\.py$/i.test(filePath) ||
+    /(?:^|\/)[^/]+_test\.(?:py|go)$/i.test(filePath) ||
+    /(?:^|\/)[^/]+(?:Test|Tests|Spec)\.(?:java|kt|cs|swift)$/i.test(filePath) ||
+    /(?:^|\/)[^/]+_(?:test|spec)\.rs$/i.test(filePath)
+  );
 }
 
 async function exists(filePath: string): Promise<boolean> {

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -413,6 +413,148 @@ test("generateTestPlan scopes monorepo changes to the requested package", async 
   assert.match(localMarkdown, /Includes working tree changes: yes/);
 });
 
+test("generateTestPlan suggests validation commands for common non-JavaScript projects", async () => {
+  const fixtures = [
+    {
+      name: "python",
+      expectedCommands: ["uv run tox", "uv run pytest", "uv run ruff check .", "uv run mypy ."],
+      setup: async (root) => {
+        await mkdir(path.join(root, "app"), { recursive: true });
+        await mkdir(path.join(root, "tests"), { recursive: true });
+        await writeFile(
+          path.join(root, "pyproject.toml"),
+          [
+            "[project]",
+            'name = "codeward-python-fixture"',
+            "",
+            "[tool.pytest.ini_options]",
+            'testpaths = ["tests"]',
+            "",
+            "[tool.ruff]",
+            'target-version = "py311"',
+            "",
+            "[tool.mypy]",
+            "strict = true",
+          ].join("\n"),
+        );
+        await writeFile(path.join(root, "uv.lock"), "");
+        await writeFile(path.join(root, "tox.ini"), "[tox]\nenv_list = py311\n");
+        await writeFile(path.join(root, "app/service.py"), "def price() -> int:\n    return 1\n");
+      },
+      edit: async (root) => {
+        await writeFile(path.join(root, "app/service.py"), "def price() -> int:\n    return 2\n");
+      },
+    },
+    {
+      name: "go",
+      expectedCommands: ["go test ./...", "go vet ./...", "golangci-lint run"],
+      setup: async (root) => {
+        await mkdir(path.join(root, "internal/offer"), { recursive: true });
+        await writeFile(path.join(root, "go.mod"), "module example.com/codeward-fixture\n\ngo 1.22\n");
+        await writeFile(path.join(root, ".golangci.yml"), "run:\n  timeout: 2m\n");
+        await writeFile(path.join(root, "internal/offer/service.go"), "package offer\n\nfunc Price() int { return 1 }\n");
+      },
+      edit: async (root) => {
+        await writeFile(path.join(root, "internal/offer/service.go"), "package offer\n\nfunc Price() int { return 2 }\n");
+      },
+    },
+    {
+      name: "rust",
+      expectedCommands: ["cargo test", "cargo clippy --all-targets --all-features", "cargo build"],
+      setup: async (root) => {
+        await mkdir(path.join(root, "src"), { recursive: true });
+        await writeFile(
+          path.join(root, "Cargo.toml"),
+          ['[package]', 'name = "codeward-rust-fixture"', 'version = "0.1.0"', 'edition = "2021"'].join("\n"),
+        );
+        await writeFile(path.join(root, "src/lib.rs"), "pub fn price() -> u32 { 1 }\n");
+      },
+      edit: async (root) => {
+        await writeFile(path.join(root, "src/lib.rs"), "pub fn price() -> u32 { 2 }\n");
+      },
+    },
+    {
+      name: "maven",
+      expectedCommands: ["mvn test", "mvn verify"],
+      setup: async (root) => {
+        await mkdir(path.join(root, "src/main/java/com/example"), { recursive: true });
+        await writeFile(
+          path.join(root, "pom.xml"),
+          [
+            '<project xmlns="http://maven.apache.org/POM/4.0.0">',
+            "  <modelVersion>4.0.0</modelVersion>",
+            "  <groupId>com.example</groupId>",
+            "  <artifactId>codeward-java-fixture</artifactId>",
+            "  <version>1.0.0</version>",
+            "</project>",
+          ].join("\n"),
+        );
+        await writeFile(path.join(root, "src/main/java/com/example/App.java"), "package com.example;\nclass App {}\n");
+      },
+      edit: async (root) => {
+        await writeFile(
+          path.join(root, "src/main/java/com/example/App.java"),
+          "package com.example;\nclass App { int price() { return 2; } }\n",
+        );
+      },
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    const root = await makeTempRepo();
+    await initGitRepo(root);
+    await fixture.setup(root);
+    await git(root, ["add", "."]);
+    await git(root, ["commit", "-m", "base"]);
+    await git(root, ["branch", "-M", "main"]);
+
+    await git(root, ["switch", "-c", `feature/${fixture.name}-change`]);
+    await fixture.edit(root);
+    await git(root, ["add", "."]);
+    await git(root, ["commit", "-m", `update ${fixture.name}`]);
+
+    const plan = await generateTestPlan(root, { base: "main", head: "HEAD" });
+
+    assert.deepEqual(plan.suggestedCommands, fixture.expectedCommands, fixture.name);
+  }
+});
+
+test("evaluateChangeReadiness recognizes non-JavaScript test files", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "internal/offer"), { recursive: true });
+  await writeFile(path.join(root, "go.mod"), "module example.com/codeward-fixture\n\ngo 1.22\n");
+  await writeFile(path.join(root, ".golangci.yml"), "run:\n  timeout: 2m\n");
+  await writeFile(path.join(root, "internal/offer/service.go"), "package offer\n\nfunc Price() int { return 1 }\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/go-coverage"]);
+  await writeFile(path.join(root, "internal/offer/service.go"), "package offer\n\nfunc Price() int { return 2 }\n");
+  await writeFile(
+    path.join(root, "internal/offer/service_test.go"),
+    "package offer\n\nimport \"testing\"\n\nfunc TestPrice(t *testing.T) { if Price() != 2 { t.Fatal(\"price\") } }\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "update go coverage"]);
+
+  const result = await evaluateChangeReadiness(root, {
+    base: "main",
+    head: "HEAD",
+    prBody: [
+      "문제: offer price calculation changed for the new flow.",
+      "이유: downstream callers need the updated price.",
+      "Risk: behavior change is covered by a focused Go test.",
+      "Rollback: revert the price calculation branch.",
+    ].join("\n"),
+  });
+
+  assert.equal(result.checks.find((check) => check.id === "validation-commands")?.status, "pass");
+  assert.equal(result.checks.find((check) => check.id === "changed-test-coverage")?.status, "pass");
+  assert.equal(result.rating, "strong");
+});
+
 test("evaluateChangeReadiness scores intent, risk, and verification evidence", async () => {
   const root = await makeTempRepo();
   await initGitRepo(root);


### PR DESCRIPTION
## Summary

- Discover static validation commands for Python, Go, Rust, Gradle, and Maven projects in test-plan and verify flows.
- Teach readiness scoring to recognize non-JavaScript validation and test-file conventions.
- Add cross-language fixture coverage so the behavior is not tied to a single application repository.

## Validation

- pnpm test
- pnpm scan
- git diff --check