### PR TITLE
Feat: match core flow manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ node dist/cli.js scan /path/to/repo
 | `codeward e2e plan . --base origin/main --head HEAD` | Suggest E2E runner, user flows, coverage targets, existing test evidence, and missing testability hooks for changed files. |
 | `codeward e2e plan . --base origin/main --head HEAD --record-history` | Save a compact local run snapshot under `.codeward/runs/` while keeping JSON/Markdown output usable. |
 | `codeward e2e draft . --base origin/main --head HEAD` | Generate first-pass Maestro or Playwright E2E draft files from changed flows. |
+| `codeward flows init .` | Create a starter `.codeward/flows.yml` for team-approved core flow definitions. |
 | `codeward history init .` | Create local CodeWard history directories and protect generated run history with `.gitignore`. |
 | `codeward doctor services/offer --workspace-root .` | Scan a monorepo package while using root guardrails. |
 | `codeward context . --write AGENTS.md` | Generate starter agent instructions for the repo. |
@@ -148,7 +149,28 @@ For monorepos, pass `--workspace-root` when scanning a package. Package-local ch
 
 `codeward e2e plan` turns changed file paths into a first-pass E2E testing plan. It detects whether a project looks like Expo/React Native or web, recommends a runner such as Maestro or Playwright, suggests candidate user flows, adds coverage targets, compares those targets with existing test-suite evidence when tests are present, and points out missing stable selectors such as `testID` or `data-testid` before anyone starts writing tests from a blank file.
 
-Pass `--record-history` when you want CodeWard to keep a compact local snapshot of an E2E plan under `.codeward/runs/`. CodeWard automatically protects `.codeward/runs/`, `.codeward/cache/`, `.codeward/tmp/`, and `.codeward/*.local.json` with `.gitignore` so generated history stays local by default. Shared project policy, such as `codeward.config.json` or future `.codeward/flows.yml` files, remains commit-friendly.
+If `.codeward/flows.yml` exists, `codeward e2e plan` also matches changed files against team-approved core flows. This lets maintainers encode the product or domain flows humans already care about:
+
+```yaml
+flows:
+  - id: checkout-purchase
+    name: Checkout purchase
+    priority: critical
+    domains:
+      - checkout
+    files:
+      - src/pages/checkout/**
+      - src/features/checkout/**
+    routes:
+      - /checkout
+    checks:
+      - Complete checkout with a valid payment method.
+      - Verify declined payment recovery.
+```
+
+Run `codeward flows init .` to create a starter manifest. Unlike generated run history, `.codeward/flows.yml` is meant to be reviewed and committed when those flow definitions should become team policy.
+
+Pass `--record-history` when you want CodeWard to keep a compact local snapshot of an E2E plan under `.codeward/runs/`. CodeWard automatically protects `.codeward/runs/`, `.codeward/cache/`, `.codeward/tmp/`, and `.codeward/*.local.json` with `.gitignore` so generated history stays local by default. Shared project policy, such as `codeward.config.json` and `.codeward/flows.yml`, remains commit-friendly.
 
 `codeward e2e draft` writes runnable draft files from that plan. Expo and React Native projects get Maestro YAML flows under `.maestro/` by default, while web projects get Playwright specs under `tests/e2e/`. Drafts infer stable selectors such as `testID`, `accessibilityLabel`, `data-testid`, `aria-label`, and visible text where possible. They keep `TODO` placeholders where selectors or project-specific launch details are still needed, and existing files are not overwritten unless `--force` is passed.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,3 +74,44 @@ Use `--record-history` when an analysis should leave a compact local snapshot fo
 ```sh
 codeward e2e plan . --base origin/main --head HEAD --record-history
 ```
+
+## Core Flows
+
+Create a starter core flow manifest:
+
+```sh
+codeward flows init .
+```
+
+`.codeward/flows.yml` is meant to be committed when the team wants CodeWard to understand project-specific flows during E2E planning.
+
+```yaml
+flows:
+  - id: checkout-purchase
+    name: Checkout purchase
+    priority: critical
+    domains:
+      - checkout
+    files:
+      - src/pages/checkout/**
+      - src/features/checkout/**
+    routes:
+      - /checkout
+    tags:
+      - payment
+    checks:
+      - Complete checkout with a valid payment method.
+      - Verify declined payment recovery.
+```
+
+Supported match fields:
+
+| Field | Description |
+| --- | --- |
+| `files` | Glob-like path patterns relative to the repository or workspace root. |
+| `domains` | Domain tokens matched against changed file path segments. |
+| `routes` | Route-like strings matched against changed file paths. |
+| `tags` | Additional tokens that can match file path segments. |
+| `checks` | Human-approved verification points shown in the E2E plan. |
+
+`priority` can be `critical`, `recommended`, or `optional`.

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
   "devDependencies": {
     "@types/node": "^24.0.0",
     "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "yaml": "^2.9.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@types/node':
         specifier: ^24.0.0
@@ -28,6 +32,11 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
 snapshots:
 
   '@types/node@24.13.2':
@@ -37,3 +46,5 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@7.18.2: {}
+
+  yaml@2.9.0: {}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { generateAgentContext } from "./context.js";
 import { buildDoctorResult, formatDoctorReport, formatMarkdownDoctorReport } from "./doctor.js";
 import { formatMarkdownE2eDraft, formatMarkdownE2ePlan, generateE2eDraft, generateE2ePlan } from "./e2e.js";
 import { evaluateChangeReadiness, formatEvalReport, formatMarkdownEvalReport } from "./eval.js";
+import { defaultFlowManifestPath, writeDefaultCoreFlowManifest } from "./flows.js";
 import { runGitHubAction } from "./github.js";
 import { formatLocalHistoryInitResult, initializeLocalHistory, recordE2ePlanHistory } from "./history.js";
 import { formatMarkdownReport, formatSarifReport, formatTextReport, hasFindingsAtOrAbove } from "./report.js";
@@ -234,6 +235,32 @@ async function main(argv: string[]): Promise<number> {
       await printOrWrite(`${JSON.stringify(result, null, 2)}\n`, options.output);
     } else {
       await printOrWrite(formatLocalHistoryInitResult(result), options.output);
+    }
+    return 0;
+  }
+
+  if (command === "flows") {
+    const [subcommand, ...subcommandRest] = rest;
+    if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+      printFlowsHelp();
+      return 0;
+    }
+    if (subcommand !== "init") {
+      throw new Error(`Unknown flows subcommand: ${subcommand}`);
+    }
+    const options = parseOptions(subcommandRest);
+    const outputPath = await writeDefaultCoreFlowManifest(
+      options.path,
+      options.write ?? defaultFlowManifestPath,
+      options.force,
+    );
+    if (options.json || options.format === "json") {
+      await printOrWrite(`${JSON.stringify({ path: outputPath }, null, 2)}\n`, options.output);
+    } else {
+      await printOrWrite(
+        `Wrote ${outputPath}\nCommit this file when the flow definitions should become team policy.\n`,
+        options.output,
+      );
     }
     return 0;
   }
@@ -623,6 +650,7 @@ Usage:
   codeward test-plan [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--format <format>] [--output <file>]
   codeward e2e plan [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--record-history] [--format <format>]
   codeward e2e draft [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--runner maestro|playwright|manual] [--output <dir>] [--force]
+  codeward flows init [path] [--write <file>] [--force]
   codeward history init [path]
   codeward context [path] [--write [file]] [--force]
   codeward init [path] [--write <file>] [--force]
@@ -648,6 +676,7 @@ Examples:
   codeward e2e plan . --base origin/main --head HEAD
   codeward e2e plan . --base origin/main --head HEAD --record-history
   codeward e2e draft . --base origin/main --head HEAD
+  codeward flows init .
   codeward history init .
   codeward test-plan services/offer --workspace-root . --base origin/main --head HEAD --include-working-tree
   codeward context . --write AGENTS.md
@@ -682,6 +711,19 @@ Usage:
 
 Examples:
   codeward history init .
+`);
+}
+
+function printFlowsHelp(): void {
+  console.log(`CodeWard ${VERSION}
+
+Core flow definitions for project-specific E2E planning.
+
+Usage:
+  codeward flows init [path] [--write <file>] [--force]
+
+Examples:
+  codeward flows init .
 `);
 }
 

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import { loadCoreFlowManifest, matchCoreFlows } from "./flows.js";
 import {
   collectTestSuiteInventory,
   evaluateFlowCoverageEvidence,
@@ -7,6 +8,7 @@ import {
 } from "./test-evidence.js";
 import { generateTestPlan } from "./test-plan.js";
 import type { TestPlanChangedFile, TestPlanOptions } from "./test-plan.js";
+import type { MatchedCoreFlow } from "./flows.js";
 import type { LocalHistoryReference } from "./history.js";
 import type { CoverageEvidence, TestSuiteInventory, TestSuiteSummary } from "./test-evidence.js";
 import { TOOL_NAME, VERSION } from "./version.js";
@@ -80,6 +82,8 @@ export interface E2ePlanResult {
   project: E2eProjectProfile;
   recommendedRunner: E2eRunnerRecommendation;
   testSuite: TestSuiteSummary;
+  coreFlowManifestPath?: string;
+  coreFlows: MatchedCoreFlow[];
   changedFiles: TestPlanChangedFile[];
   suggestedCommands: string[];
   localHistory?: LocalHistoryReference;
@@ -127,6 +131,10 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
   const project = await detectProjectProfile(root);
   const recommendedRunner = options.runner ? overrideRunner(project, options.runner) : recommendRunner(project);
   const testSuiteInventory = await collectTestSuiteInventory(root);
+  const coreFlowRoot = testPlan.workspaceRoot ?? root;
+  const coreFlowManifest = await loadCoreFlowManifest(coreFlowRoot);
+  const coreFlowChangedFiles = toCoreFlowChangedFiles(testPlan.changedFiles, root, coreFlowRoot);
+  const coreFlows = matchCoreFlows(coreFlowManifest, coreFlowChangedFiles);
   const flows = await buildFlows(root, testPlan.changedFiles, recommendedRunner.name, project.type, testSuiteInventory);
   const missingTestability = uniqueStrings([
     ...flows.flatMap((flow) => flow.missingTestability),
@@ -147,6 +155,8 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
     project,
     recommendedRunner,
     testSuite: summarizeTestSuiteInventory(testSuiteInventory),
+    coreFlowManifestPath: coreFlowManifest.path,
+    coreFlows,
     changedFiles: testPlan.changedFiles,
     suggestedCommands: testPlan.suggestedCommands,
     flows,
@@ -396,6 +406,10 @@ export function formatMarkdownE2ePlan(result: E2ePlanResult): string {
   if (result.testSuite.frameworkSignals.length > 0) {
     lines.push(`- Test frameworks: ${result.testSuite.frameworkSignals.join(", ")}`);
   }
+  if (result.coreFlowManifestPath) {
+    lines.push(`- Core flow manifest: \`${escapeMarkdownInline(result.coreFlowManifestPath)}\``);
+  }
+  lines.push(`- Matched core flows: ${result.coreFlows.length}`);
   lines.push(`- Changed files considered: ${result.changedFiles.length}`);
   if (result.localHistory) {
     lines.push(`- Local history: \`${escapeMarkdownInline(result.localHistory.path)}\``);
@@ -413,6 +427,34 @@ export function formatMarkdownE2ePlan(result: E2ePlanResult): string {
     }
   }
   lines.push("");
+
+  if (result.coreFlows.length > 0) {
+    lines.push("## Matched Core Flows");
+    lines.push("");
+    for (const flow of result.coreFlows) {
+      lines.push(`### ${escapeMarkdownInline(flow.name)} \`${escapeMarkdownInline(flow.id)}\``);
+      lines.push("");
+      lines.push(`Priority: ${flow.priority}`);
+      lines.push("");
+      lines.push(flow.reason);
+      lines.push("");
+      lines.push("Matched files:");
+      for (const file of flow.matchedFiles.slice(0, maxFilesPerFlow)) {
+        lines.push(`- \`${escapeMarkdownInline(file)}\``);
+      }
+      if (flow.matchedFiles.length > maxFilesPerFlow) {
+        lines.push(`- ... ${flow.matchedFiles.length - maxFilesPerFlow} more`);
+      }
+      if (flow.checks.length > 0) {
+        lines.push("");
+        lines.push("Human-approved checks:");
+        for (const check of flow.checks) {
+          lines.push(`- ${escapeMarkdownInline(check)}`);
+        }
+      }
+      lines.push("");
+    }
+  }
 
   lines.push("## Candidate E2E Flows");
   lines.push("");
@@ -624,6 +666,22 @@ function overrideRunner(project: E2eProjectProfile, runner: E2eRunnerName): E2eR
     name: runner,
     reason: `Use a manual checklist because no runnable E2E runner was selected for this ${formatProjectType(project.type)} project.`,
   };
+}
+
+function toCoreFlowChangedFiles(
+  changedFiles: TestPlanChangedFile[],
+  scopedRoot: string,
+  coreFlowRoot: string,
+): TestPlanChangedFile[] {
+  const relativeRoot = toPosixPath(path.relative(coreFlowRoot, scopedRoot));
+  if (!relativeRoot || relativeRoot.startsWith("..") || path.isAbsolute(relativeRoot)) {
+    return changedFiles;
+  }
+  return changedFiles.map((file) => ({
+    ...file,
+    path: toPosixPath(path.join(relativeRoot, file.path)),
+    previousPath: file.previousPath ? toPosixPath(path.join(relativeRoot, file.previousPath)) : undefined,
+  }));
 }
 
 type E2eFlowKind = "ui" | "api" | "state" | "content" | "config" | "domain" | "changed-file";

--- a/src/flows.ts
+++ b/src/flows.ts
@@ -1,0 +1,317 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
+import { pathExists, toPosixPath } from "./fs.js";
+import type { TestPlanChangedFile } from "./test-plan.js";
+
+export const defaultFlowManifestPath = ".codeward/flows.yml";
+
+export type CoreFlowPriority = "critical" | "recommended" | "optional";
+
+export interface CoreFlowDefinition {
+  id: string;
+  name: string;
+  description?: string;
+  owner?: string;
+  priority: CoreFlowPriority;
+  domains: string[];
+  files: string[];
+  routes: string[];
+  tags: string[];
+  checks: string[];
+}
+
+export interface CoreFlowManifest {
+  path?: string;
+  flows: CoreFlowDefinition[];
+}
+
+export interface MatchedCoreFlow {
+  id: string;
+  name: string;
+  priority: CoreFlowPriority;
+  reason: string;
+  matchedFiles: string[];
+  matchedSignals: string[];
+  checks: string[];
+}
+
+const flowManifestCandidates = [
+  ".codeward/flows.yml",
+  ".codeward/flows.yaml",
+  ".codeward/flows.json",
+];
+
+const priorityWeights: Record<CoreFlowPriority, number> = {
+  critical: 3,
+  recommended: 2,
+  optional: 1,
+};
+
+export async function loadCoreFlowManifest(rootInput: string): Promise<CoreFlowManifest> {
+  const root = path.resolve(rootInput);
+  const manifestPath = await findFlowManifestPath(root);
+  if (!manifestPath) {
+    return { flows: [] };
+  }
+
+  const raw = await fs.readFile(manifestPath, "utf8");
+  const parsed = parseFlowManifest(raw, manifestPath);
+  return {
+    path: toPosixPath(path.relative(root, manifestPath)),
+    flows: normalizeCoreFlows(parsed, manifestPath),
+  };
+}
+
+export function matchCoreFlows(
+  manifest: CoreFlowManifest,
+  changedFiles: TestPlanChangedFile[],
+): MatchedCoreFlow[] {
+  if (manifest.flows.length === 0 || changedFiles.length === 0) {
+    return [];
+  }
+
+  const files = changedFiles.map((file) => file.path);
+  return manifest.flows
+    .map((flow) => matchCoreFlow(flow, files))
+    .filter((flow): flow is MatchedCoreFlow => Boolean(flow))
+    .sort((left, right) => {
+      const priorityDiff = priorityWeights[right.priority] - priorityWeights[left.priority];
+      if (priorityDiff !== 0) {
+        return priorityDiff;
+      }
+      return right.matchedFiles.length + right.matchedSignals.length - (left.matchedFiles.length + left.matchedSignals.length);
+    })
+    .slice(0, 10);
+}
+
+export async function writeDefaultCoreFlowManifest(
+  rootInput: string,
+  fileName = defaultFlowManifestPath,
+  force = false,
+): Promise<string> {
+  const root = path.resolve(rootInput);
+  const outputPath = path.resolve(root, fileName);
+  if (!force && (await pathExists(outputPath))) {
+    throw new Error(`Refusing to overwrite ${outputPath}. Pass --force to replace it.`);
+  }
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, defaultCoreFlowManifestText(), "utf8");
+  return outputPath;
+}
+
+function matchCoreFlow(flow: CoreFlowDefinition, changedFiles: string[]): MatchedCoreFlow | undefined {
+  const matchedFiles = new Set<string>();
+  const matchedSignals = new Set<string>();
+
+  for (const file of changedFiles) {
+    if (flow.files.some((pattern) => matchesPathPattern(file, pattern))) {
+      matchedFiles.add(file);
+      matchedSignals.add("file pattern");
+    }
+    const fileTokens = pathTokens(file);
+    for (const domain of flow.domains) {
+      const normalizedDomain = normalizeToken(domain);
+      if (normalizedDomain && fileTokens.includes(normalizedDomain)) {
+        matchedFiles.add(file);
+        matchedSignals.add(`domain:${domain}`);
+      }
+    }
+    for (const route of flow.routes) {
+      const routeSignal = normalizeRoute(route);
+      if (routeSignal && normalizePathForMatch(file).includes(routeSignal)) {
+        matchedFiles.add(file);
+        matchedSignals.add(`route:${route}`);
+      }
+    }
+    for (const tag of flow.tags) {
+      const normalizedTag = normalizeToken(tag);
+      if (normalizedTag && fileTokens.includes(normalizedTag)) {
+        matchedFiles.add(file);
+        matchedSignals.add(`tag:${tag}`);
+      }
+    }
+  }
+
+  if (matchedFiles.size === 0) {
+    return undefined;
+  }
+
+  const signals = [...matchedSignals];
+  return {
+    id: flow.id,
+    name: flow.name,
+    priority: flow.priority,
+    reason: `Changed files match ${signals.slice(0, 4).join(", ")} for this declared core flow.`,
+    matchedFiles: [...matchedFiles].slice(0, 20),
+    matchedSignals: signals.slice(0, 12),
+    checks: flow.checks.slice(0, 10),
+  };
+}
+
+function parseFlowManifest(raw: string, manifestPath: string): unknown {
+  try {
+    if (/\.json$/i.test(manifestPath)) {
+      return JSON.parse(raw);
+    }
+    return YAML.parse(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Could not parse CodeWard flow manifest at ${manifestPath}: ${message}`);
+  }
+}
+
+function normalizeCoreFlows(value: unknown, manifestPath: string): CoreFlowDefinition[] {
+  const record = asRecord(value, `CodeWard flow manifest must be an object: ${manifestPath}`);
+  const rawFlows = record.flows;
+  if (!Array.isArray(rawFlows)) {
+    throw new Error(`CodeWard flow manifest flows must be an array: ${manifestPath}`);
+  }
+  return rawFlows.map((flow, index) => normalizeCoreFlow(flow, manifestPath, index));
+}
+
+function normalizeCoreFlow(value: unknown, manifestPath: string, index: number): CoreFlowDefinition {
+  const record = asRecord(value, `CodeWard flow manifest flow at index ${index} must be an object: ${manifestPath}`);
+  const id = readRequiredString(record, "id", manifestPath, index);
+  const name = readOptionalString(record, "name") ?? readOptionalString(record, "title") ?? id;
+  const priority = normalizePriority(readOptionalString(record, "priority") ?? "recommended", manifestPath, index);
+  const files = readStringArray(record, "files");
+  const domains = readStringArray(record, "domains");
+  const routes = readStringArray(record, "routes");
+  const tags = readStringArray(record, "tags");
+  const checks = readStringArray(record, "checks");
+
+  if (files.length + domains.length + routes.length + tags.length === 0) {
+    throw new Error(
+      `CodeWard flow manifest flow ${id} must include at least one of files, domains, routes, or tags: ${manifestPath}`,
+    );
+  }
+
+  return {
+    id,
+    name,
+    description: readOptionalString(record, "description"),
+    owner: readOptionalString(record, "owner"),
+    priority,
+    domains,
+    files,
+    routes,
+    tags,
+    checks,
+  };
+}
+
+async function findFlowManifestPath(root: string): Promise<string | undefined> {
+  for (const candidate of flowManifestCandidates) {
+    const absolutePath = path.join(root, candidate);
+    if (await pathExists(absolutePath)) {
+      return absolutePath;
+    }
+  }
+  return undefined;
+}
+
+function matchesPathPattern(file: string, pattern: string): boolean {
+  const normalizedFile = normalizePathForMatch(file);
+  const normalizedPattern = normalizePathForMatch(pattern);
+  if (!normalizedPattern) {
+    return false;
+  }
+  if (!normalizedPattern.includes("*")) {
+    return normalizedFile === normalizedPattern || normalizedFile.startsWith(`${normalizedPattern}/`);
+  }
+  const regex = new RegExp(
+    `^${normalizedPattern
+      .split("**")
+      .map((part) => part.split("*").map(escapeRegex).join("[^/]*"))
+      .join(".*")}$`,
+  );
+  return regex.test(normalizedFile);
+}
+
+function pathTokens(file: string): string[] {
+  return file
+    .replace(/\.[^.\/]+$/g, "")
+    .split("/")
+    .flatMap((part) => part.replace(/([a-z0-9])([A-Z])/g, "$1 $2").split(/[^a-zA-Z0-9]+/))
+    .map(normalizeToken)
+    .filter(Boolean);
+}
+
+function normalizeRoute(route: string): string {
+  return normalizePathForMatch(route).replace(/^\//, "");
+}
+
+function normalizePathForMatch(value: string): string {
+  return toPosixPath(value).replace(/^\.\/+/, "").replace(/\/+$/g, "").toLowerCase();
+}
+
+function normalizeToken(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function asRecord(value: unknown, message: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(message);
+  }
+  return value as Record<string, unknown>;
+}
+
+function readRequiredString(record: Record<string, unknown>, key: string, manifestPath: string, index: number): string {
+  const value = readOptionalString(record, key);
+  if (!value) {
+    throw new Error(`CodeWard flow manifest flow at index ${index} is missing ${key}: ${manifestPath}`);
+  }
+  return value;
+}
+
+function readOptionalString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function readStringArray(record: Record<string, unknown>, key: string): string[] {
+  const value = record[key];
+  if (value === undefined) {
+    return [];
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    return [value.trim()];
+  }
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return [...new Set(value.filter((item): item is string => typeof item === "string").map((item) => item.trim()).filter(Boolean))];
+}
+
+function normalizePriority(value: string, manifestPath: string, index: number): CoreFlowPriority {
+  if (value === "critical" || value === "recommended" || value === "optional") {
+    return value;
+  }
+  throw new Error(
+    `CodeWard flow manifest flow at index ${index} has invalid priority ${value}; expected critical, recommended, or optional: ${manifestPath}`,
+  );
+}
+
+function defaultCoreFlowManifestText(): string {
+  return [
+    "# Commit this file when your team wants CodeWard to know the flows humans care about.",
+    "flows:",
+    "  - id: primary-success-path",
+    "    name: Primary success path",
+    "    priority: critical",
+    "    domains: []",
+    "    files:",
+    "      - src/**",
+    "    routes: []",
+    "    tags: []",
+    "    checks:",
+    "      - Verify the happy path from entry point to completion.",
+    "      - Verify one realistic failure, empty, or blocked state.",
+    "",
+  ].join("\n");
+}

--- a/src/history.ts
+++ b/src/history.ts
@@ -47,6 +47,14 @@ export interface E2ePlanHistorySnapshot {
     includeWorkingTree: boolean;
     projectType: string;
     recommendedRunner: string;
+    coreFlowManifestPath?: string;
+    coreFlows: Array<{
+      id: string;
+      name: string;
+      priority: string;
+      matchedFiles: string[];
+      matchedSignals: string[];
+    }>;
     changedFilesCount: number;
     changedFiles: string[];
     suggestedCommands: string[];
@@ -71,6 +79,7 @@ export interface E2ePlanHistorySnapshot {
   summary: {
     changedFiles: number;
     flows: number;
+    coreFlows: number;
     coverageEvidence: {
       covered: number;
       partial: number;
@@ -155,6 +164,14 @@ function buildE2ePlanHistorySnapshot(historyRoot: string, plan: E2ePlanResult): 
       includeWorkingTree: plan.includeWorkingTree,
       projectType: plan.project.type,
       recommendedRunner: plan.recommendedRunner.name,
+      coreFlowManifestPath: plan.coreFlowManifestPath,
+      coreFlows: plan.coreFlows.map((flow) => ({
+        id: flow.id,
+        name: flow.name,
+        priority: flow.priority,
+        matchedFiles: flow.matchedFiles.slice(0, 10),
+        matchedSignals: flow.matchedSignals.slice(0, 10),
+      })),
       changedFilesCount: plan.changedFiles.length,
       changedFiles: plan.changedFiles.map((file) => file.path).slice(0, 50),
       suggestedCommands: plan.suggestedCommands.slice(0, 20),
@@ -179,6 +196,7 @@ function buildE2ePlanHistorySnapshot(historyRoot: string, plan: E2ePlanResult): 
     summary: {
       changedFiles: plan.changedFiles.length,
       flows: plan.flows.length,
+      coreFlows: plan.coreFlows.length,
       coverageEvidence: {
         covered: coverageEvidence.filter((evidence) => evidence.status === "covered").length,
         partial: coverageEvidence.filter((evidence) => evidence.status === "partial").length,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,12 @@ export { generateAgentContext } from "./context.js";
 export { buildDoctorResult, formatDoctorReport, formatMarkdownDoctorReport } from "./doctor.js";
 export { formatMarkdownE2eDraft, formatMarkdownE2ePlan, generateE2eDraft, generateE2ePlan } from "./e2e.js";
 export { evaluateChangeReadiness, formatEvalReport, formatMarkdownEvalReport } from "./eval.js";
+export {
+  defaultFlowManifestPath,
+  loadCoreFlowManifest,
+  matchCoreFlows,
+  writeDefaultCoreFlowManifest,
+} from "./flows.js";
 export { githubCommentMarker, runGitHubAction } from "./github.js";
 export {
   codewardDirectoryName,
@@ -47,6 +53,12 @@ export type {
   E2eRunnerRecommendation,
 } from "./e2e.js";
 export type { EvalCheck, EvalCheckStatus, EvalOptions, EvalRating, EvalResult } from "./eval.js";
+export type {
+  CoreFlowDefinition,
+  CoreFlowManifest,
+  CoreFlowPriority,
+  MatchedCoreFlow,
+} from "./flows.js";
 export type { GitHubActionMode, GitHubActionOptions, GitHubActionResult } from "./github.js";
 export type { E2ePlanHistorySnapshot, LocalHistoryInitResult, LocalHistoryReference } from "./history.js";
 export type { ChangedFile, ChangedRiskyFinding, ReviewOptions, ReviewResult } from "./review.js";

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -769,6 +769,117 @@ test("generateE2eDraft uses web selectors in Playwright specs", async () => {
   assert.match(spec, /Inferred selectors/);
 });
 
+test("generateE2ePlan matches committed core flow definitions", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, ".codeward"), { recursive: true });
+  await mkdir(path.join(root, "src/pages/checkout"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      scripts: {
+        test: "playwright test",
+      },
+      dependencies: {
+        "@playwright/test": "^1.56.0",
+        vite: "^7.0.0",
+      },
+    }),
+  );
+  await writeFile(
+    path.join(root, ".codeward/flows.yml"),
+    [
+      "flows:",
+      "  - id: checkout-purchase",
+      "    name: Checkout purchase",
+      "    priority: critical",
+      "    domains:",
+      "      - checkout",
+      "    files:",
+      "      - src/pages/checkout/**",
+      "    routes:",
+      "      - /checkout",
+      "    checks:",
+      "      - Complete checkout with a valid payment method.",
+      "      - Verify declined payment recovery.",
+    ].join("\n"),
+  );
+  await writeFile(
+    path.join(root, "src/pages/checkout/CheckoutPage.tsx"),
+    "export function CheckoutPage() { return <button data-testid=\"checkout-submit\">Checkout</button>; }\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/checkout-flow"]);
+  await writeFile(
+    path.join(root, "src/pages/checkout/CheckoutPage.tsx"),
+    "export function CheckoutPage() { return <button data-testid=\"checkout-submit\">Complete checkout</button>; }\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "update checkout flow"]);
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const markdown = formatMarkdownE2ePlan(plan);
+
+  assert.equal(plan.coreFlowManifestPath, ".codeward/flows.yml");
+  assert.equal(plan.coreFlows.length, 1);
+  assert.equal(plan.coreFlows[0].id, "checkout-purchase");
+  assert.equal(plan.coreFlows[0].priority, "critical");
+  assert.ok(plan.coreFlows[0].matchedFiles.includes("src/pages/checkout/CheckoutPage.tsx"));
+  assert.ok(plan.coreFlows[0].checks.includes("Complete checkout with a valid payment method."));
+  assert.match(markdown, /## Matched Core Flows/);
+  assert.match(markdown, /Checkout purchase/);
+  assert.match(markdown, /Human-approved checks:/);
+});
+
+test("generateE2ePlan matches workspace core flows for package scans", async () => {
+  const workspaceRoot = await makeTempRepo();
+  const packageRoot = path.join(workspaceRoot, "services/offer");
+  await initGitRepo(workspaceRoot);
+  await mkdir(path.join(workspaceRoot, ".codeward"), { recursive: true });
+  await mkdir(path.join(packageRoot, "src/features/offer"), { recursive: true });
+  await writeFile(
+    path.join(workspaceRoot, ".codeward/flows.yml"),
+    [
+      "flows:",
+      "  - id: offer-submit",
+      "    name: Offer submit",
+      "    priority: critical",
+      "    files:",
+      "      - services/offer/src/features/offer/**",
+      "    checks:",
+      "      - Submit an offer with valid terms.",
+    ].join("\n"),
+  );
+  await writeFile(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify({
+      scripts: {
+        test: "node --test",
+      },
+    }),
+  );
+  await writeFile(path.join(packageRoot, "src/features/offer/submit.ts"), "export const submit = () => true;\n");
+  await git(workspaceRoot, ["add", "."]);
+  await git(workspaceRoot, ["commit", "-m", "base"]);
+  await git(workspaceRoot, ["branch", "-M", "main"]);
+
+  await git(workspaceRoot, ["switch", "-c", "feature/offer-submit"]);
+  await writeFile(path.join(packageRoot, "src/features/offer/submit.ts"), "export const submit = () => 'changed';\n");
+  await git(workspaceRoot, ["add", "."]);
+  await git(workspaceRoot, ["commit", "-m", "update offer submit"]);
+
+  const plan = await generateE2ePlan(packageRoot, { base: "main", head: "HEAD", workspaceRoot });
+
+  assert.equal(plan.coreFlowManifestPath, ".codeward/flows.yml");
+  assert.equal(plan.coreFlows.length, 1);
+  assert.equal(plan.coreFlows[0].id, "offer-submit");
+  assert.ok(plan.coreFlows[0].matchedFiles.includes("services/offer/src/features/offer/submit.ts"));
+  assert.deepEqual(plan.changedFiles.map((file) => file.path), ["src/features/offer/submit.ts"]);
+});
+
 test("generateE2eDraft creates a fallback smoke draft without changed files", async () => {
   const root = await makeTempRepo();
   await initGitRepo(root);
@@ -1198,6 +1309,17 @@ test("e2e plan can record compact local history without breaking JSON output", a
   for (const pattern of localHistoryGitignorePatterns) {
     assert.match(gitignore, new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   }
+});
+
+test("flows init creates a commit-friendly core flow manifest", async () => {
+  const root = await makeTempRepo();
+  const cliOutput = await execFileAsync(process.execPath, [cliPath, "flows", "init", root]);
+  const manifest = await readFile(path.join(root, ".codeward/flows.yml"), "utf8");
+
+  assert.match(cliOutput.stdout, /Wrote /);
+  assert.match(cliOutput.stdout, /team policy/);
+  assert.match(manifest, /flows:/);
+  assert.match(manifest, /primary-success-path/);
 });
 
 test("configured validation commands feed test-plan and eval outputs", async () => {


### PR DESCRIPTION
## Summary
- add `.codeward/flows.yml` support for committed, team-approved core flow definitions
- match changed files against flow `files`, `domains`, `routes`, and `tags` during E2E planning
- add `codeward flows init` to create a starter manifest
- include matched core flows in E2E plan output and local history snapshots
- document commit-friendly flow policy and local-only run history

## Validation
- pnpm test
- pnpm scan
- git diff --check
- node dist/cli.js flows init /tmp/codeward-flows-init-smoke --force --json
- node dist/cli.js e2e plan . --base origin/main --head HEAD --include-working-tree --json