### PR TITLE
Feat: add context briefs to E2E drafts

### DIFF
--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -1865,6 +1865,7 @@ function buildMaestroDraft(plan: E2ePlanResult, flow: E2eFlow): string {
   }
   lines.push(`# Base: ${plan.base}`);
   lines.push(`# Head: ${plan.head}`);
+  appendDraftBriefComments(lines, flow, "maestro", "#");
   lines.push("# Replace ${APP_ID} with the app id or export APP_ID before running Maestro.");
   lines.push("");
   lines.push("appId: ${APP_ID}");
@@ -1939,6 +1940,7 @@ function buildPlaywrightDraft(plan: E2ePlanResult, flow: E2eFlow): string {
     lines.push(`// Domain scenario: ${scenario.title}`);
     lines.push(`// Intent: ${scenario.intent}`);
   }
+  appendDraftBriefComments(lines, flow, "playwright", "//");
   lines.push("");
   lines.push('import { expect, test } from "@playwright/test";');
   lines.push("");
@@ -2010,6 +2012,8 @@ function buildManualDraft(plan: E2ePlanResult, flow: E2eFlow): string {
   lines.push("");
   lines.push(`- Base: \`${plan.base}\``);
   lines.push(`- Head: \`${plan.head}\``);
+  lines.push("");
+  appendManualDraftBrief(lines, flow, "manual");
   lines.push("");
   lines.push("## Steps");
   lines.push("");
@@ -2109,6 +2113,118 @@ function appendSetupHints(lines: string[], flow: E2eFlow, commentPrefix: string)
   for (const hint of flow.setupHints.slice(0, maxFilesPerFlow)) {
     lines.push(`${commentPrefix} - ${formatSetupHint(hint)}`);
   }
+}
+
+interface DraftBrief {
+  changedBehavior: string;
+  whyThisFlowMatters: string;
+  humanFixtureInputs: string[];
+}
+
+function appendDraftBriefComments(
+  lines: string[],
+  flow: E2eFlow,
+  runner: E2eRunnerName,
+  commentPrefix: string,
+): void {
+  const brief = buildDraftBrief(flow, runner);
+  lines.push(`${commentPrefix} Draft brief:`);
+  lines.push(`${commentPrefix} - Changed behavior: ${brief.changedBehavior}`);
+  lines.push(`${commentPrefix} - Why this flow matters: ${brief.whyThisFlowMatters}`);
+  lines.push(`${commentPrefix} - Human fixture inputs:`);
+  for (const input of brief.humanFixtureInputs) {
+    lines.push(`${commentPrefix}   - ${input}`);
+  }
+}
+
+function appendManualDraftBrief(lines: string[], flow: E2eFlow, runner: E2eRunnerName): void {
+  const brief = buildDraftBrief(flow, runner);
+  lines.push("## Draft Brief");
+  lines.push("");
+  lines.push(`- Changed behavior: ${brief.changedBehavior}`);
+  lines.push(`- Why this flow matters: ${brief.whyThisFlowMatters}`);
+  lines.push("- Human fixture inputs:");
+  for (const input of brief.humanFixtureInputs) {
+    lines.push(`  - ${input}`);
+  }
+}
+
+function buildDraftBrief(flow: E2eFlow, runner: E2eRunnerName): DraftBrief {
+  const scenario = domainScenarioForFlow(flow);
+  const changedBehavior = flow.files.length > 0
+    ? `${flow.reason} Changed files include ${formatFileSummary(flow.files)}.`
+    : flow.reason;
+  const criticalCoverage = flow.coverage.filter((target) => target.priority === "critical").map((target) => target.title);
+  const whyThisFlowMatters = scenario
+    ? `It uses "${scenario.title}" as the team-facing behavior name and protects ${formatHumanList(criticalCoverage)}.`
+    : `It protects ${formatHumanList(criticalCoverage)} for the changed surface.`;
+
+  return {
+    changedBehavior,
+    whyThisFlowMatters,
+    humanFixtureInputs: buildHumanFixtureInputs(flow, runner),
+  };
+}
+
+function buildHumanFixtureInputs(flow: E2eFlow, runner: E2eRunnerName): string[] {
+  const inputs: string[] = [];
+  if (runner === "maestro") {
+    inputs.push("Set APP_ID to the target app id or export it before running the flow.");
+  }
+  if (runner === "playwright") {
+    const route = primaryRouteEntrypoint(flow)?.value;
+    const routeDraft = route ? buildPlaywrightRouteDraft(route) : undefined;
+    for (const param of routeDraft?.params ?? []) {
+      inputs.push(`Replace route param ${param.name} with a real fixture value for ${route}.`);
+    }
+  }
+  for (const hint of flow.setupHints) {
+    inputs.push(humanFixtureInputForSetupHint(hint));
+  }
+  if (flow.missingTestability.length > 0) {
+    inputs.push("Replace placeholder selectors with stable test ids, accessibility labels, roles, or visible copy from the app.");
+  }
+  if (inputs.length === 0) {
+    inputs.push("Use realistic data for the primary success path and one blocked, empty, or failed path.");
+  }
+  return uniqueStrings(inputs).slice(0, 6);
+}
+
+function humanFixtureInputForSetupHint(hint: E2eSetupHint): string {
+  switch (hint.kind) {
+    case "auth":
+      return "Prepare logged-in, anonymous, expired-session, and permission-denied identities.";
+    case "network":
+      return "Seed or mock success, empty, unauthorized, timeout, and server-error responses.";
+    case "fixture":
+      return "Prepare deterministic success data plus one blocked or empty fixture.";
+    case "environment":
+      return "Set required env vars, feature flags, build variant, or dependency mode.";
+    case "payment":
+      return "Use sandbox or simulated payment responses for success, cancellation, declined, and already-owned cases.";
+    case "state":
+      return "Reset persisted storage, cache, and provider state before each run.";
+  }
+}
+
+function formatFileSummary(files: string[]): string {
+  const visibleFiles = files.slice(0, 3);
+  const suffix = files.length > visibleFiles.length ? ` and ${files.length - visibleFiles.length} more` : "";
+  return `${visibleFiles.join(", ")}${suffix}`;
+}
+
+function formatHumanList(values: string[]): string {
+  const visibleValues = values.length > 0 ? values.slice(0, 3) : ["the primary success path"];
+  if (values.length > visibleValues.length) {
+    visibleValues.push(`${values.length - visibleValues.length} more coverage target${values.length - visibleValues.length === 1 ? "" : "s"}`);
+  }
+  if (visibleValues.length === 1) {
+    return visibleValues[0];
+  }
+  if (visibleValues.length === 2) {
+    return `${visibleValues[0]} and ${visibleValues[1]}`;
+  }
+  return `${visibleValues.slice(0, -1).join(", ")}, and ${visibleValues.at(-1)}`;
 }
 
 function appendDomainScenarioComments(lines: string[], flow: E2eFlow, commentPrefix: string): void {

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -548,6 +548,11 @@ test("generateE2ePlan recommends mobile flows for Expo changes", async () => {
   assert.match(uiDraft, /appId: \$\{APP_ID\}/);
   assert.match(uiDraft, new RegExp(`Flow: ${uiDraftFile.flowTitle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
   assert.match(uiDraft, /Domain scenario:/);
+  assert.match(uiDraft, /Draft brief:/);
+  assert.match(uiDraft, /Changed behavior:/);
+  assert.match(uiDraft, /Why this flow matters:/);
+  assert.match(uiDraft, /Human fixture inputs:/);
+  assert.match(uiDraft, /Set APP_ID to the target app id/);
   assert.match(uiDraft, /Domain scenario checks:/);
   assert.match(uiDraft, /Entrypoint hints:/);
   assert.match(uiDraft, /screen (?:Record Mode Sheet|Ink Drawing)/);
@@ -607,6 +612,16 @@ test("generateE2ePlan keeps service changes generic and avoids fixture-specific 
     ),
   );
   assert.equal(titles.some((title) => /Ink drawing|Record mode|Saved entry|Localized visual/i.test(title)), false);
+
+  const draft = await generateE2eDraft(root, { base: "main", head: "HEAD", output: "docs/e2e" });
+  const manualDraftFile = draft.files.find((file) => file.path.endsWith(".md"));
+  assert.ok(manualDraftFile);
+  const manualDraft = await readFile(path.join(root, manualDraftFile.path), "utf8");
+  assert.match(manualDraft, /## Draft Brief/);
+  assert.match(manualDraft, /Changed behavior:/);
+  assert.match(manualDraft, /Why this flow matters:/);
+  assert.match(manualDraft, /Human fixture inputs:/);
+  assert.match(manualDraft, /Seed or mock success, empty, unauthorized, timeout, and server-error responses/);
 });
 
 test("generateE2eDraft scopes entrypoint hints to each domain scenario", async () => {
@@ -879,6 +894,11 @@ test("generateE2eDraft uses web selectors in Playwright specs", async () => {
   assert.match(draftFile.primaryEntrypoint ?? "", /route \/checkout/);
   assert.match(spec, /test\("Checkout primary journey"/);
   assert.match(spec, /Domain scenario:/);
+  assert.match(spec, /Draft brief:/);
+  assert.match(spec, /Changed behavior:/);
+  assert.match(spec, /Why this flow matters:/);
+  assert.match(spec, /Human fixture inputs:/);
+  assert.match(spec, /Seed or mock success, empty, unauthorized, timeout, and server-error responses/);
   assert.match(spec, /Entrypoint hints:/);
   assert.match(spec, /Setup hints:/);
   assert.match(spec, /Network response setup/);
@@ -937,6 +957,7 @@ test("generateE2eDraft normalizes dynamic routes without creating id domain scen
   assert.match(spec, /route \/public \[medium\]/);
   assert.match(spec, /const routeParams = \{/);
   assert.match(spec, /id: "TODO-id"/);
+  assert.match(spec, /Replace route param id with a real fixture value for \/campaign\/official\/:id/);
   assert.match(spec, /page\.goto\(`\/campaign\/official\/\$\{routeParams\.id\}`\)/);
   assert.doesNotMatch(spec, /page\.goto\("\/campaign\/official\/:id"\)/);
 });


### PR DESCRIPTION
## Summary

- Add a `Draft brief` block to Playwright, Maestro, and manual E2E draft outputs.
- Summarize changed behavior, why the flow matters, and the human fixture inputs needed before making a draft required.
- Derive fixture guidance from existing route params, setup hints, runner requirements, and testability gaps.

## Validation

- `pnpm test` (43 tests passed)
- `git diff --check`
- `pnpm scan` (0 findings)
- Smoke-tested `e2e draft` against `/Users/khs/Desktop/inpock-frontend/services/offer`; generated Playwright draft now includes a top-level `Draft brief` with changed behavior, coverage value, and fixture inputs.
- Smoke-tested `e2e draft` against `/Users/khs/Desktop/inpock-app-client`; generated Maestro drafts now include `Draft brief` with APP_ID, network, fixture, state, environment, and selector preparation guidance.
