### PR TITLE
Fix: align follow-up docs and branch guidance

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,8 @@ Commit-friendly files:
 
 - `codeward.config.json`
 - `.codeward/flows.yml` when a project chooses to define durable core flows
-- `.codeward/domains.yml` when a project chooses to define durable domain mappings
+
+CodeWard does not currently load a separate domain manifest. Domain language suggestions are derived from committed core flows, changed paths, and selected UI copy until a future domain mapping file is implemented.
 
 Ignored local artifacts:
 

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -2103,6 +2103,7 @@ test("generateAgentContext reflects npm scripts and repository boundaries", asyn
   assert.match(context, /Build command: `npm run build`/);
   assert.match(context, /Do not push directly to `main`/);
   assert.match(context, /Never create or suggest branches with a `codex\/` prefix/);
+  assert.match(context, /Use `feat\/`, `fix\/`, `refactor\/`, `style\/`, `hotfix\/`, `chore\/`, or `docs\/` branch prefixes/);
 });
 
 async function makeTempRepo() {


### PR DESCRIPTION
## Summary
- remove the misleading `.codeward/domains.yml` commit-friendly policy reference because no domain manifest loader exists yet
- document that domain language suggestions currently come from core flows, changed paths, and selected UI copy
- lock the generated agent context to include both the `codex/` prefix ban and the allowed project branch prefixes

## Validation
- `pnpm test`
- `pnpm scan`
- `git diff --check`

## Notes
- Historical PR head names that used `codex/` cannot be rewritten from repository docs or code. The repository now keeps the active guidance and generated agent context aligned on `feat/`, `fix/`, `refactor/`, `style/`, `hotfix/`, `chore/`, and `docs/`.