### PR TITLE
Feat: suggest domain language for E2E plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ For monorepos, pass `--workspace-root` when scanning a package. Package-local ch
 
 `codeward test-plan` turns changed file paths into a review-ready domain test checklist. It also discovers common validation commands from `package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, Gradle files, and Maven `pom.xml`. Add `--include-working-tree` for local, uncommitted changes while iterating.
 
-`codeward e2e plan` turns changed file paths into a first-pass E2E testing plan. It detects whether a project looks like Expo/React Native or web, recommends a runner such as Maestro or Playwright, suggests candidate user flows, adds coverage targets, compares those targets with existing test-suite evidence when tests are present, and points out missing stable selectors such as `testID` or `data-testid` before anyone starts writing tests from a blank file.
+`codeward e2e plan` turns changed file paths into a first-pass E2E testing plan. It detects whether a project looks like Expo/React Native or web, recommends a runner such as Maestro or Playwright, suggests domain language for the changed behavior, suggests candidate user flows, adds coverage targets, compares those targets with existing test-suite evidence when tests are present, and points out missing stable selectors such as `testID` or `data-testid` before anyone starts writing tests from a blank file.
+
+The domain language section is intentionally less implementation-oriented than the raw file list. For example, changes under `src/features/in-app-purchase/` become terms such as `In App Purchase` and scenarios such as `In App Purchase primary journey`. When `.codeward/flows.yml` exists, team-approved flow names receive higher confidence and appear as preferred scenario names.
 
 If `.codeward/flows.yml` exists, `codeward e2e plan` also matches changed files against team-approved core flows. This lets maintainers encode the product or domain flows humans already care about:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,3 +115,15 @@ Supported match fields:
 | `checks` | Human-approved verification points shown in the E2E plan. |
 
 `priority` can be `critical`, `recommended`, or `optional`.
+
+## Domain Language Suggestions
+
+`codeward e2e plan` includes a domain language section before the lower-level E2E candidates. CodeWard derives these suggestions from:
+
+- team-approved `.codeward/flows.yml` names
+- changed file path terms such as `features/in-app-purchase`
+- selected UI copy such as accessibility labels, placeholders, and text labels
+
+The goal is to help reviewers and test authors use the product words the team already understands. For example, a service or component path can become `In App Purchase primary journey` instead of a generic implementation phrase such as "API smoke flow".
+
+High-confidence terms usually come from committed core flows. Medium-confidence terms usually come from changed paths. Low-confidence terms can come from UI copy and should be treated as naming hints, not final policy.

--- a/src/domain-language.ts
+++ b/src/domain-language.ts
@@ -1,0 +1,338 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { pathExists } from "./fs.js";
+import type { MatchedCoreFlow } from "./flows.js";
+import type { TestPlanChangedFile } from "./test-plan.js";
+
+export type DomainLanguageSource = "core-flow" | "changed-file" | "ui-copy";
+export type DomainLanguageConfidence = "high" | "medium" | "low";
+
+export interface DomainLanguageTerm {
+  term: string;
+  source: DomainLanguageSource;
+  confidence: DomainLanguageConfidence;
+  files: string[];
+}
+
+export interface DomainScenarioSuggestion {
+  title: string;
+  intent: string;
+  checks: string[];
+  files: string[];
+  source: DomainLanguageSource;
+}
+
+export interface DomainLanguageSummary {
+  terms: DomainLanguageTerm[];
+  scenarios: DomainScenarioSuggestion[];
+  guidance: string[];
+}
+
+const maxFilesPerTerm = 8;
+
+export async function buildDomainLanguageSummary(
+  rootInput: string,
+  changedFiles: TestPlanChangedFile[],
+  coreFlows: MatchedCoreFlow[],
+): Promise<DomainLanguageSummary> {
+  const root = path.resolve(rootInput);
+  const files = changedFiles.map((file) => file.path).filter((file) => !isTestLikeFile(file));
+  const termMap = new Map<string, DomainLanguageTerm>();
+
+  for (const flow of coreFlows) {
+    addTerm(termMap, flow.name, "core-flow", "high", flow.matchedFiles);
+  }
+
+  for (const file of files) {
+    for (const term of termsFromPath(file)) {
+      addTerm(termMap, term, "changed-file", "medium", [file]);
+    }
+  }
+
+  for (const term of await collectUiCopyTerms(root, files)) {
+    addTerm(termMap, term.term, "ui-copy", "low", term.files);
+  }
+
+  const terms = [...termMap.values()]
+    .filter((term) => isUsefulTerm(term.term))
+    .sort(compareTerms)
+    .slice(0, 12);
+  const scenarios = buildScenarioSuggestions(terms, coreFlows);
+
+  return {
+    terms,
+    scenarios,
+    guidance: [
+      "Prefer these product words in generated test names, PR notes, and reviewer checklists.",
+      "Promote high-confidence repeated terms into `.codeward/flows.yml` when the team agrees they describe a durable user flow.",
+      "Use the suggested scenarios as starting points, then replace generic actor or outcome wording with the team's domain language.",
+    ],
+  };
+}
+
+function addTerm(
+  terms: Map<string, DomainLanguageTerm>,
+  rawTerm: string,
+  source: DomainLanguageSource,
+  confidence: DomainLanguageConfidence,
+  files: string[],
+): void {
+  const term = source === "core-flow" ? rawTerm.trim() : titleCase(rawTerm);
+  if (!isUsefulTerm(term)) {
+    return;
+  }
+  const key = term.toLowerCase();
+  const existing = terms.get(key);
+  if (!existing) {
+    terms.set(key, {
+      term,
+      source,
+      confidence,
+      files: uniqueStrings(files).slice(0, maxFilesPerTerm),
+    });
+    return;
+  }
+  existing.files = uniqueStrings([...existing.files, ...files]).slice(0, maxFilesPerTerm);
+  if (confidenceRank(confidence) > confidenceRank(existing.confidence)) {
+    existing.confidence = confidence;
+    existing.source = source;
+  }
+}
+
+function buildScenarioSuggestions(
+  terms: DomainLanguageTerm[],
+  coreFlows: MatchedCoreFlow[],
+): DomainScenarioSuggestion[] {
+  const scenarios: DomainScenarioSuggestion[] = [];
+
+  for (const flow of coreFlows.slice(0, 4)) {
+    scenarios.push({
+      title: flow.name,
+      intent: `Verify the team-approved "${flow.name}" flow with the words reviewers already use for this behavior.`,
+      checks:
+        flow.checks.length > 0
+          ? flow.checks
+          : [
+              "Start from the entry point a real user uses.",
+              "Complete the main action.",
+              "Confirm the user-visible result.",
+            ],
+      files: flow.matchedFiles,
+      source: "core-flow",
+    });
+  }
+
+  for (const term of terms.filter((item) => item.source !== "core-flow").slice(0, 5)) {
+    scenarios.push({
+      title: `${term.term} primary journey`,
+      intent: `Use "${term.term}" as the shared name for this changed behavior until the team chooses a better domain term.`,
+      checks: [
+        `Start from the normal entry point for ${term.term}.`,
+        `Complete the main ${term.term} action with realistic data.`,
+        `Confirm the visible result, saved state, navigation, or event that proves ${term.term} worked.`,
+        `Try one empty, blocked, rejected, or failed ${term.term} path that a real user could hit.`,
+      ],
+      files: term.files,
+      source: term.source,
+    });
+  }
+
+  return dedupeScenarios(scenarios).slice(0, 6);
+}
+
+async function collectUiCopyTerms(
+  root: string,
+  files: string[],
+): Promise<Array<{ term: string; files: string[] }>> {
+  const terms: Array<{ term: string; files: string[] }> = [];
+  for (const file of files.filter(isUiImplementationFile).slice(0, 8)) {
+    const absolutePath = path.join(root, file);
+    if (!(await pathExists(absolutePath))) {
+      continue;
+    }
+    const text = await fs.readFile(absolutePath, "utf8");
+    for (const term of extractUiCopyTerms(text)) {
+      terms.push({ term, files: [file] });
+    }
+  }
+  return terms;
+}
+
+function termsFromPath(file: string): string[] {
+  if (!isDomainLanguageFile(file)) {
+    return [];
+  }
+  const terms: string[] = [];
+  const segments = file.split("/");
+  for (const key of ["features", "domains", "modules", "services", "entities", "pages", "screens", "app"]) {
+    const index = segments.indexOf(key);
+    const value = normalizeSegment(segments[index + 1]);
+    if (value) {
+      terms.push(value);
+    }
+  }
+  const basename = normalizeSegment(path.basename(file));
+  if (basename) {
+    terms.push(basename);
+  }
+  return uniqueStrings(terms);
+}
+
+function extractUiCopyTerms(text: string): string[] {
+  const terms: string[] = [];
+  const patterns = [
+    /\b(?:accessibilityLabel|aria-label|placeholder|title|label)=["']([^"']{2,80})["']/g,
+    /<Text[^>]*>\s*([^<{]{2,80})\s*<\/Text>/g,
+    /(?:button|cta|action|screen|page)Title\s*[:=]\s*["']([^"']{2,80})["']/gi,
+  ];
+  for (const pattern of patterns) {
+    for (const match of text.matchAll(pattern)) {
+      const value = normalizeUiCopy(match[1] ?? "");
+      if (value) {
+        terms.push(value);
+      }
+    }
+  }
+  return uniqueStrings(terms).slice(0, 8);
+}
+
+function normalizeUiCopy(value: string): string | undefined {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (!normalized || normalized.length > 60) {
+    return undefined;
+  }
+  if (/TODO|http|www\.|[{}[\]();]/i.test(normalized)) {
+    return undefined;
+  }
+  return normalized;
+}
+
+function normalizeSegment(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const normalized = value
+    .replace(/\.(?:d\.)?(?:[cm]?[jt]sx?|vue|svelte|css|scss|sass|less|json|ya?ml|md|py|go|rs|kt|java|swift|cs|png|jpe?g|webp|gif|svg)$/i, "")
+    .replace(/(?:Api|Service|Controller|Component|Screen)$/g, "")
+    .replace(/^_+|_+$/g, "")
+    .trim();
+  if (/^use[A-Z]/.test(normalized)) {
+    return undefined;
+  }
+  return isUsefulTerm(normalized) ? normalized : undefined;
+}
+
+function isDomainLanguageFile(file: string): boolean {
+  if (/(?:^|\/)(?:assets?|images?|icons?|fonts?)\//i.test(file)) {
+    return false;
+  }
+  if (/(?:package\.json|pnpm-lock\.yaml|yarn\.lock|package-lock\.json|bun\.lockb|Podfile\.lock|\.xcodeproj|eas\.json|app\.config\.)/i.test(file)) {
+    return false;
+  }
+  return true;
+}
+
+function isUiImplementationFile(file: string): boolean {
+  return /\.(?:tsx|jsx|vue|svelte)$/i.test(file);
+}
+
+function isTestLikeFile(file: string): boolean {
+  return (
+    /(?:^|\/)(?:__tests__|tests?|specs?|e2e)\//i.test(file) ||
+    /(?:\.|-)(?:test|spec)\.[cm]?[jt]sx?$/i.test(file) ||
+    /(?:^|\/)test_[^/]+\.py$/i.test(file) ||
+    /(?:^|\/)[^/]+_test\.(?:py|go)$/i.test(file)
+  );
+}
+
+function isUsefulTerm(value: string): boolean {
+  const normalized = value.toLowerCase().replace(/[^a-z0-9가-힣]+/g, "-").replace(/^-+|-+$/g, "");
+  const ignored = new Set([
+    "api",
+    "apis",
+    "app",
+    "client",
+    "component",
+    "components",
+    "config",
+    "controller",
+    "content",
+    "index",
+    "ios",
+    "android",
+    "layout",
+    "model",
+    "screen",
+    "screens",
+    "service",
+    "services",
+    "shared",
+    "src",
+    "test",
+    "tests",
+    "ui",
+    "util",
+    "utils",
+  ]);
+  return normalized.length > 1 && !ignored.has(normalized);
+}
+
+function compareTerms(left: DomainLanguageTerm, right: DomainLanguageTerm): number {
+  const confidenceDiff = confidenceRank(right.confidence) - confidenceRank(left.confidence);
+  if (confidenceDiff !== 0) {
+    return confidenceDiff;
+  }
+  const fileDiff = right.files.length - left.files.length;
+  if (fileDiff !== 0) {
+    return fileDiff;
+  }
+  return left.term.localeCompare(right.term);
+}
+
+function confidenceRank(confidence: DomainLanguageConfidence): number {
+  if (confidence === "high") {
+    return 3;
+  }
+  if (confidence === "medium") {
+    return 2;
+  }
+  return 1;
+}
+
+function titleCase(value: string): string {
+  if (/[가-힣]/.test(value)) {
+    return value.trim();
+  }
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[-_]+/g, " ")
+    .replace(/[^a-zA-Z0-9 ]+/g, " ")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => {
+      if (/^[A-Z0-9]+$/.test(part)) {
+        return part;
+      }
+      return `${part.charAt(0).toUpperCase()}${part.slice(1)}`;
+    })
+    .join(" ");
+}
+
+function dedupeScenarios(scenarios: DomainScenarioSuggestion[]): DomainScenarioSuggestion[] {
+  const seen = new Set<string>();
+  const deduped: DomainScenarioSuggestion[] = [];
+  for (const scenario of scenarios) {
+    const key = scenario.title.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(scenario);
+  }
+  return deduped;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import { buildDomainLanguageSummary } from "./domain-language.js";
 import { loadCoreFlowManifest, matchCoreFlows } from "./flows.js";
 import {
   collectTestSuiteInventory,
@@ -8,6 +9,7 @@ import {
 } from "./test-evidence.js";
 import { generateTestPlan } from "./test-plan.js";
 import type { TestPlanChangedFile, TestPlanOptions } from "./test-plan.js";
+import type { DomainLanguageSummary } from "./domain-language.js";
 import type { MatchedCoreFlow } from "./flows.js";
 import type { LocalHistoryReference } from "./history.js";
 import type { CoverageEvidence, TestSuiteInventory, TestSuiteSummary } from "./test-evidence.js";
@@ -84,6 +86,7 @@ export interface E2ePlanResult {
   testSuite: TestSuiteSummary;
   coreFlowManifestPath?: string;
   coreFlows: MatchedCoreFlow[];
+  domainLanguage: DomainLanguageSummary;
   changedFiles: TestPlanChangedFile[];
   suggestedCommands: string[];
   localHistory?: LocalHistoryReference;
@@ -135,6 +138,7 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
   const coreFlowManifest = await loadCoreFlowManifest(coreFlowRoot);
   const coreFlowChangedFiles = toCoreFlowChangedFiles(testPlan.changedFiles, root, coreFlowRoot);
   const coreFlows = matchCoreFlows(coreFlowManifest, coreFlowChangedFiles);
+  const domainLanguage = await buildDomainLanguageSummary(root, testPlan.changedFiles, coreFlows);
   const flows = await buildFlows(root, testPlan.changedFiles, recommendedRunner.name, project.type, testSuiteInventory);
   const missingTestability = uniqueStrings([
     ...flows.flatMap((flow) => flow.missingTestability),
@@ -157,6 +161,7 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
     testSuite: summarizeTestSuiteInventory(testSuiteInventory),
     coreFlowManifestPath: coreFlowManifest.path,
     coreFlows,
+    domainLanguage,
     changedFiles: testPlan.changedFiles,
     suggestedCommands: testPlan.suggestedCommands,
     flows,
@@ -427,6 +432,33 @@ export function formatMarkdownE2ePlan(result: E2ePlanResult): string {
     }
   }
   lines.push("");
+
+  if (result.domainLanguage.terms.length > 0 || result.domainLanguage.scenarios.length > 0) {
+    lines.push("## Domain Language");
+    lines.push("");
+    if (result.domainLanguage.terms.length > 0) {
+      lines.push("Suggested terms:");
+      for (const term of result.domainLanguage.terms.slice(0, 10)) {
+        const files = term.files.length > 0 ? ` (${term.files.slice(0, 3).join(", ")})` : "";
+        lines.push(`- ${escapeMarkdownInline(term.term)} [${term.confidence}, ${term.source}]${files}`);
+      }
+      lines.push("");
+    }
+    if (result.domainLanguage.scenarios.length > 0) {
+      lines.push("Suggested user scenarios:");
+      for (const scenario of result.domainLanguage.scenarios.slice(0, 6)) {
+        lines.push(`- ${escapeMarkdownInline(scenario.title)}: ${escapeMarkdownInline(scenario.intent)}`);
+      }
+      lines.push("");
+    }
+    if (result.domainLanguage.guidance.length > 0) {
+      lines.push("Naming guidance:");
+      for (const guidance of result.domainLanguage.guidance) {
+        lines.push(`- ${escapeMarkdownInline(guidance)}`);
+      }
+      lines.push("");
+    }
+  }
 
   if (result.coreFlows.length > 0) {
     lines.push("## Matched Core Flows");

--- a/src/history.ts
+++ b/src/history.ts
@@ -55,6 +55,14 @@ export interface E2ePlanHistorySnapshot {
       matchedFiles: string[];
       matchedSignals: string[];
     }>;
+    domainLanguage: {
+      terms: Array<{
+        term: string;
+        confidence: string;
+        source: string;
+      }>;
+      scenarios: string[];
+    };
     changedFilesCount: number;
     changedFiles: string[];
     suggestedCommands: string[];
@@ -80,6 +88,7 @@ export interface E2ePlanHistorySnapshot {
     changedFiles: number;
     flows: number;
     coreFlows: number;
+    domainTerms: number;
     coverageEvidence: {
       covered: number;
       partial: number;
@@ -172,6 +181,14 @@ function buildE2ePlanHistorySnapshot(historyRoot: string, plan: E2ePlanResult): 
         matchedFiles: flow.matchedFiles.slice(0, 10),
         matchedSignals: flow.matchedSignals.slice(0, 10),
       })),
+      domainLanguage: {
+        terms: plan.domainLanguage.terms.slice(0, 12).map((term) => ({
+          term: term.term,
+          confidence: term.confidence,
+          source: term.source,
+        })),
+        scenarios: plan.domainLanguage.scenarios.map((scenario) => scenario.title).slice(0, 8),
+      },
       changedFilesCount: plan.changedFiles.length,
       changedFiles: plan.changedFiles.map((file) => file.path).slice(0, 50),
       suggestedCommands: plan.suggestedCommands.slice(0, 20),
@@ -197,6 +214,7 @@ function buildE2ePlanHistorySnapshot(historyRoot: string, plan: E2ePlanResult): 
       changedFiles: plan.changedFiles.length,
       flows: plan.flows.length,
       coreFlows: plan.coreFlows.length,
+      domainTerms: plan.domainLanguage.terms.length,
       coverageEvidence: {
         covered: coverageEvidence.filter((evidence) => evidence.status === "covered").length,
         partial: coverageEvidence.filter((evidence) => evidence.status === "partial").length,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { defaultConfig, loadConfig, writeDefaultConfig } from "./config.js";
 export { generateAgentContext } from "./context.js";
+export { buildDomainLanguageSummary } from "./domain-language.js";
 export { buildDoctorResult, formatDoctorReport, formatMarkdownDoctorReport } from "./doctor.js";
 export { formatMarkdownE2eDraft, formatMarkdownE2ePlan, generateE2eDraft, generateE2ePlan } from "./e2e.js";
 export { evaluateChangeReadiness, formatEvalReport, formatMarkdownEvalReport } from "./eval.js";
@@ -36,6 +37,13 @@ export type {
   TestSuiteSummary,
 } from "./test-evidence.js";
 export type { DoctorArea, DoctorPriority, DoctorResult } from "./doctor.js";
+export type {
+  DomainLanguageConfidence,
+  DomainLanguageSource,
+  DomainLanguageSummary,
+  DomainLanguageTerm,
+  DomainScenarioSuggestion,
+} from "./domain-language.js";
 export type {
   E2eCoveragePriority,
   E2eCoverageTarget,

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -829,9 +829,50 @@ test("generateE2ePlan matches committed core flow definitions", async () => {
   assert.equal(plan.coreFlows[0].priority, "critical");
   assert.ok(plan.coreFlows[0].matchedFiles.includes("src/pages/checkout/CheckoutPage.tsx"));
   assert.ok(plan.coreFlows[0].checks.includes("Complete checkout with a valid payment method."));
+  assert.ok(plan.domainLanguage.terms.some((term) => term.term === "Checkout purchase" && term.confidence === "high"));
+  assert.ok(plan.domainLanguage.scenarios.some((scenario) => scenario.title === "Checkout purchase"));
   assert.match(markdown, /## Matched Core Flows/);
+  assert.match(markdown, /## Domain Language/);
   assert.match(markdown, /Checkout purchase/);
   assert.match(markdown, /Human-approved checks:/);
+});
+
+test("generateE2ePlan suggests domain language from changed paths without core flows", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src/features/in-app-purchase/services"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      scripts: {
+        test: "node --test",
+      },
+    }),
+  );
+  await writeFile(
+    path.join(root, "src/features/in-app-purchase/services/nativeInAppPurchaseService.ts"),
+    "export const purchase = () => true;\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/in-app-purchase"]);
+  await writeFile(
+    path.join(root, "src/features/in-app-purchase/services/nativeInAppPurchaseService.ts"),
+    "export const purchase = () => 'changed';\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "update in app purchase"]);
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const markdown = formatMarkdownE2ePlan(plan);
+
+  assert.equal(plan.coreFlows.length, 0);
+  assert.ok(plan.domainLanguage.terms.some((term) => term.term === "In App Purchase"));
+  assert.ok(plan.domainLanguage.scenarios.some((scenario) => scenario.title === "In App Purchase primary journey"));
+  assert.match(markdown, /Suggested terms:/);
+  assert.match(markdown, /In App Purchase primary journey/);
 });
 
 test("generateE2ePlan matches workspace core flows for package scans", async () => {


### PR DESCRIPTION
## Summary
- add a domain-language summary to E2E plans so reports suggest product/domain terms before lower-level test candidates
- derive terms from committed core flows, changed path names, and selected UI copy
- add human-readable scenario suggestions such as `In App Purchase primary journey`
- store compact domain language summaries in local run history snapshots
- document how domain language suggestions fit with `.codeward/flows.yml`

## Validation
- pnpm test
- pnpm scan
- git diff --check
- spot-checked domain language output against inpock-app-client and mood-note-client without writing files