### PR TITLE
Feat: use domain scenarios for E2E drafts

### DIFF
--- a/src/domain-language.ts
+++ b/src/domain-language.ts
@@ -28,6 +28,11 @@ export interface DomainLanguageSummary {
   guidance: string[];
 }
 
+interface PathTermCandidate {
+  term: string;
+  confidence: DomainLanguageConfidence;
+}
+
 const maxFilesPerTerm = 8;
 
 export async function buildDomainLanguageSummary(
@@ -44,8 +49,8 @@ export async function buildDomainLanguageSummary(
   }
 
   for (const file of files) {
-    for (const term of termsFromPath(file)) {
-      addTerm(termMap, term, "changed-file", "medium", [file]);
+    for (const candidate of termsFromPath(file)) {
+      addTerm(termMap, candidate.term, "changed-file", candidate.confidence, [file]);
     }
   }
 
@@ -158,24 +163,51 @@ async function collectUiCopyTerms(
   return terms;
 }
 
-function termsFromPath(file: string): string[] {
+function termsFromPath(file: string): PathTermCandidate[] {
   if (!isDomainLanguageFile(file)) {
     return [];
   }
-  const terms: string[] = [];
+  const terms: PathTermCandidate[] = [];
   const segments = file.split("/");
-  for (const key of ["features", "domains", "modules", "services", "entities", "pages", "screens", "app"]) {
+  const semanticKeys: Array<{ key: string; confidence: DomainLanguageConfidence }> = [
+    { key: "features", confidence: "high" },
+    { key: "domains", confidence: "high" },
+    { key: "modules", confidence: "high" },
+    { key: "services", confidence: "high" },
+    { key: "entities", confidence: "high" },
+    { key: "pages", confidence: "medium" },
+    { key: "screens", confidence: "medium" },
+    { key: "app", confidence: "medium" },
+  ];
+  for (const { key, confidence } of semanticKeys) {
     const index = segments.indexOf(key);
-    const value = normalizeSegment(segments[index + 1]);
+    const value = normalizeSegment(semanticSegmentAfterKey(segments, index));
     if (value) {
-      terms.push(value);
+      terms.push({ term: value, confidence });
     }
   }
   const basename = normalizeSegment(path.basename(file));
   if (basename) {
-    terms.push(basename);
+    terms.push({ term: basename, confidence: "medium" });
   }
-  return uniqueStrings(terms);
+  return uniquePathTermCandidates(terms);
+}
+
+function semanticSegmentAfterKey(segments: string[], keyIndex: number): string | undefined {
+  if (keyIndex < 0) {
+    return undefined;
+  }
+  for (const segment of segments.slice(keyIndex + 1)) {
+    if (!isStructuralSegment(segment)) {
+      return segment;
+    }
+  }
+  return undefined;
+}
+
+function isStructuralSegment(segment: string): boolean {
+  const normalized = segment.toLowerCase().replace(/[^a-z0-9가-힣]+/g, "-").replace(/^-+|-+$/g, "");
+  return structuralSegments.has(normalized);
 }
 
 function extractUiCopyTerms(text: string): string[] {
@@ -257,11 +289,22 @@ function isUsefulTerm(value: string): boolean {
     "config",
     "controller",
     "content",
+    "doc",
+    "docs",
     "index",
     "ios",
     "android",
     "layout",
     "model",
+    "navigation",
+    "navigations",
+    "page",
+    "pages",
+    "provider",
+    "providers",
+    "readme",
+    "route",
+    "routes",
     "screen",
     "screens",
     "service",
@@ -336,3 +379,35 @@ function dedupeScenarios(scenarios: DomainScenarioSuggestion[]): DomainScenarioS
 function uniqueStrings(values: string[]): string[] {
   return [...new Set(values.filter(Boolean))];
 }
+
+function uniquePathTermCandidates(values: PathTermCandidate[]): PathTermCandidate[] {
+  const candidates = new Map<string, PathTermCandidate>();
+  for (const value of values) {
+    const key = value.term.toLowerCase();
+    const existing = candidates.get(key);
+    if (!existing || confidenceRank(value.confidence) > confidenceRank(existing.confidence)) {
+      candidates.set(key, value);
+    }
+  }
+  return [...candidates.values()];
+}
+
+const structuralSegments = new Set([
+  "app",
+  "apps",
+  "components",
+  "content",
+  "docs",
+  "features",
+  "layouts",
+  "modules",
+  "navigation",
+  "navigations",
+  "pages",
+  "providers",
+  "routes",
+  "screens",
+  "services",
+  "shared",
+  "src",
+]);

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -9,7 +9,7 @@ import {
 } from "./test-evidence.js";
 import { generateTestPlan } from "./test-plan.js";
 import type { TestPlanChangedFile, TestPlanOptions } from "./test-plan.js";
-import type { DomainLanguageSummary } from "./domain-language.js";
+import type { DomainLanguageSummary, DomainScenarioSuggestion } from "./domain-language.js";
 import type { MatchedCoreFlow } from "./flows.js";
 import type { LocalHistoryReference } from "./history.js";
 import type { CoverageEvidence, TestSuiteInventory, TestSuiteSummary } from "./test-evidence.js";
@@ -100,6 +100,8 @@ export interface E2eDraftFile {
   flowTitle: string;
   runner: E2eRunnerName;
   status: "created" | "skipped";
+  source?: "domain-language" | "core-flow" | "heuristic";
+  stability?: "ready" | "needs-selector" | "needs-setup" | "needs-selector-and-setup";
   todoCount?: number;
   inferredSelectorCount?: number;
   coverageTargetCount?: number;
@@ -175,7 +177,7 @@ export async function generateE2eDraft(rootInput: string, options: E2eDraftOptio
   const plan = await generateE2ePlan(root, options);
   const runner = plan.recommendedRunner.name;
   const outputDirectory = path.resolve(root, options.output ?? defaultDraftOutputDirectory(runner));
-  const flows = plan.flows.length > 0 ? plan.flows : [buildFallbackFlow(plan)];
+  const flows = buildDraftFlows(plan);
 
   await fs.mkdir(outputDirectory, { recursive: true });
 
@@ -189,6 +191,8 @@ export async function generateE2eDraft(rootInput: string, options: E2eDraftOptio
         flowTitle: flow.title,
         runner,
         status: "skipped",
+        source: draftFlowSource(flow),
+        stability: draftStability(plan, flow),
         coverageTargetCount: flow.coverage.length,
         reason: "File already exists. Pass --force to overwrite it.",
       });
@@ -201,6 +205,8 @@ export async function generateE2eDraft(rootInput: string, options: E2eDraftOptio
       flowTitle: flow.title,
       runner,
       status: "created",
+      source: draftFlowSource(flow),
+      stability: draftStability(plan, flow),
       todoCount: countTodos(content),
       inferredSelectorCount: flow.selectors.length,
       coverageTargetCount: flow.coverage.length,
@@ -719,6 +725,11 @@ function toCoreFlowChangedFiles(
 type E2eFlowKind = "ui" | "api" | "state" | "content" | "config" | "domain" | "changed-file";
 type FlowCandidate = Omit<E2eFlow, "coverage" | "coverageEvidence" | "selectors" | "missingTestability"> & {
   kind: E2eFlowKind;
+};
+type DraftFlowSource = "domain-language" | "core-flow" | "heuristic";
+type DraftE2eFlow = E2eFlow & {
+  draftSource?: DraftFlowSource;
+  domainScenario?: DomainScenarioSuggestion;
 };
 
 async function buildFlows(
@@ -1271,6 +1282,104 @@ function dedupeFlows(flows: E2eFlow[]): E2eFlow[] {
   return deduped;
 }
 
+function buildDraftFlows(plan: E2ePlanResult): DraftE2eFlow[] {
+  const baseFlows = plan.flows.length > 0 ? plan.flows : [buildFallbackFlow(plan)];
+  const scenarioFlows = plan.domainLanguage.scenarios
+    .filter((scenario) => scenario.files.length > 0 || scenario.source === "core-flow")
+    .slice(0, 4)
+    .map((scenario) => buildDomainScenarioDraftFlow(plan, scenario, baseFlows));
+
+  if (scenarioFlows.length === 0) {
+    return baseFlows.map((flow) => ({
+      ...flow,
+      draftSource: "heuristic",
+    }));
+  }
+
+  const combined = dedupeFlows([...scenarioFlows, ...baseFlows]).slice(0, 4);
+  return combined.map((flow) => ({
+    ...flow,
+    draftSource: draftFlowSource(flow),
+  }));
+}
+
+function buildDomainScenarioDraftFlow(
+  plan: E2ePlanResult,
+  scenario: DomainScenarioSuggestion,
+  baseFlows: E2eFlow[],
+): DraftE2eFlow {
+  const baseFlow = bestBaseFlowForScenario(scenario, baseFlows);
+  const files = uniqueStrings(scenario.files.length > 0 ? scenario.files : (baseFlow?.files ?? [])).slice(0, 20);
+  const coverage = baseFlow?.coverage ?? buildCoverageTargets("domain", files, plan.recommendedRunner.name);
+  return {
+    title: scenario.title,
+    reason: scenario.intent,
+    files,
+    steps: scenario.checks.length > 0 ? scenario.checks : (baseFlow?.steps ?? []),
+    coverage,
+    coverageEvidence: baseFlow?.coverageEvidence ?? [],
+    selectors: baseFlow?.selectors ?? [],
+    missingTestability: baseFlow?.missingTestability ?? [],
+    draftSource: scenario.source === "core-flow" ? "core-flow" : "domain-language",
+    domainScenario: scenario,
+  };
+}
+
+function bestBaseFlowForScenario(
+  scenario: DomainScenarioSuggestion,
+  baseFlows: E2eFlow[],
+): E2eFlow | undefined {
+  let best: { flow: E2eFlow; score: number } | undefined;
+  for (const flow of baseFlows) {
+    const score = fileOverlapScore(scenario.files, flow.files);
+    if (!best || score > best.score) {
+      best = { flow, score };
+    }
+  }
+  return best && best.score > 0 ? best.flow : baseFlows[0];
+}
+
+function fileOverlapScore(leftFiles: string[], rightFiles: string[]): number {
+  let score = 0;
+  for (const left of leftFiles) {
+    for (const right of rightFiles) {
+      if (left === right || left.endsWith(`/${right}`) || right.endsWith(`/${left}`)) {
+        score += 3;
+      } else if (path.dirname(left) === path.dirname(right)) {
+        score += 1;
+      }
+    }
+  }
+  return score;
+}
+
+function draftFlowSource(flow: E2eFlow): DraftFlowSource {
+  const draftFlow = flow as DraftE2eFlow;
+  return draftFlow.draftSource ?? "heuristic";
+}
+
+function domainScenarioForFlow(flow: E2eFlow): DomainScenarioSuggestion | undefined {
+  return (flow as DraftE2eFlow).domainScenario;
+}
+
+function draftStability(
+  plan: E2ePlanResult,
+  flow: E2eFlow,
+): "ready" | "needs-selector" | "needs-setup" | "needs-selector-and-setup" {
+  const needsSelector = flow.missingTestability.length > 0;
+  const needsSetup = plan.missingTestability.some((gap) => /No \.maestro|No Playwright config/i.test(gap));
+  if (needsSelector && needsSetup) {
+    return "needs-selector-and-setup";
+  }
+  if (needsSelector) {
+    return "needs-selector";
+  }
+  if (needsSetup) {
+    return "needs-setup";
+  }
+  return "ready";
+}
+
 function buildFallbackFlow(plan: E2ePlanResult): E2eFlow {
   const coverage = buildCoverageTargets("changed-file", [], plan.recommendedRunner.name);
   return {
@@ -1330,8 +1439,13 @@ function draftContentForFlow(plan: E2ePlanResult, flow: E2eFlow, runner: E2eRunn
 function buildMaestroDraft(plan: E2ePlanResult, flow: E2eFlow): string {
   const lines: string[] = [];
   const selectorQueue = [...flow.selectors];
+  const scenario = domainScenarioForFlow(flow);
   lines.push(`# Generated by CodeWard ${VERSION}`);
   lines.push(`# Flow: ${flow.title}`);
+  if (scenario) {
+    lines.push(`# Domain scenario: ${scenario.title}`);
+    lines.push(`# Intent: ${scenario.intent}`);
+  }
   lines.push(`# Base: ${plan.base}`);
   lines.push(`# Head: ${plan.head}`);
   lines.push("# Replace ${APP_ID} with the app id or export APP_ID before running Maestro.");
@@ -1343,6 +1457,7 @@ function buildMaestroDraft(plan: E2ePlanResult, flow: E2eFlow): string {
     const command = maestroCommandForStep(step, selectorQueue);
     lines.push(...formatMaestroCommand(command));
   }
+  appendDomainScenarioComments(lines, flow, "#");
   appendMaestroCoverageComments(lines, flow);
   if (flow.missingTestability.length > 0) {
     lines.push("");
@@ -1395,11 +1510,16 @@ function maestroCommandForStep(
 function buildPlaywrightDraft(plan: E2ePlanResult, flow: E2eFlow): string {
   const testName = flow.title.replaceAll('"', "'");
   const selectorQueue = [...flow.selectors];
+  const scenario = domainScenarioForFlow(flow);
   const lines: string[] = [];
   lines.push(`// Generated by CodeWard ${VERSION}`);
   lines.push(`// Base: ${plan.base}`);
   lines.push(`// Head: ${plan.head}`);
   lines.push(`// Flow: ${flow.title}`);
+  if (scenario) {
+    lines.push(`// Domain scenario: ${scenario.title}`);
+    lines.push(`// Intent: ${scenario.intent}`);
+  }
   lines.push("");
   lines.push('import { expect, test } from "@playwright/test";');
   lines.push("");
@@ -1415,6 +1535,7 @@ function buildPlaywrightDraft(plan: E2ePlanResult, flow: E2eFlow): string {
       lines.push(`  await ${locator}.click();`);
     }
   }
+  appendDomainScenarioComments(lines, flow, "  //");
   appendPlaywrightCoverageComments(lines, flow);
   lines.push("});");
   if (flow.missingTestability.length > 0) {
@@ -1443,10 +1564,17 @@ function buildPlaywrightDraft(plan: E2ePlanResult, flow: E2eFlow): string {
 }
 
 function buildManualDraft(plan: E2ePlanResult, flow: E2eFlow): string {
+  const scenario = domainScenarioForFlow(flow);
   const lines: string[] = [];
   lines.push(`# ${flow.title}`);
   lines.push("");
   lines.push(`Generated by CodeWard ${VERSION}.`);
+  if (scenario) {
+    lines.push("");
+    lines.push(`Domain scenario: ${scenario.title}`);
+    lines.push("");
+    lines.push(scenario.intent);
+  }
   lines.push("");
   lines.push(`- Base: \`${plan.base}\``);
   lines.push(`- Head: \`${plan.head}\``);
@@ -1455,6 +1583,18 @@ function buildManualDraft(plan: E2ePlanResult, flow: E2eFlow): string {
   lines.push("");
   for (const step of flow.steps) {
     lines.push(`- [ ] ${step}`);
+  }
+  if (scenario) {
+    lines.push("");
+    lines.push("## Scenario Checks");
+    lines.push("");
+    if (sameStringList(scenario.checks, flow.steps)) {
+      lines.push("The scenario checks are already used as the draft steps above.");
+    } else {
+      for (const check of scenario.checks) {
+        lines.push(`- [ ] ${check}`);
+      }
+    }
   }
   if (flow.coverage.length > 0) {
     lines.push("");
@@ -1501,6 +1641,18 @@ function appendMaestroCoverageComments(lines: string[], flow: E2eFlow): void {
   }
 }
 
+function appendDomainScenarioComments(lines: string[], flow: E2eFlow, commentPrefix: string): void {
+  const scenario = domainScenarioForFlow(flow);
+  if (!scenario || scenario.checks.length === 0) {
+    return;
+  }
+  lines.push("");
+  lines.push(`${commentPrefix} Domain scenario checks:`);
+  for (const check of scenario.checks) {
+    lines.push(`${commentPrefix} - [ ] ${check}`);
+  }
+}
+
 function appendPlaywrightCoverageComments(lines: string[], flow: E2eFlow): void {
   if (flow.coverage.length === 0) {
     return;
@@ -1513,6 +1665,10 @@ function appendPlaywrightCoverageComments(lines: string[], flow: E2eFlow): void 
       lines.push(`  //   - [ ] ${check}`);
     }
   }
+}
+
+function sameStringList(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
 function buildDraftNextSteps(plan: E2ePlanResult, runner: E2eRunnerName): string[] {
@@ -1536,6 +1692,12 @@ function buildDraftNextSteps(plan: E2ePlanResult, runner: E2eRunnerName): string
 
 function formatDraftFileQuality(file: E2eDraftFile): string | undefined {
   const details: string[] = [];
+  if (file.source !== undefined) {
+    details.push(file.source);
+  }
+  if (file.stability !== undefined) {
+    details.push(file.stability);
+  }
   if (file.todoCount !== undefined) {
     details.push(`${file.todoCount} TODO${file.todoCount === 1 ? "" : "s"}`);
   }

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -478,7 +478,9 @@ test("generateE2ePlan recommends mobile flows for Expo changes", async () => {
   const draft = await generateE2eDraft(root, { base: "main", head: "HEAD", output: ".maestro" });
   const draftMarkdown = formatMarkdownE2eDraft(draft);
   const uiFlow = plan.flows.find((flow) => flow.title.endsWith("UI smoke flow"));
-  const uiDraftFile = draft.files.find((file) => file.flowTitle === uiFlow?.title);
+  const uiDraftFile = draft.files.find(
+    (file) => file.source === "domain-language" && file.inferredSelectorCount !== undefined && file.inferredSelectorCount > 0,
+  );
   assert.ok(uiFlow);
   assert.ok(uiDraftFile);
   const uiDraft = await readFile(path.join(root, uiDraftFile.path), "utf8");
@@ -530,7 +532,8 @@ test("generateE2ePlan recommends mobile flows for Expo changes", async () => {
   assert.match(markdown, /Recommended runner: Maestro/);
   assert.match(markdown, /Coverage targets:/);
   assert.equal(draft.runner, "maestro");
-  assert.ok(draft.files.some((file) => file.flowTitle === uiFlow.title));
+  assert.ok(draft.files.some((file) => file.source === "domain-language"));
+  assert.ok(draft.files.some((file) => file.stability === "needs-setup" || file.stability === "needs-selector-and-setup"));
   assert.ok(draft.files.every((file) => file.status === "created"));
   assert.ok(draft.files.some((file) => file.todoCount !== undefined && file.todoCount > 0));
   assert.ok(draft.files.some((file) => file.inferredSelectorCount !== undefined && file.inferredSelectorCount > 0));
@@ -542,7 +545,9 @@ test("generateE2ePlan recommends mobile flows for Expo changes", async () => {
   assert.match(draftMarkdown, /inferred selector/);
   assert.match(draftMarkdown, /coverage targets/);
   assert.match(uiDraft, /appId: \$\{APP_ID\}/);
-  assert.match(uiDraft, new RegExp(`Flow: ${uiFlow.title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  assert.match(uiDraft, new RegExp(`Flow: ${uiDraftFile.flowTitle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  assert.match(uiDraft, /Domain scenario:/);
+  assert.match(uiDraft, /Domain scenario checks:/);
   assert.match(uiDraft, /tapOn: \{ id: "ink-save-button" \}/);
   assert.match(uiDraft, /record-mode-ink/);
   assert.match(uiDraft, /Coverage matrix/);
@@ -550,7 +555,7 @@ test("generateE2ePlan recommends mobile flows for Expo changes", async () => {
   assert.match(uiDraft, /TODO:/);
   assert.equal(cliPlan.recommendedRunner.name, "maestro");
   assert.equal(cliDraft.runner, "maestro");
-  assert.ok(cliDraft.files.some((file) => file.flowTitle === uiFlow.title));
+  assert.ok(cliDraft.files.some((file) => file.source === "domain-language"));
 });
 
 test("generateE2ePlan keeps service changes generic and avoids fixture-specific names", async () => {
@@ -754,15 +759,20 @@ test("generateE2eDraft uses web selectors in Playwright specs", async () => {
     output: "tests/e2e",
     runner: "playwright",
   });
-  const spec = await readFile(path.join(root, "tests/e2e/checkout-ui-smoke-flow.spec.ts"), "utf8");
+  const draftFile = draft.files.find((file) => file.flowTitle === "Checkout primary journey");
+  assert.ok(draftFile);
+  const spec = await readFile(path.join(root, draftFile.path), "utf8");
 
   assert.equal(draft.runner, "playwright");
+  assert.equal(draftFile.source, "domain-language");
   assert.equal(draft.plan.testSuite.hasTestSuite, false);
   assert.equal(
     draft.plan.flows[0].coverageEvidence.find((evidence) => evidence.targetTitle === "Primary success path")?.status,
     "missing",
   );
-  assert.ok(draft.files.some((file) => file.path === "tests/e2e/checkout-ui-smoke-flow.spec.ts"));
+  assert.ok(draft.files.some((file) => file.path === "tests/e2e/checkout-primary-journey.spec.ts"));
+  assert.match(spec, /test\("Checkout primary journey"/);
+  assert.match(spec, /Domain scenario:/);
   assert.match(spec, /page\.getByTestId\("checkout-submit"\)/);
   assert.match(spec, /Coverage matrix/);
   assert.match(spec, /Browser viewport regression/);
@@ -873,6 +883,50 @@ test("generateE2ePlan suggests domain language from changed paths without core f
   assert.ok(plan.domainLanguage.scenarios.some((scenario) => scenario.title === "In App Purchase primary journey"));
   assert.match(markdown, /Suggested terms:/);
   assert.match(markdown, /In App Purchase primary journey/);
+});
+
+test("generateE2ePlan prefers product domains over structural route folders", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src/app/navigations"), { recursive: true });
+  await mkdir(path.join(root, "src/features/membership/components"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      scripts: {
+        test: "node --test",
+      },
+    }),
+  );
+  await writeFile(
+    path.join(root, "src/app/navigations/MembershipScreen.tsx"),
+    "export function MembershipScreen() { return null; }\n",
+  );
+  await writeFile(
+    path.join(root, "src/features/membership/components/MembershipOverviewScreen.tsx"),
+    "export function MembershipOverviewScreen() { return null; }\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/membership"]);
+  await writeFile(
+    path.join(root, "src/app/navigations/MembershipScreen.tsx"),
+    "export function MembershipScreen() { return <Text>Membership</Text>; }\n",
+  );
+  await writeFile(
+    path.join(root, "src/features/membership/components/MembershipOverviewScreen.tsx"),
+    "export function MembershipOverviewScreen() { return <Text>Membership overview</Text>; }\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "update membership"]);
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+
+  assert.equal(plan.domainLanguage.scenarios[0].title, "Membership primary journey");
+  assert.ok(plan.domainLanguage.terms.some((term) => term.term === "Membership" && term.confidence === "high"));
+  assert.ok(!plan.domainLanguage.terms.some((term) => term.term === "Navigations"));
 });
 
 test("generateE2ePlan matches workspace core flows for package scans", async () => {


### PR DESCRIPTION
## Summary
- Promote domain-language scenarios into generated E2E draft filenames, flow titles, and draft metadata.
- Add source/stability metadata so reviewers can see whether a draft came from domain language, core flows, or heuristics.
- Include domain scenario intent/check comments in Maestro, Playwright, and manual drafts.
- Prefer product/domain path terms over structural route folders such as app/navigations.

## Validation
- pnpm test
- pnpm scan
- git diff --check
- Smoke generated drafts in /tmp for inpock-app-client and inpock-frontend/services/offer, then cleaned them up.

## Smoke notes
- inpock-app-client against origin/feat/native-in-app-purchase suggested Membership and In App Purchase Maestro drafts.
- inpock-frontend/services/offer with workspaceRoot had no scoped offer changes and correctly fell back to an app launch smoke draft.