### PR TITLE
Feat: support configured validation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Use `codeward.config.json` or `.codeward.json` to tune repository policy.
   "failOn": "high",
   "ignoreRules": ["CW011"],
   "maxFiles": 2000,
+  "validationCommands": ["make test", "make lint"],
   "severity": {
     "CW007": "info"
   }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,7 @@ codeward scan . --config ./codeward.config.json
   "failOn": "high",
   "ignoreRules": ["CW011"],
   "maxFiles": 2000,
+  "validationCommands": ["make test", "make lint"],
   "severity": {
     "CW007": "info"
   }
@@ -36,9 +37,11 @@ codeward scan . --config ./codeward.config.json
 | `ignoreRules` | `string[]` | Suppresses rule ids for this repository. |
 | `maxFiles` | `number` | Maximum number of files CodeWard inspects. CLI `--max-files` takes precedence. |
 | `severity` | `Record<string, Severity>` | Overrides severity for specific rule ids. |
+| `validationCommands` | `string[]` | Adds project-specific validation commands to `test-plan`, `eval`, `verify`, and GitHub Action reports. |
 
 ## Notes
 
 - Prefer severity overrides over ignores when a finding is still useful but too noisy for CI.
 - Keep ignores small and documented in pull requests.
+- Use `validationCommands` for custom stacks, Makefile-based projects, or monorepos where the right validation command is not discoverable from standard project files.
 - CodeWard does not execute scanned project code while reading config.

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -30,6 +30,8 @@ Each gate is scored from `0` to `2`.
 | Domain test plan | Changed files can be mapped to focused domain verification scenarios. |
 | Review size | The branch is small enough to review without unnecessary verification tax. |
 
+`validationCommands` in `codeward.config.json` can supply commands for custom stacks or monorepos when standard project files are not enough.
+
 ## Ratings
 
 | Rating | Meaning |

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -16,6 +16,8 @@ Suggested commands are discovered statically from common project files:
 - Rust: `cargo test`, `cargo clippy`, and `cargo build` when `Cargo.toml` exists
 - JVM: Gradle wrapper, Gradle build files, or Maven `pom.xml`
 
+For custom stacks or team-specific flows, add `validationCommands` to `codeward.config.json`. Configured commands are shown before automatically discovered commands.
+
 ## Usage
 
 ```sh

--- a/schema/codeward.schema.json
+++ b/schema/codeward.schema.json
@@ -34,6 +34,15 @@
       "propertyNames": {
         "$ref": "#/$defs/ruleId"
       }
+    },
+    "validationCommands": {
+      "type": "array",
+      "description": "Project-specific validation commands to show in test-plan, eval, verify, and GitHub Action reports.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
     }
   },
   "$defs": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -112,6 +112,7 @@ async function main(argv: string[]): Promise<number> {
       scanOptions: buildScanOptions(options, loadedConfig),
       includeWorkingTree: options.includeWorkingTree,
       prBodyFile: options.prBodyFile,
+      validationCommands: loadedConfig.config.validationCommands,
     });
     const output = formatVerifyOutput(result, options.format ?? (options.json ? "json" : "markdown"));
     await printOrWrite(output, options.output);
@@ -139,18 +140,21 @@ async function main(argv: string[]): Promise<number> {
       evalFile: options.evalFile,
       prBodyFile: options.prBodyFile,
       includeWorkingTree: options.includeWorkingTree,
+      validationCommands: loadedConfig.config.validationCommands,
     });
     return result.exitCode;
   }
 
   if (command === "eval") {
     const options = parseOptions(rest);
+    const loadedConfig = await loadOptionsConfig(options);
     const result = await evaluateChangeReadiness(options.path, {
       base: options.base,
       head: options.head,
       workspaceRoot: options.workspaceRoot,
       includeWorkingTree: options.includeWorkingTree,
       prBodyFile: options.prBodyFile,
+      validationCommands: loadedConfig.config.validationCommands,
     });
     const output = formatEvalOutput(result, options.format ?? (options.json ? "json" : "markdown"));
     await printOrWrite(output, options.output);
@@ -159,11 +163,13 @@ async function main(argv: string[]): Promise<number> {
 
   if (command === "test-plan") {
     const options = parseOptions(rest);
+    const loadedConfig = await loadOptionsConfig(options);
     const result = await generateTestPlan(options.path, {
       base: options.base,
       head: options.head,
       workspaceRoot: options.workspaceRoot,
       includeWorkingTree: options.includeWorkingTree,
+      validationCommands: loadedConfig.config.validationCommands,
     });
     const output = formatTestPlanOutput(result, options.format ?? (options.json ? "json" : "markdown"));
     await printOrWrite(output, options.output);

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ export const defaultConfig: CodeWardConfig = {
   ignoreRules: [],
   maxFiles: 2000,
   severity: {},
+  validationCommands: [],
 };
 
 export async function loadConfig(rootInput: string, explicitPath?: string): Promise<ResolvedCodeWardConfig> {
@@ -107,6 +108,16 @@ function normalizeConfig(value: unknown, configPath: string): CodeWardConfig {
       throw new Error("CodeWard config severity must be an object of rule id to severity");
     }
     config.severity = normalizeSeverityOverrides(record.severity as Record<string, unknown>);
+  }
+
+  if (record.validationCommands !== undefined) {
+    if (
+      !Array.isArray(record.validationCommands) ||
+      !record.validationCommands.every((item) => typeof item === "string" && item.trim().length > 0)
+    ) {
+      throw new Error("CodeWard config validationCommands must be an array of non-empty strings");
+    }
+    config.validationCommands = [...new Set(record.validationCommands.map((item) => item.trim()))];
   }
 
   return config;

--- a/src/github.ts
+++ b/src/github.ts
@@ -28,6 +28,7 @@ export interface GitHubActionOptions {
   prBody?: string;
   prBodyFile?: string;
   includeWorkingTree?: boolean;
+  validationCommands?: string[];
 }
 
 export interface GitHubActionResult {
@@ -62,6 +63,7 @@ export async function runGitHubAction(rootInput: string, options: GitHubActionOp
           head: options.head,
           workspaceRoot: options.scanOptions?.workspaceRoot,
           includeWorkingTree: options.includeWorkingTree,
+          validationCommands: options.validationCommands,
         }),
       )
     : undefined;
@@ -74,6 +76,7 @@ export async function runGitHubAction(rootInput: string, options: GitHubActionOp
           includeWorkingTree: options.includeWorkingTree,
           prBody: options.prBody ?? (await readPullRequestBody()),
           prBodyFile: options.prBodyFile,
+          validationCommands: options.validationCommands,
         }),
       )
     : undefined;

--- a/src/test-plan.ts
+++ b/src/test-plan.ts
@@ -11,6 +11,7 @@ export interface TestPlanOptions {
   head?: string;
   workspaceRoot?: string;
   includeWorkingTree?: boolean;
+  validationCommands?: string[];
 }
 
 export interface TestPlanChangedFile {
@@ -57,7 +58,10 @@ export async function generateTestPlan(rootInput: string, options: TestPlanOptio
   const head = options.head ?? "HEAD";
   const includeWorkingTree = options.includeWorkingTree ?? false;
   const changedFiles = scopeChangedFiles(await getChangedFiles(gitRoot, base, head, includeWorkingTree), relativeRoot);
-  const suggestedCommands = await discoverSuggestedCommands(root, workspaceRoot);
+  const suggestedCommands = uniqueCommands([
+    ...normalizeValidationCommands(options.validationCommands),
+    ...(await discoverSuggestedCommands(root, workspaceRoot)),
+  ]);
   const items = buildPlanItems(changedFiles);
 
   return {
@@ -512,6 +516,10 @@ function withRunner(runner: string | undefined, command: string): string {
 
 function uniqueCommands(commands: string[]): string[] {
   return commands.filter((command, index) => commands.indexOf(command) === index);
+}
+
+function normalizeValidationCommands(commands: string[] | undefined): string[] {
+  return (commands ?? []).map((command) => command.trim()).filter(Boolean);
 }
 
 function isTestLikeFile(filePath: string): boolean {

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,7 @@ export interface CodeWardConfig {
   ignoreRules?: string[];
   maxFiles?: number;
   severity?: Record<string, Severity>;
+  validationCommands?: string[];
 }
 
 export interface ResolvedCodeWardConfig {

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -40,6 +40,7 @@ export async function verifyChange(rootInput: string, options: VerifyOptions = {
     includeWorkingTree: options.includeWorkingTree,
     prBody: options.prBody,
     prBodyFile: options.prBodyFile,
+    validationCommands: options.validationCommands,
   });
 
   return {

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -704,6 +704,7 @@ test("loadConfig reads repository policy", async () => {
       failOn: "medium",
       ignoreRules: ["cw011"],
       maxFiles: 10,
+      validationCommands: [" make test ", "make test", "make lint"],
       severity: {
         cw007: "info",
       },
@@ -716,6 +717,7 @@ test("loadConfig reads repository policy", async () => {
   assert.equal(loaded.config.failOn, "medium");
   assert.deepEqual(loaded.config.ignoreRules, ["CW011"]);
   assert.equal(loaded.config.maxFiles, 10);
+  assert.deepEqual(loaded.config.validationCommands, ["make test", "make lint"]);
   assert.deepEqual(loaded.config.severity, { CW007: "info" });
 });
 
@@ -727,6 +729,55 @@ test("writeDefaultConfig creates a starter config", async () => {
   assert.equal(outputPath, path.join(root, "codeward.config.json"));
   assert.equal(loaded.config.failOn, "high");
   assert.deepEqual(loaded.config.ignoreRules, []);
+  assert.deepEqual(loaded.config.validationCommands, []);
+});
+
+test("configured validation commands feed test-plan and eval outputs", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src"), { recursive: true });
+  await writeFile(
+    path.join(root, "codeward.config.json"),
+    JSON.stringify({
+      validationCommands: ["make test", "make lint"],
+    }),
+  );
+  await writeFile(path.join(root, "src/service.py"), "def price() -> int:\n    return 1\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/custom-validation"]);
+  await writeFile(path.join(root, "src/service.py"), "def price() -> int:\n    return 2\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "update custom validation"]);
+
+  const testPlanOutput = await execFileAsync(process.execPath, [
+    cliPath,
+    "test-plan",
+    root,
+    "--base",
+    "main",
+    "--head",
+    "HEAD",
+    "--json",
+  ]);
+  const testPlan = JSON.parse(testPlanOutput.stdout);
+  const evaluation = await evaluateChangeReadiness(root, {
+    base: "main",
+    head: "HEAD",
+    validationCommands: ["make test", "make lint"],
+    prBody: [
+      "문제: custom stack validation is declared in CodeWard config.",
+      "이유: this repository does not expose standard language project files.",
+      "Risk: validation remains explicit and reviewable.",
+      "Rollback: remove the custom validation command config.",
+    ].join("\n"),
+  });
+
+  assert.deepEqual(testPlan.suggestedCommands, ["make test", "make lint"]);
+  assert.equal(evaluation.checks.find((check) => check.id === "validation-commands")?.status, "pass");
+  assert.deepEqual(evaluation.suggestedCommands, ["make test", "make lint"]);
 });
 
 test("formatSarifReport emits SARIF 2.1.0", async () => {


### PR DESCRIPTION
## Summary

- Add validationCommands to CodeWard config and JSON schema.
- Feed configured commands into test-plan, eval, verify, and GitHub Action report paths before auto-discovered commands.
- Document the option for custom stacks, Makefile-based projects, and monorepos.

## Validation

- pnpm test
- pnpm scan
- git diff --check