### PR TITLE
Feat: honor core flow routes in E2E drafts

### DIFF
--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -520,6 +520,13 @@ export function formatMarkdownE2ePlan(result: E2ePlanResult): string {
           lines.push(`- ${escapeMarkdownInline(check)}`);
         }
       }
+      if (flow.routes.length > 0) {
+        lines.push("");
+        lines.push("Declared routes:");
+        for (const route of flow.routes) {
+          lines.push(`- \`${escapeMarkdownInline(route)}\``);
+        }
+      }
       lines.push("");
     }
   }
@@ -777,6 +784,7 @@ type DraftFlowSource = "domain-language" | "core-flow" | "heuristic";
 type DraftE2eFlow = E2eFlow & {
   draftSource?: DraftFlowSource;
   domainScenario?: DomainScenarioSuggestion;
+  coreFlow?: MatchedCoreFlow;
 };
 
 async function buildFlows(
@@ -1687,11 +1695,14 @@ async function buildDomainScenarioDraftFlow(
   scenario: DomainScenarioSuggestion,
   baseFlows: E2eFlow[],
 ): Promise<DraftE2eFlow> {
+  const coreFlow = matchedCoreFlowForScenario(plan, scenario);
   const baseFlow = bestBaseFlowForScenario(scenario, baseFlows);
-  const files = uniqueStrings(scenario.files.length > 0 ? scenario.files : (baseFlow?.files ?? [])).slice(0, 20);
+  const scenarioFiles = normalizeScenarioFilesForRoot(plan, scenario.files);
+  const files = uniqueStrings(scenarioFiles.length > 0 ? scenarioFiles : (baseFlow?.files ?? [])).slice(0, 20);
   const coverage = baseFlow?.coverage ?? buildCoverageTargets("domain", files, plan.recommendedRunner.name);
   const runner = plan.recommendedRunner.name;
   const entrypoints = uniqueEntrypoints([
+    ...coreFlowEntrypoints(plan, coreFlow, runner),
     ...filterEntrypointsForFiles(baseFlows.flatMap((flow) => flow.entrypoints), files),
     ...(await inferFlowEntrypoints(plan.root, files, runner)),
   ]);
@@ -1716,7 +1727,53 @@ async function buildDomainScenarioDraftFlow(
     missingTestability: await findFlowTestabilityGaps(plan.root, files, runner),
     draftSource: scenario.source === "core-flow" ? "core-flow" : "domain-language",
     domainScenario: scenario,
+    coreFlow,
   };
+}
+
+function matchedCoreFlowForScenario(
+  plan: E2ePlanResult,
+  scenario: DomainScenarioSuggestion,
+): MatchedCoreFlow | undefined {
+  if (scenario.source !== "core-flow") {
+    return undefined;
+  }
+  return plan.coreFlows.find((flow) => flow.name === scenario.title);
+}
+
+function normalizeScenarioFilesForRoot(plan: E2ePlanResult, files: string[]): string[] {
+  if (!plan.workspaceRoot) {
+    return files;
+  }
+  const packagePathFromWorkspace = toPosixPath(path.relative(plan.workspaceRoot, plan.root));
+  if (!packagePathFromWorkspace || packagePathFromWorkspace.startsWith("..") || path.isAbsolute(packagePathFromWorkspace)) {
+    return files;
+  }
+  return files.map((file) =>
+    file === packagePathFromWorkspace || file.startsWith(`${packagePathFromWorkspace}/`)
+      ? file.slice(packagePathFromWorkspace.length).replace(/^\/+/, "")
+      : file,
+  );
+}
+
+function coreFlowEntrypoints(
+  plan: E2ePlanResult,
+  coreFlow: MatchedCoreFlow | undefined,
+  runner: E2eRunnerName,
+): E2eEntrypoint[] {
+  if (!coreFlow || runner === "maestro") {
+    return [];
+  }
+  const manifestPath = plan.coreFlowManifestPath ?? ".codeward/flows.yml";
+  return coreFlow.routes
+    .map((route) => normalizeEntrypointRoute(route))
+    .filter((route): route is string => Boolean(route))
+    .map((route) => ({
+      kind: "route",
+      value: route,
+      file: manifestPath,
+      confidence: "high",
+    }));
 }
 
 function filterEntrypointsForFiles(entrypoints: E2eEntrypoint[], files: string[]): E2eEntrypoint[] {
@@ -2151,13 +2208,21 @@ function appendManualDraftBrief(lines: string[], flow: E2eFlow, runner: E2eRunne
 
 function buildDraftBrief(flow: E2eFlow, runner: E2eRunnerName): DraftBrief {
   const scenario = domainScenarioForFlow(flow);
+  const coreFlow = coreFlowForDraftFlow(flow);
   const changedBehavior = flow.files.length > 0
     ? `${flow.reason} Changed files include ${formatFileSummary(flow.files)}.`
     : flow.reason;
   const criticalCoverage = flow.coverage.filter((target) => target.priority === "critical").map((target) => target.title);
-  const whyThisFlowMatters = scenario
-    ? `It uses "${scenario.title}" as the team-facing behavior name and protects ${formatHumanList(criticalCoverage)}.`
-    : `It protects ${formatHumanList(criticalCoverage)} for the changed surface.`;
+  let whyThisFlowMatters: string;
+  if (coreFlow) {
+    whyThisFlowMatters =
+      `Core flow: ${coreFlow.id} [${coreFlow.priority}]. It protects the team-approved "${coreFlow.name}" flow and ${formatHumanList(criticalCoverage)}.`;
+  } else if (scenario) {
+    whyThisFlowMatters =
+      `It uses "${scenario.title}" as the team-facing behavior name and protects ${formatHumanList(criticalCoverage)}.`;
+  } else {
+    whyThisFlowMatters = `It protects ${formatHumanList(criticalCoverage)} for the changed surface.`;
+  }
 
   return {
     changedBehavior,
@@ -2168,6 +2233,10 @@ function buildDraftBrief(flow: E2eFlow, runner: E2eRunnerName): DraftBrief {
 
 function buildHumanFixtureInputs(flow: E2eFlow, runner: E2eRunnerName): string[] {
   const inputs: string[] = [];
+  const coreFlow = coreFlowForDraftFlow(flow);
+  if (coreFlow?.checks.length) {
+    inputs.push(`Keep manifest checks required: ${formatHumanList(coreFlow.checks.slice(0, 3))}.`);
+  }
   if (runner === "maestro") {
     inputs.push("Set APP_ID to the target app id or export it before running the flow.");
   }
@@ -2188,6 +2257,10 @@ function buildHumanFixtureInputs(flow: E2eFlow, runner: E2eRunnerName): string[]
     inputs.push("Use realistic data for the primary success path and one blocked, empty, or failed path.");
   }
   return uniqueStrings(inputs).slice(0, 6);
+}
+
+function coreFlowForDraftFlow(flow: E2eFlow): MatchedCoreFlow | undefined {
+  return (flow as DraftE2eFlow).coreFlow;
 }
 
 function humanFixtureInputForSetupHint(hint: E2eSetupHint): string {

--- a/src/flows.ts
+++ b/src/flows.ts
@@ -33,6 +33,7 @@ export interface MatchedCoreFlow {
   reason: string;
   matchedFiles: string[];
   matchedSignals: string[];
+  routes: string[];
   checks: string[];
 }
 
@@ -145,6 +146,7 @@ function matchCoreFlow(flow: CoreFlowDefinition, changedFiles: string[]): Matche
     reason: `Changed files match ${signals.slice(0, 4).join(", ")} for this declared core flow.`,
     matchedFiles: [...matchedFiles].slice(0, 20),
     matchedSignals: signals.slice(0, 12),
+    routes: flow.routes.slice(0, 10),
     checks: flow.checks.slice(0, 10),
   };
 }

--- a/src/history.ts
+++ b/src/history.ts
@@ -54,6 +54,7 @@ export interface E2ePlanHistorySnapshot {
       priority: string;
       matchedFiles: string[];
       matchedSignals: string[];
+      routes: string[];
     }>;
     domainLanguage: {
       terms: Array<{
@@ -180,6 +181,7 @@ function buildE2ePlanHistorySnapshot(historyRoot: string, plan: E2ePlanResult): 
         priority: flow.priority,
         matchedFiles: flow.matchedFiles.slice(0, 10),
         matchedSignals: flow.matchedSignals.slice(0, 10),
+        routes: flow.routes.slice(0, 10),
       })),
       domainLanguage: {
         terms: plan.domainLanguage.terms.slice(0, 12).map((term) => ({

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -1021,6 +1021,7 @@ test("generateE2ePlan matches committed core flow definitions", async () => {
   assert.equal(plan.coreFlows[0].id, "checkout-purchase");
   assert.equal(plan.coreFlows[0].priority, "critical");
   assert.ok(plan.coreFlows[0].matchedFiles.includes("src/pages/checkout/CheckoutPage.tsx"));
+  assert.deepEqual(plan.coreFlows[0].routes, ["/checkout"]);
   assert.ok(plan.coreFlows[0].checks.includes("Complete checkout with a valid payment method."));
   assert.ok(plan.domainLanguage.terms.some((term) => term.term === "Checkout purchase" && term.confidence === "high"));
   assert.ok(plan.domainLanguage.scenarios.some((scenario) => scenario.title === "Checkout purchase"));
@@ -1028,6 +1029,24 @@ test("generateE2ePlan matches committed core flow definitions", async () => {
   assert.match(markdown, /## Domain Language/);
   assert.match(markdown, /Checkout purchase/);
   assert.match(markdown, /Human-approved checks:/);
+  assert.match(markdown, /Declared routes:/);
+
+  const draft = await generateE2eDraft(root, {
+    base: "main",
+    head: "HEAD",
+    output: "tests/e2e",
+    runner: "playwright",
+  });
+  const draftFile = draft.files.find((file) => file.flowTitle === "Checkout purchase");
+  assert.ok(draftFile);
+  assert.equal(draftFile.source, "core-flow");
+  assert.match(draftFile.primaryEntrypoint ?? "", /route \/checkout \[high\] \(\.codeward\/flows\.yml\)/);
+  const spec = await readFile(path.join(root, draftFile.path), "utf8");
+  assert.match(spec, /Core flow: checkout-purchase \[critical\]/);
+  assert.match(spec, /Keep manifest checks required: Complete checkout with a valid payment method\. and Verify declined payment recovery\./);
+  assert.match(spec, /route \/checkout \[high\] \(\.codeward\/flows\.yml\)/);
+  assert.match(spec, /page\.goto\("\/checkout"\)/);
+  assert.match(spec, /TODO: Complete checkout with a valid payment method\./);
 });
 
 test("generateE2ePlan suggests domain language from changed paths without core flows", async () => {
@@ -1196,6 +1215,22 @@ test("generateE2ePlan matches workspace core flows for package scans", async () 
   assert.equal(plan.coreFlows[0].id, "offer-submit");
   assert.ok(plan.coreFlows[0].matchedFiles.includes("services/offer/src/features/offer/submit.ts"));
   assert.deepEqual(plan.changedFiles.map((file) => file.path), ["src/features/offer/submit.ts"]);
+
+  const draft = await generateE2eDraft(packageRoot, {
+    base: "main",
+    head: "HEAD",
+    workspaceRoot,
+    output: "docs/e2e",
+  });
+  const draftFile = draft.files.find((file) => file.flowTitle === "Offer submit");
+  assert.ok(draftFile);
+  assert.equal(draftFile.source, "core-flow");
+  const manualDraft = await readFile(path.join(packageRoot, draftFile.path), "utf8");
+  assert.match(manualDraft, /## Draft Brief/);
+  assert.match(manualDraft, /Core flow: offer-submit \[critical\]/);
+  assert.match(manualDraft, /Submit an offer with valid terms\./);
+  assert.match(manualDraft, /src\/features\/offer\/submit\.ts/);
+  assert.doesNotMatch(manualDraft, /services\/offer\/src\/features\/offer\/submit\.ts/);
 });
 
 test("generateE2eDraft creates a fallback smoke draft without changed files", async () => {


### PR DESCRIPTION
## Summary

- Carry declared core flow routes from `.codeward/flows.yml` into matched core flow metadata.
- Use those declared routes as high-confidence Playwright draft entrypoints.
- Preserve core flow id and priority in draft briefs, and keep manifest checks visible as required fixture guidance.
- Normalize workspace-relative core flow matched files back to package-relative paths when generating package-scoped monorepo drafts.
- Record declared core flow routes in local E2E history snapshots.

## Validation

- `pnpm test` (43 tests passed)
- `git diff --check`
- `pnpm scan` (0 findings)
- Smoke-tested `e2e draft` against `/Users/khs/Desktop/inpock-frontend/services/offer`; generated Playwright draft remains valid for a repo without a core flow manifest.
- Smoke-tested `e2e draft` against `/Users/khs/Desktop/inpock-app-client`; generated Maestro drafts remain valid for a repo without a core flow manifest.
