### PR TITLE
Feat: evaluate test suite coverage evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ node dist/cli.js scan /path/to/repo
 | `codeward eval . --base origin/main --head HEAD --pr-body-file pr-body.md` | Score change readiness across intent, risk, tests, and review size. |
 | `codeward github-action . --mode review --base origin/main --head HEAD` | Generate GitHub Action annotations, step summary, and PR comment body. |
 | `codeward test-plan . --base origin/main --head HEAD --include-working-tree` | Suggest domain test scenarios for changed files. |
-| `codeward e2e plan . --base origin/main --head HEAD` | Suggest E2E runner, user flows, and missing testability hooks for changed files. |
+| `codeward e2e plan . --base origin/main --head HEAD` | Suggest E2E runner, user flows, coverage targets, existing test evidence, and missing testability hooks for changed files. |
 | `codeward e2e draft . --base origin/main --head HEAD` | Generate first-pass Maestro or Playwright E2E draft files from changed flows. |
 | `codeward doctor services/offer --workspace-root .` | Scan a monorepo package while using root guardrails. |
 | `codeward context . --write AGENTS.md` | Generate starter agent instructions for the repo. |
@@ -144,7 +144,7 @@ For monorepos, pass `--workspace-root` when scanning a package. Package-local ch
 
 `codeward test-plan` turns changed file paths into a review-ready domain test checklist. It also discovers common validation commands from `package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, Gradle files, and Maven `pom.xml`. Add `--include-working-tree` for local, uncommitted changes while iterating.
 
-`codeward e2e plan` turns changed file paths into a first-pass E2E testing plan. It detects whether a project looks like Expo/React Native or web, recommends a runner such as Maestro or Playwright, suggests candidate user flows, and points out missing stable selectors such as `testID` or `data-testid` before anyone starts writing tests from a blank file.
+`codeward e2e plan` turns changed file paths into a first-pass E2E testing plan. It detects whether a project looks like Expo/React Native or web, recommends a runner such as Maestro or Playwright, suggests candidate user flows, adds coverage targets, compares those targets with existing test-suite evidence when tests are present, and points out missing stable selectors such as `testID` or `data-testid` before anyone starts writing tests from a blank file.
 
 `codeward e2e draft` writes runnable draft files from that plan. Expo and React Native projects get Maestro YAML flows under `.maestro/` by default, while web projects get Playwright specs under `tests/e2e/`. Drafts infer stable selectors such as `testID`, `accessibilityLabel`, `data-testid`, `aria-label`, and visible text where possible. They keep `TODO` placeholders where selectors or project-specific launch details are still needed, and existing files are not overwritten unless `--force` is passed.
 

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -1,7 +1,13 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import {
+  collectTestSuiteInventory,
+  evaluateFlowCoverageEvidence,
+  summarizeTestSuiteInventory,
+} from "./test-evidence.js";
 import { generateTestPlan } from "./test-plan.js";
 import type { TestPlanChangedFile, TestPlanOptions } from "./test-plan.js";
+import type { CoverageEvidence, TestSuiteInventory, TestSuiteSummary } from "./test-evidence.js";
 import { TOOL_NAME, VERSION } from "./version.js";
 
 export type E2eProjectType = "expo-react-native" | "react-native" | "web" | "unknown";
@@ -48,6 +54,7 @@ export interface E2eFlow {
   files: string[];
   steps: string[];
   coverage: E2eCoverageTarget[];
+  coverageEvidence: CoverageEvidence[];
   selectors: E2eSelector[];
   missingTestability: string[];
 }
@@ -71,6 +78,7 @@ export interface E2ePlanResult {
   includeWorkingTree: boolean;
   project: E2eProjectProfile;
   recommendedRunner: E2eRunnerRecommendation;
+  testSuite: TestSuiteSummary;
   changedFiles: TestPlanChangedFile[];
   suggestedCommands: string[];
   flows: E2eFlow[];
@@ -116,7 +124,8 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
   const testPlan = await generateTestPlan(root, options);
   const project = await detectProjectProfile(root);
   const recommendedRunner = options.runner ? overrideRunner(project, options.runner) : recommendRunner(project);
-  const flows = await buildFlows(root, testPlan.changedFiles, recommendedRunner.name, project.type);
+  const testSuiteInventory = await collectTestSuiteInventory(root);
+  const flows = await buildFlows(root, testPlan.changedFiles, recommendedRunner.name, project.type, testSuiteInventory);
   const missingTestability = uniqueStrings([
     ...flows.flatMap((flow) => flow.missingTestability),
     ...(await buildGlobalTestabilityGaps(root, recommendedRunner.name)),
@@ -135,6 +144,7 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
     includeWorkingTree: testPlan.includeWorkingTree,
     project,
     recommendedRunner,
+    testSuite: summarizeTestSuiteInventory(testSuiteInventory),
     changedFiles: testPlan.changedFiles,
     suggestedCommands: testPlan.suggestedCommands,
     flows,
@@ -378,6 +388,12 @@ export function formatMarkdownE2ePlan(result: E2ePlanResult): string {
   }
   lines.push(`- Project: ${formatProjectType(result.project.type)}`);
   lines.push(`- Recommended runner: ${formatRunnerName(result.recommendedRunner.name)}`);
+  lines.push(
+    `- Test suite: ${result.testSuite.hasTestSuite ? `${result.testSuite.testFileCount} test file${result.testSuite.testFileCount === 1 ? "" : "s"}` : "not detected"}`,
+  );
+  if (result.testSuite.frameworkSignals.length > 0) {
+    lines.push(`- Test frameworks: ${result.testSuite.frameworkSignals.join(", ")}`);
+  }
   lines.push(`- Changed files considered: ${result.changedFiles.length}`);
   lines.push("");
 
@@ -421,6 +437,17 @@ export function formatMarkdownE2ePlan(result: E2ePlanResult): string {
         lines.push("Coverage targets:");
         for (const target of flow.coverage) {
           lines.push(`- ${formatCoveragePriority(target.priority)} ${escapeMarkdownInline(target.title)}: ${escapeMarkdownInline(target.reason)}`);
+        }
+      }
+      if (flow.coverageEvidence.length > 0) {
+        lines.push("");
+        lines.push("Existing test evidence:");
+        for (const evidence of flow.coverageEvidence) {
+          const files = evidence.files.length > 0 ? ` (${evidence.files.slice(0, 3).join(", ")})` : "";
+          const signals = evidence.signals.length > 0 ? ` signals: ${evidence.signals.join(", ")}` : "";
+          lines.push(
+            `- ${evidence.status} ${escapeMarkdownInline(evidence.targetTitle)} [${evidence.confidence} confidence]${files}${signals}`,
+          );
         }
       }
       if (flow.missingTestability.length > 0) {
@@ -595,17 +622,22 @@ function overrideRunner(project: E2eProjectProfile, runner: E2eRunnerName): E2eR
 }
 
 type E2eFlowKind = "ui" | "api" | "state" | "content" | "config" | "domain" | "changed-file";
-type FlowCandidate = Omit<E2eFlow, "coverage" | "selectors" | "missingTestability"> & { kind: E2eFlowKind };
+type FlowCandidate = Omit<E2eFlow, "coverage" | "coverageEvidence" | "selectors" | "missingTestability"> & {
+  kind: E2eFlowKind;
+};
 
 async function buildFlows(
   root: string,
   changedFiles: TestPlanChangedFile[],
   runner: E2eRunnerName,
   projectType: E2eProjectType,
+  testSuiteInventory: TestSuiteInventory,
 ): Promise<E2eFlow[]> {
   const files = changedFiles.map((file) => file.path);
   const flowResults = await Promise.all(
-    buildFlowCandidates(files, runner, projectType).map((candidate) => buildFlow(root, runner, candidate)),
+    buildFlowCandidates(files, runner, projectType).map((candidate) =>
+      buildFlow(root, runner, candidate, testSuiteInventory),
+    ),
   );
   const flows = flowResults.filter((flow): flow is E2eFlow => Boolean(flow));
 
@@ -750,17 +782,20 @@ async function buildFlow(
   root: string,
   runner: E2eRunnerName,
   candidate: FlowCandidate,
+  testSuiteInventory: TestSuiteInventory,
 ): Promise<E2eFlow | undefined> {
   const files = uniqueStrings(candidate.files).slice(0, 20);
   if (files.length === 0) {
     return undefined;
   }
+  const coverage = buildCoverageTargets(candidate.kind, files, runner);
   return {
     title: candidate.title,
     reason: candidate.reason,
     files,
     steps: candidate.steps,
-    coverage: buildCoverageTargets(candidate.kind, files, runner),
+    coverage,
+    coverageEvidence: evaluateFlowCoverageEvidence({ title: candidate.title, files, coverage }, testSuiteInventory),
     selectors: await inferFlowSelectors(root, files, runner),
     missingTestability: await findFlowTestabilityGaps(root, files, runner),
   };
@@ -1142,6 +1177,7 @@ function dedupeFlows(flows: E2eFlow[]): E2eFlow[] {
 }
 
 function buildFallbackFlow(plan: E2ePlanResult): E2eFlow {
+  const coverage = buildCoverageTargets("changed-file", [], plan.recommendedRunner.name);
   return {
     title: "App launch smoke flow",
     reason:
@@ -1153,7 +1189,14 @@ function buildFallbackFlow(plan: E2ePlanResult): E2eFlow {
       "Exercise the primary visible action if one is present.",
       "Verify the app remains usable after the action.",
     ],
-    coverage: buildCoverageTargets("changed-file", [], plan.recommendedRunner.name),
+    coverage,
+    coverageEvidence: evaluateFlowCoverageEvidence(
+      { title: "App launch smoke flow", files: [], coverage },
+      {
+        ...plan.testSuite,
+        files: [],
+      },
+    ),
     selectors: [],
     missingTestability: plan.missingTestability,
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,10 +7,22 @@ export { githubCommentMarker, runGitHubAction } from "./github.js";
 export { formatMarkdownReport, formatSarifReport, formatTextReport, hasFindingsAtOrAbove } from "./report.js";
 export { formatMarkdownReviewReport, formatReviewReport, reviewProject } from "./review.js";
 export { scanProject } from "./scanner.js";
+export { collectTestSuiteInventory, evaluateFlowCoverageEvidence, summarizeTestSuiteInventory } from "./test-evidence.js";
 export { formatMarkdownTestPlan, generateTestPlan } from "./test-plan.js";
 export { formatMarkdownVerifyReport, formatVerifyReport, verifyChange } from "./verify.js";
+export type {
+  CoverageEvidence,
+  CoverageEvidenceConfidence,
+  CoverageEvidenceStatus,
+  FlowCoverageInput,
+  TestSuiteEvidenceFile,
+  TestSuiteInventory,
+  TestSuiteSummary,
+} from "./test-evidence.js";
 export type { DoctorArea, DoctorPriority, DoctorResult } from "./doctor.js";
 export type {
+  E2eCoveragePriority,
+  E2eCoverageTarget,
   E2eFlow,
   E2eSelector,
   E2eSelectorKind,

--- a/src/test-evidence.ts
+++ b/src/test-evidence.ts
@@ -1,0 +1,382 @@
+import path from "node:path";
+import { collectProjectFiles } from "./fs.js";
+import type { ProjectFile } from "./types.js";
+
+export type CoverageEvidenceStatus = "covered" | "partial" | "missing";
+export type CoverageEvidenceConfidence = "high" | "medium" | "low";
+
+export interface CoverageTargetLike {
+  title: string;
+  checks: string[];
+}
+
+export interface FlowCoverageInput {
+  title: string;
+  files: string[];
+  coverage: CoverageTargetLike[];
+}
+
+export interface TestSuiteEvidenceFile {
+  path: string;
+  testNames: string[];
+  imports: string[];
+  signals: string[];
+}
+
+export interface TestSuiteInventory {
+  hasTestSuite: boolean;
+  testFileCount: number;
+  frameworkSignals: string[];
+  files: TestSuiteEvidenceFile[];
+}
+
+export interface TestSuiteSummary {
+  hasTestSuite: boolean;
+  testFileCount: number;
+  frameworkSignals: string[];
+}
+
+export interface CoverageEvidence {
+  targetTitle: string;
+  status: CoverageEvidenceStatus;
+  confidence: CoverageEvidenceConfidence;
+  files: string[];
+  signals: string[];
+  reason: string;
+}
+
+const maxInventoryFiles = 20000;
+const maxEvidenceFiles = 6;
+
+export async function collectTestSuiteInventory(root: string): Promise<TestSuiteInventory> {
+  const projectFiles = await collectProjectFiles(root, maxInventoryFiles);
+  const files = projectFiles.filter((file) => isTestLikeFile(file.path)).map(toTestEvidenceFile);
+  return {
+    hasTestSuite: files.length > 0,
+    testFileCount: files.length,
+    frameworkSignals: detectFrameworkSignals(projectFiles, files),
+    files,
+  };
+}
+
+export function summarizeTestSuiteInventory(inventory: TestSuiteInventory): TestSuiteSummary {
+  return {
+    hasTestSuite: inventory.hasTestSuite,
+    testFileCount: inventory.testFileCount,
+    frameworkSignals: inventory.frameworkSignals,
+  };
+}
+
+export function evaluateFlowCoverageEvidence(
+  flow: FlowCoverageInput,
+  inventory: TestSuiteInventory,
+): CoverageEvidence[] {
+  return flow.coverage.map((target) => evaluateCoverageTarget(flow, target, inventory));
+}
+
+function evaluateCoverageTarget(
+  flow: FlowCoverageInput,
+  target: CoverageTargetLike,
+  inventory: TestSuiteInventory,
+): CoverageEvidence {
+  if (!inventory.hasTestSuite) {
+    return {
+      targetTitle: target.title,
+      status: "missing",
+      confidence: "high",
+      files: [],
+      signals: [],
+      reason: "No existing test files were detected, so CodeWard cannot find coverage evidence for this target.",
+    };
+  }
+
+  const relatedFiles = findRelatedTestFiles(flow, inventory.files);
+  if (relatedFiles.length === 0) {
+    return {
+      targetTitle: target.title,
+      status: "missing",
+      confidence: "medium",
+      files: [],
+      signals: [],
+      reason: "No related test files were found for the changed flow.",
+    };
+  }
+
+  const groups = signalGroupsForTarget(target.title);
+  const matchedGroups = groups.filter((group) =>
+    relatedFiles.some((file) => group.patterns.some((pattern) => pattern.test(searchableEvidenceText(file)))),
+  );
+  const evidenceFiles = relatedFiles
+    .filter((file) => matchedGroups.some((group) => group.patterns.some((pattern) => pattern.test(searchableEvidenceText(file)))))
+    .slice(0, maxEvidenceFiles)
+    .map((file) => file.path);
+
+  if (matchedGroups.length === 0) {
+    return {
+      targetTitle: target.title,
+      status: target.title === "Primary success path" ? "partial" : "missing",
+      confidence: "low",
+      files: relatedFiles.slice(0, maxEvidenceFiles).map((file) => file.path),
+      signals: [],
+      reason:
+        target.title === "Primary success path"
+          ? "Related tests exist, but CodeWard did not find explicit success-path wording or assertions."
+          : "Related tests exist, but CodeWard did not find target-specific coverage signals.",
+    };
+  }
+
+  const rawStatus = coverageStatusForMatchedGroups(target.title, groups.length, matchedGroups.length);
+  const status = rawStatus === "covered" && isBroadFlow(flow) ? "partial" : rawStatus;
+  return {
+    targetTitle: target.title,
+    status,
+    confidence: status === "covered" ? "medium" : "low",
+    files: evidenceFiles,
+    signals: matchedGroups.map((group) => group.label),
+    reason:
+      rawStatus === "covered" && status === "partial"
+        ? "Related tests contain matching signals, but the flow is broad enough that CodeWard treats the evidence as partial."
+        : status === "covered"
+        ? "Related tests contain signals that match this coverage target."
+        : "Related tests contain some signals for this target, but the evidence looks incomplete.",
+  };
+}
+
+function toTestEvidenceFile(file: ProjectFile): TestSuiteEvidenceFile {
+  const text = file.text ?? "";
+  const testNames = extractTestNames(text);
+  const imports = extractImports(text);
+  return {
+    path: file.path,
+    testNames,
+    imports,
+    signals: extractSignals(`${file.path}\n${testNames.join("\n")}\n${text}`),
+  };
+}
+
+function findRelatedTestFiles(flow: FlowCoverageInput, files: TestSuiteEvidenceFile[]): TestSuiteEvidenceFile[] {
+  const flowTokens = meaningfulTokens([flow.title, ...flow.files].join("\n"));
+  if (flowTokens.length === 0) {
+    return [];
+  }
+  return files.filter((file) => {
+    const testTokens = meaningfulTokens([file.path, ...file.imports, ...file.testNames].join("\n"));
+    const overlap = flowTokens.filter((token) => testTokens.includes(token));
+    return overlap.length > 0 || importsFlowFile(file.imports, flow.files);
+  });
+}
+
+function importsFlowFile(imports: string[], flowFiles: string[]): boolean {
+  return imports.some((importPath) => {
+    const importStem = normalizePathForMatch(importPath);
+    if (!importStem) {
+      return false;
+    }
+    return flowFiles.some((file) => normalizePathForMatch(file).endsWith(importStem));
+  });
+}
+
+function normalizePathForMatch(value: string): string {
+  return value
+    .replace(/\.(?:[cm]?[jt]sx?|vue|svelte|py|go|rs|java|kt|swift)$/i, "")
+    .replace(/^\.\//, "")
+    .replace(/\.\.\//g, "")
+    .toLowerCase();
+}
+
+function extractTestNames(text: string): string[] {
+  const names: string[] = [];
+  const matcher = /\b(?:describe|it|test)\s*(?:\.\w+)?\s*\(\s*(["'`])([^"'`]+)\1/g;
+  for (const match of text.matchAll(matcher)) {
+    names.push(normalizeText(match[2]));
+  }
+  return uniqueStrings(names).slice(0, 40);
+}
+
+function extractImports(text: string): string[] {
+  const imports: string[] = [];
+  const importMatcher = /\bfrom\s+["']([^"']+)["']|require\(\s*["']([^"']+)["']\s*\)/g;
+  for (const match of text.matchAll(importMatcher)) {
+    imports.push(match[1] ?? match[2]);
+  }
+  return uniqueStrings(imports).slice(0, 80);
+}
+
+function extractSignals(text: string): string[] {
+  const lowered = text.toLowerCase();
+  const signals = [
+    ["success", /\b(success|happy path|renders?|visible|complete[sd]?|submit(?:s|ted)?|save[sd]?|created|loads?)\b/],
+    ["loading", /\b(loading|pending|spinner|skeleton|progress)\b/],
+    ["empty", /\b(empty|no results?|zero results?|not found|blank state)\b/],
+    ["error", /\b(error|failure|failed|reject(?:ed)?|throws?|exception)\b/],
+    ["unauthorized", /\b(unauthorized|unauthenticated|forbidden|permission denied|401|403|expired session)\b/],
+    ["network failure", /\b(timeout|network error|offline|server error|500|502|503|504|retry)\b/],
+    ["api contract", /\b(contract|schema|response|request|status code|payload|headers?)\b/],
+    ["state transition", /\b(state|transition|cache|stale|optimistic|refresh|re-entry|restart|resume|back navigation)\b/],
+    ["config variant", /\b(config|fallback|feature flag|flag on|flag off|enabled|disabled|environment|env)\b/],
+    ["viewport", /\b(viewport|mobile|desktop|responsive|small screen|dark mode|focus|disabled)\b/],
+    ["locale", /\b(locale|i18n|translation|translated|theme)\b/],
+    ["boundary input", /\b(invalid|validation|duplicate|boundary|missing|required|too long|empty input)\b/],
+    ["browser viewport", /\b(browser|playwright|viewport|mobile|desktop|chromium|webkit|firefox)\b/],
+    ["startup", /\b(startup|boot|runtime|install|build|clean checkout)\b/],
+  ] as const;
+  return signals.filter(([, pattern]) => pattern.test(lowered)).map(([label]) => label);
+}
+
+function signalGroupsForTarget(title: string): Array<{ label: string; patterns: RegExp[] }> {
+  if (title === "Primary success path") {
+    return [{ label: "success", patterns: [/\b(success|happy path|renders?|visible|complete[sd]?|submit(?:s|ted)?|save[sd]?|created|loads?)\b/i] }];
+  }
+  if (title === "Loading, empty, error, and success states") {
+    return [
+      { label: "loading", patterns: [/\b(loading|pending|spinner|skeleton|progress)\b/i] },
+      { label: "empty", patterns: [/\b(empty|no results?|zero results?|not found|blank state)\b/i] },
+      { label: "error", patterns: [/\b(error|failure|failed|reject(?:ed)?|throws?|exception)\b/i] },
+      { label: "success", patterns: [/\b(success|renders?|visible|complete[sd]?|loads?)\b/i] },
+    ];
+  }
+  if (title === "Navigation and re-entry") {
+    return [{ label: "navigation", patterns: [/\b(back|forward|navigation|navigate|route|re-entry|refresh|resume|restart)\b/i] }];
+  }
+  if (title === "API contract compatibility") {
+    return [{ label: "api contract", patterns: [/\b(contract|schema|response|request|status code|payload|headers?|200|201)\b/i] }];
+  }
+  if (title === "Network and server failure handling") {
+    return [{ label: "network failure", patterns: [/\b(timeout|network error|offline|server error|500|502|503|504|retry|4xx|5xx)\b/i] }];
+  }
+  if (title === "State transition boundaries") {
+    return [{ label: "state transition", patterns: [/\b(state|transition|cache|stale|optimistic|refresh|re-entry|restart|resume)\b/i] }];
+  }
+  if (title === "Authorization and permission states") {
+    return [{ label: "authorization", patterns: [/\b(unauthorized|unauthenticated|forbidden|permission denied|401|403|expired session|auth|session)\b/i] }];
+  }
+  if (title === "Viewport and visual variants" || title === "Browser viewport regression") {
+    return [{ label: "viewport", patterns: [/\b(viewport|mobile|desktop|responsive|small screen|dark mode|focus|disabled)\b/i] }];
+  }
+  if (title === "Locale and theme variants") {
+    return [{ label: "locale/theme", patterns: [/\b(locale|i18n|translation|translated|theme|dark mode)\b/i] }];
+  }
+  if (title === "Configuration variants") {
+    return [{ label: "configuration", patterns: [/\b(config|fallback|feature flag|flag on|flag off|enabled|disabled|environment|env)\b/i] }];
+  }
+  if (title === "Clean install and runtime startup") {
+    return [{ label: "startup", patterns: [/\b(startup|boot|runtime|install|build|clean checkout)\b/i] }];
+  }
+  if (title === "Invalid, blocked, or boundary input") {
+    return [{ label: "boundary input", patterns: [/\b(invalid|validation|duplicate|boundary|missing|required|too long|empty input|blocked)\b/i] }];
+  }
+  return [{ label: title.toLowerCase(), patterns: [new RegExp(escapeRegExp(title), "i")] }];
+}
+
+function coverageStatusForMatchedGroups(title: string, groupCount: number, matchedCount: number): CoverageEvidenceStatus {
+  if (title === "Loading, empty, error, and success states") {
+    return matchedCount >= 3 ? "covered" : "partial";
+  }
+  if (groupCount <= 1) {
+    return "covered";
+  }
+  return matchedCount >= Math.min(2, groupCount) ? "covered" : "partial";
+}
+
+function isBroadFlow(flow: FlowCoverageInput): boolean {
+  return flow.files.length > 12 || /^Changed\b/.test(flow.title);
+}
+
+function searchableEvidenceText(file: TestSuiteEvidenceFile): string {
+  return [file.path, ...file.testNames, ...file.imports, ...file.signals].join("\n");
+}
+
+function detectFrameworkSignals(projectFiles: ProjectFile[], testFiles: TestSuiteEvidenceFile[]): string[] {
+  const text = projectFiles.map((file) => `${file.path}\n${file.text ?? ""}`).join("\n").toLowerCase();
+  const signals: string[] = [];
+  if (/@playwright\/test|playwright\.config/.test(text)) {
+    signals.push("playwright");
+  }
+  if (/\bvitest\b|from ["']vitest["']/.test(text)) {
+    signals.push("vitest");
+  }
+  if (/\bjest\b|from ["']@jest/.test(text)) {
+    signals.push("jest");
+  }
+  if (/\bnode:test\b|node --test/.test(text)) {
+    signals.push("node:test");
+  }
+  if (/\bcypress\b|cypress\//.test(text)) {
+    signals.push("cypress");
+  }
+  if (testFiles.some((file) => /(?:^|\/)test_[^/]+\.py$|(?:^|\/)[^/]+_test\.py$/i.test(file.path))) {
+    signals.push("pytest");
+  }
+  if (/\.maestro\//.test(testFiles.map((file) => file.path).join("\n"))) {
+    signals.push("maestro");
+  }
+  return uniqueStrings(signals);
+}
+
+function isTestLikeFile(file: string): boolean {
+  const basename = path.basename(file);
+  if (/(?:^|\/)__pycache__\//.test(file) || /\.pyc$/i.test(file) || basename === "__init__.py") {
+    return false;
+  }
+  return (
+    /(?:\.|-)(?:test|spec)\.[cm]?[jt]sx?$/i.test(file) ||
+    /(?:^|\/)test_[^/]+\.py$/i.test(file) ||
+    /(?:^|\/)[^/]+_test\.(?:py|go)$/i.test(file) ||
+    /(?:^|\/)[^/]+(?:Test|Tests|Spec)\.(?:java|kt|cs|swift)$/i.test(file) ||
+    /(?:^|\/)[^/]+_(?:test|spec)\.rs$/i.test(file) ||
+    /(?:^|\/)\.maestro\/[^/]+\.ya?ml$/i.test(file)
+  );
+}
+
+function meaningfulTokens(text: string): string[] {
+  const ignored = new Set([
+    "app",
+    "apps",
+    "api",
+    "apis",
+    "changed",
+    "checklist",
+    "component",
+    "components",
+    "contract",
+    "flow",
+    "index",
+    "init",
+    "page",
+    "pages",
+    "route",
+    "routes",
+    "screen",
+    "screens",
+    "smoke",
+    "service",
+    "services",
+    "client",
+    "clients",
+    "spec",
+    "src",
+    "test",
+    "tests",
+    "ui",
+    "workflow",
+  ]);
+  return uniqueStrings(
+    text
+      .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+      .split(/[^a-zA-Z0-9]+/)
+      .map((part) => part.toLowerCase())
+      .filter((part) => part.length > 2 && !ignored.has(part)),
+  );
+}
+
+function normalizeText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return values.filter((value, index) => values.indexOf(value) === index);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -599,6 +599,119 @@ test("generateE2ePlan keeps service changes generic and avoids fixture-specific 
   assert.equal(titles.some((title) => /Ink drawing|Record mode|Saved entry|Localized visual/i.test(title)), false);
 });
 
+test("generateE2ePlan evaluates existing test suite coverage evidence", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src/features/campaign/fragments"), { recursive: true });
+  await mkdir(path.join(root, "src/features/campaign/__tests__"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      scripts: {
+        test: "vitest run",
+      },
+      dependencies: {
+        vite: "^7.0.0",
+        "react-dom": "^19.0.0",
+      },
+      devDependencies: {
+        vitest: "^3.0.0",
+      },
+    }),
+  );
+  await writeFile(
+    path.join(root, "src/features/campaign/fragments/CampaignView.tsx"),
+    "export function CampaignView() { return <main>Campaign</main>; }\n",
+  );
+  await writeFile(
+    path.join(root, "src/features/campaign/__tests__/CampaignView.test.tsx"),
+    [
+      "import { describe, expect, it } from 'vitest';",
+      "import { CampaignView } from '../fragments/CampaignView';",
+      "describe('CampaignView', () => {",
+      "  it('renders campaign success state', () => expect(CampaignView).toBeDefined());",
+      "  it('shows empty state when there are no results', () => expect('empty').toBe('empty'));",
+      "  it('shows error state after request failure', () => expect('error').toBe('error'));",
+      "});",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/campaign-view"]);
+  await writeFile(
+    path.join(root, "src/features/campaign/fragments/CampaignView.tsx"),
+    "export function CampaignView() { return <main data-testid=\"campaign-view\">Campaign detail</main>; }\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "update campaign view"]);
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const markdown = formatMarkdownE2ePlan(plan);
+  const flow = plan.flows.find((item) => item.title === "Campaign UI smoke flow");
+
+  assert.ok(flow);
+  assert.equal(plan.testSuite.hasTestSuite, true);
+  assert.equal(plan.testSuite.testFileCount, 1);
+  assert.ok(plan.testSuite.frameworkSignals.includes("vitest"));
+  assert.equal(
+    flow.coverageEvidence.find((evidence) => evidence.targetTitle === "Primary success path")?.status,
+    "covered",
+  );
+  assert.equal(
+    flow.coverageEvidence.find((evidence) => evidence.targetTitle === "Loading, empty, error, and success states")
+      ?.status,
+    "covered",
+  );
+  assert.ok(
+    flow.coverageEvidence
+      .find((evidence) => evidence.targetTitle === "Loading, empty, error, and success states")
+      ?.files.includes("src/features/campaign/__tests__/CampaignView.test.tsx"),
+  );
+  assert.match(markdown, /Existing test evidence:/);
+  assert.match(markdown, /covered Loading, empty, error, and success states/);
+});
+
+test("generateE2ePlan keeps generic test filenames from overmatching unrelated services", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "in_app_purchases/services"), { recursive: true });
+  await mkdir(path.join(root, "in_app_purchases/tests"), { recursive: true });
+  await mkdir(path.join(root, "offers/tests"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      scripts: {
+        test: "pytest",
+      },
+    }),
+  );
+  await writeFile(path.join(root, "in_app_purchases/services/clients.py"), "def get_client():\n    return None\n");
+  await writeFile(
+    path.join(root, "in_app_purchases/tests/test_views.py"),
+    "def test_purchase_response_contract():\n    assert {'status': 200}\n",
+  );
+  await writeFile(path.join(root, "offers/tests/test_services.py"), "def test_offer_success():\n    assert True\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/iap-client"]);
+  await writeFile(path.join(root, "in_app_purchases/services/clients.py"), "def get_client():\n    return 'changed'\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "update iap client"]);
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const flow = plan.flows.find((item) => /API contract/.test(item.title));
+  const evidenceFiles = flow?.coverageEvidence.flatMap((evidence) => evidence.files) ?? [];
+
+  assert.ok(flow);
+  assert.ok(plan.testSuite.frameworkSignals.includes("pytest"));
+  assert.ok(evidenceFiles.includes("in_app_purchases/tests/test_views.py"));
+  assert.equal(evidenceFiles.includes("offers/tests/test_services.py"), false);
+});
+
 test("generateE2eDraft uses web selectors in Playwright specs", async () => {
   const root = await makeTempRepo();
   await initGitRepo(root);
@@ -642,6 +755,11 @@ test("generateE2eDraft uses web selectors in Playwright specs", async () => {
   const spec = await readFile(path.join(root, "tests/e2e/checkout-ui-smoke-flow.spec.ts"), "utf8");
 
   assert.equal(draft.runner, "playwright");
+  assert.equal(draft.plan.testSuite.hasTestSuite, false);
+  assert.equal(
+    draft.plan.flows[0].coverageEvidence.find((evidence) => evidence.targetTitle === "Primary success path")?.status,
+    "missing",
+  );
   assert.ok(draft.files.some((file) => file.path === "tests/e2e/checkout-ui-smoke-flow.spec.ts"));
   assert.match(spec, /page\.getByTestId\("checkout-submit"\)/);
   assert.match(spec, /Coverage matrix/);


### PR DESCRIPTION
## Summary
- add a test suite inventory that scans existing test files and framework signals
- attach covered/partial/missing coverage evidence to generated E2E plans
- keep broad flows conservative and avoid generic test filename overmatching
- document existing test evidence in README and E2E Markdown output

## Validation
- pnpm test
- pnpm scan
- git diff --check
- spot-checked /Users/khs/Desktop/inpock-frontend/services/offer, /Users/khs/Desktop/inpock-app-client, /Users/khs/Desktop/link-server, and /Users/khs/Desktop/mood-note-client locally without committing to those repos