### PR TITLE
Feat: add local run history

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ node dist/cli.js scan /path/to/repo
 | `codeward github-action . --mode review --base origin/main --head HEAD` | Generate GitHub Action annotations, step summary, and PR comment body. |
 | `codeward test-plan . --base origin/main --head HEAD --include-working-tree` | Suggest domain test scenarios for changed files. |
 | `codeward e2e plan . --base origin/main --head HEAD` | Suggest E2E runner, user flows, coverage targets, existing test evidence, and missing testability hooks for changed files. |
+| `codeward e2e plan . --base origin/main --head HEAD --record-history` | Save a compact local run snapshot under `.codeward/runs/` while keeping JSON/Markdown output usable. |
 | `codeward e2e draft . --base origin/main --head HEAD` | Generate first-pass Maestro or Playwright E2E draft files from changed flows. |
+| `codeward history init .` | Create local CodeWard history directories and protect generated run history with `.gitignore`. |
 | `codeward doctor services/offer --workspace-root .` | Scan a monorepo package while using root guardrails. |
 | `codeward context . --write AGENTS.md` | Generate starter agent instructions for the repo. |
 | `codeward init .` | Create a starter `codeward.config.json`. |
@@ -146,7 +148,11 @@ For monorepos, pass `--workspace-root` when scanning a package. Package-local ch
 
 `codeward e2e plan` turns changed file paths into a first-pass E2E testing plan. It detects whether a project looks like Expo/React Native or web, recommends a runner such as Maestro or Playwright, suggests candidate user flows, adds coverage targets, compares those targets with existing test-suite evidence when tests are present, and points out missing stable selectors such as `testID` or `data-testid` before anyone starts writing tests from a blank file.
 
+Pass `--record-history` when you want CodeWard to keep a compact local snapshot of an E2E plan under `.codeward/runs/`. CodeWard automatically protects `.codeward/runs/`, `.codeward/cache/`, `.codeward/tmp/`, and `.codeward/*.local.json` with `.gitignore` so generated history stays local by default. Shared project policy, such as `codeward.config.json` or future `.codeward/flows.yml` files, remains commit-friendly.
+
 `codeward e2e draft` writes runnable draft files from that plan. Expo and React Native projects get Maestro YAML flows under `.maestro/` by default, while web projects get Playwright specs under `tests/e2e/`. Drafts infer stable selectors such as `testID`, `accessibilityLabel`, `data-testid`, `aria-label`, and visible text where possible. They keep `TODO` placeholders where selectors or project-specific launch details are still needed, and existing files are not overwritten unless `--force` is passed.
+
+`codeward history init` prepares that local storage explicitly without running an analysis. It creates `.codeward/runs/`, `.codeward/cache/`, and `.codeward/tmp/`, then adds the generated-history ignore patterns to `.gitignore` idempotently.
 
 `codeward eval` scores whether a branch has enough validation evidence, changed-test coverage, intent capture, risk explanation, domain verification paths, and reviewable size. In GitHub Actions, CodeWard can read the pull request body from the event payload and append the evaluation to the PR comment.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,3 +45,32 @@ codeward scan . --config ./codeward.config.json
 - Keep ignores small and documented in pull requests.
 - Use `validationCommands` for custom stacks, Makefile-based projects, or monorepos where the right validation command is not discoverable from standard project files.
 - CodeWard does not execute scanned project code while reading config.
+
+## Local History
+
+CodeWard separates shared project policy from generated local history.
+
+Commit-friendly files:
+
+- `codeward.config.json`
+- `.codeward/flows.yml` when a project chooses to define durable core flows
+- `.codeward/domains.yml` when a project chooses to define durable domain mappings
+
+Ignored local artifacts:
+
+- `.codeward/runs/`
+- `.codeward/cache/`
+- `.codeward/tmp/`
+- `.codeward/*.local.json`
+
+Run this once to create the local directories and add those ignore patterns idempotently:
+
+```sh
+codeward history init .
+```
+
+Use `--record-history` when an analysis should leave a compact local snapshot for comparison or debugging:
+
+```sh
+codeward e2e plan . --base origin/main --head HEAD --record-history
+```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { buildDoctorResult, formatDoctorReport, formatMarkdownDoctorReport } fro
 import { formatMarkdownE2eDraft, formatMarkdownE2ePlan, generateE2eDraft, generateE2ePlan } from "./e2e.js";
 import { evaluateChangeReadiness, formatEvalReport, formatMarkdownEvalReport } from "./eval.js";
 import { runGitHubAction } from "./github.js";
+import { formatLocalHistoryInitResult, initializeLocalHistory, recordE2ePlanHistory } from "./history.js";
 import { formatMarkdownReport, formatSarifReport, formatTextReport, hasFindingsAtOrAbove } from "./report.js";
 import { formatMarkdownReviewReport, formatReviewReport, reviewProject } from "./review.js";
 import { scanProject } from "./scanner.js";
@@ -46,6 +47,7 @@ interface ParsedOptions {
   prBodyFile?: string;
   includeWorkingTree?: boolean;
   e2eRunner?: E2eRunnerName;
+  recordHistory?: boolean;
 }
 
 async function main(argv: string[]): Promise<number> {
@@ -200,6 +202,9 @@ async function main(argv: string[]): Promise<number> {
     };
     if (subcommand === "plan") {
       const result = await generateE2ePlan(options.path, e2eOptions);
+      if (options.recordHistory) {
+        result.localHistory = await recordE2ePlanHistory(options.workspaceRoot ?? options.path, result);
+      }
       const output = formatE2ePlanOutput(result, options.format ?? (options.json ? "json" : "markdown"));
       await printOrWrite(output, options.output);
       return 0;
@@ -211,6 +216,25 @@ async function main(argv: string[]): Promise<number> {
     });
     const output = formatE2eDraftOutput(result, options.format ?? (options.json ? "json" : "markdown"));
     console.log(output.trimEnd());
+    return 0;
+  }
+
+  if (command === "history") {
+    const [subcommand, ...subcommandRest] = rest;
+    if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+      printHistoryHelp();
+      return 0;
+    }
+    if (subcommand !== "init") {
+      throw new Error(`Unknown history subcommand: ${subcommand}`);
+    }
+    const options = parseOptions(subcommandRest);
+    const result = await initializeLocalHistory(options.path);
+    if (options.json || options.format === "json") {
+      await printOrWrite(`${JSON.stringify(result, null, 2)}\n`, options.output);
+    } else {
+      await printOrWrite(formatLocalHistoryInitResult(result), options.output);
+    }
     return 0;
   }
 
@@ -398,6 +422,11 @@ function parseOptions(args: string[]): ParsedOptions {
 
     if (arg === "--include-working-tree") {
       options.includeWorkingTree = true;
+      continue;
+    }
+
+    if (arg === "--record-history") {
+      options.recordHistory = true;
       continue;
     }
 
@@ -592,8 +621,9 @@ Usage:
   codeward eval [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--pr-body-file <file>] [--format <format>]
   codeward github-action [path] [--mode auto|scan|review] [--base <ref>] [--head <ref>] [--fail-on <severity>]
   codeward test-plan [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--format <format>] [--output <file>]
-  codeward e2e plan [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--format <format>]
+  codeward e2e plan [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--record-history] [--format <format>]
   codeward e2e draft [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--runner maestro|playwright|manual] [--output <dir>] [--force]
+  codeward history init [path]
   codeward context [path] [--write [file]] [--force]
   codeward init [path] [--write <file>] [--force]
 
@@ -616,7 +646,9 @@ Examples:
   codeward github-action . --mode review --base origin/main --head HEAD --fail-on high
   codeward test-plan . --base origin/main --head HEAD
   codeward e2e plan . --base origin/main --head HEAD
+  codeward e2e plan . --base origin/main --head HEAD --record-history
   codeward e2e draft . --base origin/main --head HEAD
+  codeward history init .
   codeward test-plan services/offer --workspace-root . --base origin/main --head HEAD --include-working-tree
   codeward context . --write AGENTS.md
   codeward init .
@@ -629,13 +661,27 @@ function printE2eHelp(): void {
 E2E planning for AI-assisted changes.
 
 Usage:
-  codeward e2e plan [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--format <format>] [--output <file>]
+  codeward e2e plan [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--record-history] [--format <format>] [--output <file>]
   codeward e2e draft [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--runner maestro|playwright|manual] [--output <dir>] [--force]
 
 Examples:
   codeward e2e plan . --base origin/main --head HEAD
+  codeward e2e plan . --base origin/main --head HEAD --record-history
   codeward e2e draft . --base origin/main --head HEAD
   codeward e2e plan apps/mobile --workspace-root . --include-working-tree
+`);
+}
+
+function printHistoryHelp(): void {
+  console.log(`CodeWard ${VERSION}
+
+Local history for CodeWard analysis runs.
+
+Usage:
+  codeward history init [path] [--json] [--output <file>]
+
+Examples:
+  codeward history init .
 `);
 }
 

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -7,6 +7,7 @@ import {
 } from "./test-evidence.js";
 import { generateTestPlan } from "./test-plan.js";
 import type { TestPlanChangedFile, TestPlanOptions } from "./test-plan.js";
+import type { LocalHistoryReference } from "./history.js";
 import type { CoverageEvidence, TestSuiteInventory, TestSuiteSummary } from "./test-evidence.js";
 import { TOOL_NAME, VERSION } from "./version.js";
 
@@ -81,6 +82,7 @@ export interface E2ePlanResult {
   testSuite: TestSuiteSummary;
   changedFiles: TestPlanChangedFile[];
   suggestedCommands: string[];
+  localHistory?: LocalHistoryReference;
   flows: E2eFlow[];
   missingTestability: string[];
   setupNotes: string[];
@@ -395,6 +397,9 @@ export function formatMarkdownE2ePlan(result: E2ePlanResult): string {
     lines.push(`- Test frameworks: ${result.testSuite.frameworkSignals.join(", ")}`);
   }
   lines.push(`- Changed files considered: ${result.changedFiles.length}`);
+  if (result.localHistory) {
+    lines.push(`- Local history: \`${escapeMarkdownInline(result.localHistory.path)}\``);
+  }
   lines.push("");
 
   lines.push("## Recommendation");

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,0 +1,247 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { pathExists, toPosixPath } from "./fs.js";
+import type { E2ePlanResult } from "./e2e.js";
+import { TOOL_NAME, VERSION } from "./version.js";
+
+export const codewardDirectoryName = ".codeward";
+export const localHistoryDirectory = ".codeward/runs";
+export const localCacheDirectory = ".codeward/cache";
+export const localTmpDirectory = ".codeward/tmp";
+
+export const localHistoryGitignorePatterns = [
+  `${localHistoryDirectory}/`,
+  `${localCacheDirectory}/`,
+  `${localTmpDirectory}/`,
+  ".codeward/*.local.json",
+];
+
+export interface LocalHistoryReference {
+  path: string;
+  gitignoreUpdated: boolean;
+  addedGitignorePatterns: string[];
+}
+
+export interface LocalHistoryInitResult {
+  root: string;
+  createdDirectories: string[];
+  gitignorePath: string;
+  gitignoreUpdated: boolean;
+  addedGitignorePatterns: string[];
+  existingGitignorePatterns: string[];
+}
+
+export interface E2ePlanHistorySnapshot {
+  schemaVersion: 1;
+  tool: {
+    name: string;
+    version: string;
+  };
+  kind: "e2e-plan";
+  recordedAt: string;
+  plan: {
+    generatedAt: string;
+    scope: string;
+    base: string;
+    head: string;
+    includeWorkingTree: boolean;
+    projectType: string;
+    recommendedRunner: string;
+    changedFilesCount: number;
+    changedFiles: string[];
+    suggestedCommands: string[];
+    testSuite: E2ePlanResult["testSuite"];
+    flows: Array<{
+      title: string;
+      files: string[];
+      coverageTargets: Array<{
+        title: string;
+        priority: string;
+      }>;
+      coverageEvidence: Array<{
+        targetTitle: string;
+        status: string;
+        confidence: string;
+        files: string[];
+        reason: string;
+      }>;
+      missingTestabilityCount: number;
+    }>;
+  };
+  summary: {
+    changedFiles: number;
+    flows: number;
+    coverageEvidence: {
+      covered: number;
+      partial: number;
+      missing: number;
+    };
+    missingTestability: number;
+  };
+}
+
+export async function initializeLocalHistory(rootInput: string): Promise<LocalHistoryInitResult> {
+  const root = path.resolve(rootInput);
+  const createdDirectories: string[] = [];
+  for (const directory of [codewardDirectoryName, localHistoryDirectory, localCacheDirectory, localTmpDirectory]) {
+    const absolutePath = path.join(root, directory);
+    if (!(await pathExists(absolutePath))) {
+      await fs.mkdir(absolutePath, { recursive: true });
+      createdDirectories.push(directory);
+    }
+  }
+
+  const gitignore = await ensureLocalHistoryIgnored(root);
+  return {
+    root,
+    createdDirectories,
+    gitignorePath: ".gitignore",
+    ...gitignore,
+  };
+}
+
+export function formatLocalHistoryInitResult(result: LocalHistoryInitResult): string {
+  const lines: string[] = [];
+  lines.push("CodeWard Local History");
+  lines.push(`Root: ${result.root}`);
+  lines.push(
+    `Directories: ${result.createdDirectories.length > 0 ? result.createdDirectories.join(", ") : "already present"}`,
+  );
+  lines.push(
+    `Gitignore: ${result.gitignoreUpdated ? `updated ${result.gitignorePath}` : `${result.gitignorePath} already protected`}`,
+  );
+  if (result.addedGitignorePatterns.length > 0) {
+    lines.push("Added patterns:");
+    for (const pattern of result.addedGitignorePatterns) {
+      lines.push(`- ${pattern}`);
+    }
+  }
+  lines.push("Shared flow definitions stay commit-friendly; local runs, cache, and temp files stay ignored.");
+  return `${lines.join("\n")}\n`;
+}
+
+export async function recordE2ePlanHistory(rootInput: string, plan: E2ePlanResult): Promise<LocalHistoryReference> {
+  const root = path.resolve(rootInput);
+  const gitignore = await ensureLocalHistoryIgnored(root);
+  await fs.mkdir(path.join(root, localHistoryDirectory), { recursive: true });
+
+  const snapshot = buildE2ePlanHistorySnapshot(root, plan);
+  const displayPath = await nextHistoryPath(root, snapshot.recordedAt, snapshot.kind);
+  await fs.writeFile(path.join(root, displayPath), `${JSON.stringify(snapshot, null, 2)}\n`, "utf8");
+
+  return {
+    path: displayPath,
+    gitignoreUpdated: gitignore.gitignoreUpdated,
+    addedGitignorePatterns: gitignore.addedGitignorePatterns,
+  };
+}
+
+function buildE2ePlanHistorySnapshot(historyRoot: string, plan: E2ePlanResult): E2ePlanHistorySnapshot {
+  const coverageEvidence = plan.flows.flatMap((flow) => flow.coverageEvidence);
+  const recordedAt = new Date().toISOString();
+  return {
+    schemaVersion: 1,
+    tool: {
+      name: TOOL_NAME,
+      version: VERSION,
+    },
+    kind: "e2e-plan",
+    recordedAt,
+    plan: {
+      generatedAt: plan.generatedAt,
+      scope: plan.workspaceRoot ? toDisplayScope(plan.workspaceRoot, plan.root) : toDisplayScope(historyRoot, plan.root),
+      base: plan.base,
+      head: plan.head,
+      includeWorkingTree: plan.includeWorkingTree,
+      projectType: plan.project.type,
+      recommendedRunner: plan.recommendedRunner.name,
+      changedFilesCount: plan.changedFiles.length,
+      changedFiles: plan.changedFiles.map((file) => file.path).slice(0, 50),
+      suggestedCommands: plan.suggestedCommands.slice(0, 20),
+      testSuite: plan.testSuite,
+      flows: plan.flows.map((flow) => ({
+        title: flow.title,
+        files: flow.files.slice(0, 20),
+        coverageTargets: flow.coverage.map((target) => ({
+          title: target.title,
+          priority: target.priority,
+        })),
+        coverageEvidence: flow.coverageEvidence.map((evidence) => ({
+          targetTitle: evidence.targetTitle,
+          status: evidence.status,
+          confidence: evidence.confidence,
+          files: evidence.files.slice(0, 5),
+          reason: evidence.reason,
+        })),
+        missingTestabilityCount: flow.missingTestability.length,
+      })),
+    },
+    summary: {
+      changedFiles: plan.changedFiles.length,
+      flows: plan.flows.length,
+      coverageEvidence: {
+        covered: coverageEvidence.filter((evidence) => evidence.status === "covered").length,
+        partial: coverageEvidence.filter((evidence) => evidence.status === "partial").length,
+        missing: coverageEvidence.filter((evidence) => evidence.status === "missing").length,
+      },
+      missingTestability: plan.missingTestability.length,
+    },
+  };
+}
+
+async function ensureLocalHistoryIgnored(root: string): Promise<{
+  gitignoreUpdated: boolean;
+  addedGitignorePatterns: string[];
+  existingGitignorePatterns: string[];
+}> {
+  const gitignorePath = path.join(root, ".gitignore");
+  const raw = (await pathExists(gitignorePath)) ? await fs.readFile(gitignorePath, "utf8") : "";
+  const lines = raw.split(/\r?\n/);
+  const existing = new Set(lines.map((line) => line.trim()).filter(Boolean));
+  const addedGitignorePatterns = localHistoryGitignorePatterns.filter((pattern) => !existing.has(pattern));
+
+  if (addedGitignorePatterns.length === 0) {
+    return {
+      gitignoreUpdated: false,
+      addedGitignorePatterns: [],
+      existingGitignorePatterns: localHistoryGitignorePatterns,
+    };
+  }
+
+  const prefix = raw.length > 0 && !raw.endsWith("\n") ? "\n" : "";
+  const separator = raw.trim().length > 0 ? "\n" : "";
+  const block = [
+    "# CodeWard local analysis history",
+    ...addedGitignorePatterns,
+  ].join("\n");
+  await fs.writeFile(gitignorePath, `${raw}${prefix}${separator}${block}\n`, "utf8");
+
+  return {
+    gitignoreUpdated: true,
+    addedGitignorePatterns,
+    existingGitignorePatterns: localHistoryGitignorePatterns.filter((pattern) => existing.has(pattern)),
+  };
+}
+
+async function nextHistoryPath(root: string, recordedAt: string, kind: string): Promise<string> {
+  const safeTimestamp = recordedAt.replace(/[:.]/g, "-");
+  for (let index = 0; index < 100; index += 1) {
+    const suffix = index === 0 ? "" : `-${index + 1}`;
+    const displayPath = `${localHistoryDirectory}/${safeTimestamp}.${kind}${suffix}.json`;
+    if (!(await pathExists(path.join(root, displayPath)))) {
+      return displayPath;
+    }
+  }
+  throw new Error("Could not allocate a CodeWard local history file name");
+}
+
+function toDisplayScope(base: string, target: string): string {
+  const relative = toPosixPath(path.relative(base, target));
+  if (!relative) {
+    return ".";
+  }
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    return ".";
+  }
+  return relative;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,16 @@ export { buildDoctorResult, formatDoctorReport, formatMarkdownDoctorReport } fro
 export { formatMarkdownE2eDraft, formatMarkdownE2ePlan, generateE2eDraft, generateE2ePlan } from "./e2e.js";
 export { evaluateChangeReadiness, formatEvalReport, formatMarkdownEvalReport } from "./eval.js";
 export { githubCommentMarker, runGitHubAction } from "./github.js";
+export {
+  codewardDirectoryName,
+  formatLocalHistoryInitResult,
+  initializeLocalHistory,
+  localCacheDirectory,
+  localHistoryDirectory,
+  localHistoryGitignorePatterns,
+  localTmpDirectory,
+  recordE2ePlanHistory,
+} from "./history.js";
 export { formatMarkdownReport, formatSarifReport, formatTextReport, hasFindingsAtOrAbove } from "./report.js";
 export { formatMarkdownReviewReport, formatReviewReport, reviewProject } from "./review.js";
 export { scanProject } from "./scanner.js";
@@ -38,6 +48,7 @@ export type {
 } from "./e2e.js";
 export type { EvalCheck, EvalCheckStatus, EvalOptions, EvalRating, EvalResult } from "./eval.js";
 export type { GitHubActionMode, GitHubActionOptions, GitHubActionResult } from "./github.js";
+export type { E2ePlanHistorySnapshot, LocalHistoryInitResult, LocalHistoryReference } from "./history.js";
 export type { ChangedFile, ChangedRiskyFinding, ReviewOptions, ReviewResult } from "./review.js";
 export type { TestPlanChangedFile, TestPlanItem, TestPlanOptions, TestPlanResult } from "./test-plan.js";
 export type { CodeWardConfig, Finding, ScanCounts, ScanOptions, ScanResult, Severity } from "./types.js";

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -24,7 +24,9 @@ import {
   generateE2eDraft,
   generateE2ePlan,
   generateTestPlan,
+  initializeLocalHistory,
   loadConfig,
+  localHistoryGitignorePatterns,
   reviewProject,
   scanProject,
   verifyChange,
@@ -1114,6 +1116,88 @@ test("writeDefaultConfig creates a starter config", async () => {
   assert.equal(loaded.config.failOn, "high");
   assert.deepEqual(loaded.config.ignoreRules, []);
   assert.deepEqual(loaded.config.validationCommands, []);
+});
+
+test("initializeLocalHistory protects local runs with gitignore entries", async () => {
+  const root = await makeTempRepo();
+  await writeFile(path.join(root, ".gitignore"), "node_modules/\n");
+
+  const result = await initializeLocalHistory(root);
+  const gitignore = await readFile(path.join(root, ".gitignore"), "utf8");
+  const secondResult = await initializeLocalHistory(root);
+
+  assert.deepEqual(result.createdDirectories, [".codeward", ".codeward/runs", ".codeward/cache", ".codeward/tmp"]);
+  assert.equal(result.gitignoreUpdated, true);
+  assert.deepEqual(result.addedGitignorePatterns, localHistoryGitignorePatterns);
+  for (const directory of result.createdDirectories) {
+    assert.equal((await stat(path.join(root, directory))).isDirectory(), true);
+  }
+  for (const pattern of localHistoryGitignorePatterns) {
+    assert.match(gitignore, new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+  assert.equal(secondResult.gitignoreUpdated, false);
+  assert.deepEqual(secondResult.addedGitignorePatterns, []);
+});
+
+test("e2e plan can record compact local history without breaking JSON output", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src/pages/checkout"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      scripts: {
+        test: "playwright test",
+      },
+      dependencies: {
+        "@playwright/test": "^1.56.0",
+        vite: "^7.0.0",
+      },
+    }),
+  );
+  await writeFile(
+    path.join(root, "src/pages/checkout/CheckoutPage.tsx"),
+    "export function CheckoutPage() { return <button data-testid=\"checkout-submit\">Checkout</button>; }\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/checkout-history"]);
+  await writeFile(
+    path.join(root, "src/pages/checkout/CheckoutPage.tsx"),
+    "export function CheckoutPage() { return <button data-testid=\"checkout-submit\">Complete checkout</button>; }\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "update checkout copy"]);
+
+  const cliOutput = await execFileAsync(process.execPath, [
+    cliPath,
+    "e2e",
+    "plan",
+    root,
+    "--base",
+    "main",
+    "--head",
+    "HEAD",
+    "--record-history",
+    "--json",
+  ]);
+  const plan = JSON.parse(cliOutput.stdout);
+  const snapshotRaw = await readFile(path.join(root, plan.localHistory.path), "utf8");
+  const snapshot = JSON.parse(snapshotRaw);
+  const gitignore = await readFile(path.join(root, ".gitignore"), "utf8");
+
+  assert.equal(plan.localHistory.gitignoreUpdated, true);
+  assert.match(plan.localHistory.path, /^\.codeward\/runs\/.+\.e2e-plan\.json$/);
+  assert.equal(snapshot.kind, "e2e-plan");
+  assert.equal(snapshot.plan.scope, ".");
+  assert.equal(snapshot.plan.recommendedRunner, "playwright");
+  assert.equal(snapshot.summary.changedFiles, 1);
+  assert.equal(JSON.stringify(snapshot).includes(root), false);
+  for (const pattern of localHistoryGitignorePatterns) {
+    assert.match(gitignore, new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
 });
 
 test("configured validation commands feed test-plan and eval outputs", async () => {


### PR DESCRIPTION
## Summary
- add `codeward history init` to create local CodeWard history directories and protect generated artifacts with `.gitignore`
- add `codeward e2e plan --record-history` to save compact local E2E plan snapshots under `.codeward/runs/`
- expose history helpers/types for library users
- document which CodeWard files are commit-friendly versus local-only

## Validation
- pnpm test
- pnpm scan
- git diff --check
- node dist/cli.js e2e plan . --base origin/main --head HEAD --include-working-tree --json