### PR TITLE
Feat: surface validation gaps in E2E drafts

### DIFF
--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -169,6 +169,9 @@ export interface E2eDraftFile {
   fixtureReadinessStatus?: E2eFixtureReadinessStatus;
   inferredSelectorCount?: number;
   coverageTargetCount?: number;
+  validationStatus?: E2eValidationMatrixStatus;
+  validationGapCount?: number;
+  blockingValidationGapCount?: number;
   reason?: string;
 }
 
@@ -255,6 +258,7 @@ export async function generateE2eDraft(rootInput: string, options: E2eDraftOptio
   for (const flow of flows) {
     const filePath = path.join(outputDirectory, `${slugify(flow.title)}${draftExtension(runner)}`);
     const displayPath = toDisplayPath(root, filePath);
+    const validationSummary = summarizeDraftValidation(flow);
     if ((await exists(filePath)) && !options.force) {
       files.push({
         path: displayPath,
@@ -268,6 +272,9 @@ export async function generateE2eDraft(rootInput: string, options: E2eDraftOptio
         setupHintCount: flow.setupHints.length,
         fixtureReadinessStatus: flow.fixtureReadiness.status,
         coverageTargetCount: flow.coverage.length,
+        validationStatus: validationSummary.status,
+        validationGapCount: validationSummary.gapCount,
+        blockingValidationGapCount: validationSummary.blockingGapCount,
         reason: "File already exists. Pass --force to overwrite it.",
       });
       continue;
@@ -288,6 +295,9 @@ export async function generateE2eDraft(rootInput: string, options: E2eDraftOptio
       fixtureReadinessStatus: flow.fixtureReadiness.status,
       inferredSelectorCount: flow.selectors.length,
       coverageTargetCount: flow.coverage.length,
+      validationStatus: validationSummary.status,
+      validationGapCount: validationSummary.gapCount,
+      blockingValidationGapCount: validationSummary.blockingGapCount,
     });
   }
 
@@ -682,6 +692,28 @@ function validationCategoryRank(category: E2eValidationMatrixCategory): number {
     case "setup":
       return 4;
   }
+}
+
+function validationRowsForDraftFlow(flow: E2eFlow): E2eValidationMatrixRow[] {
+  const coreFlow = coreFlowForDraftFlow(flow);
+  return buildE2eValidationMatrix([flow], coreFlow ? [coreFlow] : []).rows;
+}
+
+function summarizeDraftValidation(flow: E2eFlow): {
+  status: E2eValidationMatrixStatus;
+  gapCount: number;
+  blockingGapCount: number;
+} {
+  const rows = validationRowsForDraftFlow(flow);
+  const blockingGapCount = rows.filter((row) => row.status === "missing").length;
+  const gapCount = rows.filter((row) => row.status !== "ready").length;
+  let status: E2eValidationMatrixStatus = "ready";
+  if (blockingGapCount > 0) {
+    status = "missing";
+  } else if (gapCount > 0) {
+    status = "partial";
+  }
+  return { status, gapCount, blockingGapCount };
 }
 
 export function formatMarkdownE2ePlan(result: E2ePlanResult): string {
@@ -2515,6 +2547,7 @@ function buildMaestroDraft(plan: E2ePlanResult, flow: E2eFlow): string {
   appendEntrypointHints(lines, flow, "#");
   appendSetupHints(lines, flow, "#");
   appendFixtureReadinessHints(lines, flow, "#");
+  appendValidationGapComments(lines, flow, "#");
   for (const step of flow.steps) {
     const command = maestroCommandForStep(step, selectorQueue);
     lines.push(...formatMaestroCommand(command));
@@ -2590,6 +2623,7 @@ function buildPlaywrightDraft(plan: E2ePlanResult, flow: E2eFlow): string {
   appendEntrypointHints(lines, flow, "  //");
   appendSetupHints(lines, flow, "  //");
   appendFixtureReadinessHints(lines, flow, "  //");
+  appendValidationGapComments(lines, flow, "  //");
   const routeEntrypoint = primaryRouteEntrypoint(flow);
   const routeDraft = buildPlaywrightRouteDraft(routeEntrypoint?.value ?? "/");
   if (routeDraft.params.length > 0) {
@@ -2688,6 +2722,7 @@ function buildManualDraft(plan: E2ePlanResult, flow: E2eFlow): string {
       lines.push(`- [ ] ${action}`);
     }
   }
+  appendManualValidationGaps(lines, flow);
   if (scenario) {
     lines.push("");
     lines.push("## Scenario Checks");
@@ -2776,6 +2811,31 @@ function appendFixtureReadinessHints(lines: string[], flow: E2eFlow, commentPref
   lines.push(`${commentPrefix} - ${formatFixtureReadiness(flow.fixtureReadiness)}`);
   for (const action of flow.fixtureReadiness.nextActions.slice(0, 3)) {
     lines.push(`${commentPrefix} - Next: ${action}`);
+  }
+}
+
+function appendValidationGapComments(lines: string[], flow: E2eFlow, commentPrefix: string): void {
+  const rows = validationRowsForDraftFlow(flow).filter((row) => row.status !== "ready");
+  if (rows.length === 0) {
+    return;
+  }
+  lines.push("");
+  lines.push(`${commentPrefix} Validation gaps before this draft can be required:`);
+  for (const row of rows.slice(0, maxFilesPerFlow)) {
+    lines.push(`${commentPrefix} - [${row.status}] ${row.area}: ${row.nextAction}`);
+  }
+}
+
+function appendManualValidationGaps(lines: string[], flow: E2eFlow): void {
+  const rows = validationRowsForDraftFlow(flow).filter((row) => row.status !== "ready");
+  if (rows.length === 0) {
+    return;
+  }
+  lines.push("");
+  lines.push("## Validation Gaps");
+  lines.push("");
+  for (const row of rows.slice(0, maxFilesPerFlow)) {
+    lines.push(`- [ ] [${row.status}] ${row.area} - ${row.nextAction}`);
   }
 }
 
@@ -3049,6 +3109,9 @@ function buildDraftNextSteps(plan: E2ePlanResult, runner: E2eRunnerName): string
   if (plan.missingTestability.length > 0) {
     steps.push("Address the listed testability gaps before treating the generated drafts as stable regression tests.");
   }
+  if (plan.validationMatrix.summary.missing > 0) {
+    steps.push("Resolve missing validation matrix rows before promoting generated drafts to required PR evidence.");
+  }
   return steps;
 }
 
@@ -3078,6 +3141,17 @@ function formatDraftFileQuality(file: E2eDraftFile): string | undefined {
   if (file.coverageTargetCount !== undefined) {
     details.push(
       `${file.coverageTargetCount} coverage target${file.coverageTargetCount === 1 ? "" : "s"}`,
+    );
+  }
+  if (file.validationStatus !== undefined) {
+    details.push(`${file.validationStatus} validation`);
+  }
+  if (file.validationGapCount !== undefined) {
+    details.push(`${file.validationGapCount} validation gap${file.validationGapCount === 1 ? "" : "s"}`);
+  }
+  if (file.blockingValidationGapCount !== undefined && file.blockingValidationGapCount > 0) {
+    details.push(
+      `${file.blockingValidationGapCount} missing validation gap${file.blockingValidationGapCount === 1 ? "" : "s"}`,
     );
   }
   return details.length > 0 ? details.join(", ") : undefined;

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -539,12 +539,15 @@ test("generateE2ePlan recommends mobile flows for Expo changes", async () => {
   assert.ok(draft.files.some((file) => file.todoCount !== undefined && file.todoCount > 0));
   assert.ok(draft.files.some((file) => file.inferredSelectorCount !== undefined && file.inferredSelectorCount > 0));
   assert.ok(draft.files.some((file) => file.coverageTargetCount !== undefined && file.coverageTargetCount > 0));
+  assert.ok(draft.files.some((file) => file.validationStatus === "missing" || file.validationStatus === "partial"));
+  assert.ok(draft.files.some((file) => file.validationGapCount !== undefined && file.validationGapCount > 0));
   assert.ok(skippedDraft.files.some((file) => file.status === "skipped"));
   assert.ok(forcedDraft.files.every((file) => file.status === "created"));
   assert.match(draftMarkdown, /# CodeWard E2E Draft/);
   assert.match(draftMarkdown, /TODOs/);
   assert.match(draftMarkdown, /inferred selector/);
   assert.match(draftMarkdown, /coverage targets/);
+  assert.match(draftMarkdown, /validation gap/);
   assert.match(uiDraft, /appId: \$\{APP_ID\}/);
   assert.match(uiDraft, new RegExp(`Flow: ${uiDraftFile.flowTitle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
   assert.match(uiDraft, /Domain scenario:/);
@@ -560,10 +563,12 @@ test("generateE2ePlan recommends mobile flows for Expo changes", async () => {
   assert.match(uiDraft, /record-mode-ink/);
   assert.match(uiDraft, /Coverage matrix/);
   assert.match(uiDraft, /Loading, empty, error, and success states/);
+  assert.match(uiDraft, /Validation gaps before this draft can be required/);
   assert.match(uiDraft, /TODO:/);
   assert.equal(cliPlan.recommendedRunner.name, "maestro");
   assert.equal(cliDraft.runner, "maestro");
   assert.ok(cliDraft.files.some((file) => file.source === "domain-language"));
+  assert.ok(cliDraft.files.some((file) => file.validationGapCount > 0));
 });
 
 test("generateE2ePlan keeps service changes generic and avoids fixture-specific names", async () => {
@@ -896,9 +901,14 @@ test("generateE2ePlan flags missing mock fixtures for API-dependent UI flows", a
   const draftFile = draft.files.find((file) => file.fixtureReadinessStatus === "missing");
   assert.ok(draftFile);
   assert.equal(draftFile.fixtureReadinessStatus, "missing");
+  assert.equal(draftFile.validationStatus, "missing");
+  assert.ok((draftFile.validationGapCount ?? 0) > 0);
+  assert.ok((draftFile.blockingValidationGapCount ?? 0) > 0);
   const spec = await readFile(path.join(root, draftFile.path), "utf8");
   assert.match(spec, /Fixture\/mock readiness/);
   assert.match(spec, /Add a deterministic mock or fixture response/);
+  assert.match(spec, /Validation gaps before this draft can be required/);
+  assert.match(spec, /\[missing\].*fixture\/mock readiness/);
 });
 
 test("generateE2eDraft uses web selectors in Playwright specs", async () => {
@@ -1113,11 +1123,14 @@ test("generateE2ePlan matches committed core flow definitions", async () => {
   const draftFile = draft.files.find((file) => file.flowTitle === "Checkout purchase");
   assert.ok(draftFile);
   assert.equal(draftFile.source, "core-flow");
+  assert.ok((draftFile.validationGapCount ?? 0) > 0);
   assert.match(draftFile.primaryEntrypoint ?? "", /route \/checkout \[high\] \(\.codeward\/flows\.yml\)/);
   const spec = await readFile(path.join(root, draftFile.path), "utf8");
   assert.match(spec, /Core flow: checkout-purchase \[critical\]/);
   assert.match(spec, /Keep manifest checks required: Complete checkout with a valid payment method\. and Verify declined payment recovery\./);
   assert.match(spec, /route \/checkout \[high\] \(\.codeward\/flows\.yml\)/);
+  assert.match(spec, /Validation gaps before this draft can be required/);
+  assert.match(spec, /\[partial\] Checkout purchase: Make the matched core flow checks required validation evidence/);
   assert.match(spec, /page\.goto\("\/checkout"\)/);
   assert.match(spec, /TODO: Complete checkout with a valid payment method\./);
 });


### PR DESCRIPTION
## Summary
- Add validation status and validation gap counts to generated E2E draft file metadata.
- Insert validation gap comments/sections into Maestro, Playwright, and manual draft outputs.
- Add draft next-step guidance when the validation matrix still has missing rows.

## Why
This continues the QA automation direction: generated drafts should not only create a runnable starting point, but also carry the exact validation evidence still needed before the draft becomes required PR evidence.

## Replaces
- Replaces closed stacked PR #33 after #32 was squash-merged and its stacked base branch was removed.

## Validation
- `pnpm test`
- `pnpm scan`
- `git diff --check origin/main..HEAD`
