### PR TITLE
[codex] polish validation matrix wording

### DIFF
--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -2957,7 +2957,9 @@ function formatFileSummary(files: string[]): string {
 }
 
 function formatHumanList(values: string[]): string {
-  const visibleValues = values.length > 0 ? values.slice(0, 3) : ["the primary success path"];
+  const visibleValues = values.length > 0
+    ? values.slice(0, 3).map(stripTerminalPunctuation)
+    : ["the primary success path"];
   if (values.length > visibleValues.length) {
     visibleValues.push(`${values.length - visibleValues.length} more coverage target${values.length - visibleValues.length === 1 ? "" : "s"}`);
   }
@@ -2968,6 +2970,10 @@ function formatHumanList(values: string[]): string {
     return `${visibleValues[0]} and ${visibleValues[1]}`;
   }
   return `${visibleValues.slice(0, -1).join(", ")}, and ${visibleValues.at(-1)}`;
+}
+
+function stripTerminalPunctuation(value: string): string {
+  return value.replace(/[.!?]+$/g, "");
 }
 
 function appendDomainScenarioComments(lines: string[], flow: E2eFlow, commentPrefix: string): void {

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -1113,6 +1113,7 @@ test("generateE2ePlan matches committed core flow definitions", async () => {
   assert.match(markdown, /Checkout purchase/);
   assert.match(markdown, /Human-approved checks:/);
   assert.match(markdown, /Declared routes:/);
+  assert.doesNotMatch(markdown, /\.\./);
 
   const draft = await generateE2eDraft(root, {
     base: "main",
@@ -1127,7 +1128,7 @@ test("generateE2ePlan matches committed core flow definitions", async () => {
   assert.match(draftFile.primaryEntrypoint ?? "", /route \/checkout \[high\] \(\.codeward\/flows\.yml\)/);
   const spec = await readFile(path.join(root, draftFile.path), "utf8");
   assert.match(spec, /Core flow: checkout-purchase \[critical\]/);
-  assert.match(spec, /Keep manifest checks required: Complete checkout with a valid payment method\. and Verify declined payment recovery\./);
+  assert.match(spec, /Keep manifest checks required: Complete checkout with a valid payment method and Verify declined payment recovery\./);
   assert.match(spec, /route \/checkout \[high\] \(\.codeward\/flows\.yml\)/);
   assert.match(spec, /Validation gaps before this draft can be required/);
   assert.match(spec, /\[partial\] Checkout purchase: Make the matched core flow checks required validation evidence/);


### PR DESCRIPTION
## Summary

- Strip trailing punctuation from items before joining them in human-readable validation matrix sentences.
- Prevent generated E2E plan/draft text from producing doubled punctuation such as `viewport..`.
- Add a regression assertion for the committed core-flow plan output.

## Follow-up Notes

- Synced local `main` with the other session's merged PRs #31, #32, and #34.
- Confirmed the new domain manifest, fixture readiness, validation matrix, and draft validation gap work passes locally.
- Smoke-checked `e2e plan` against `/Users/khs/Desktop/inpock-frontend/services/offer` and verified the validation matrix wording is cleaner.

## Validation

- `pnpm test` (46 tests passed)
- `git diff --check`
- `pnpm scan` (0 findings)
- `codeward e2e plan /Users/khs/Desktop/inpock-frontend/services/offer --workspace-root /Users/khs/Desktop/inpock-frontend --base origin/hotfix/resort-multi-store-campaign --head HEAD --include-working-tree --runner playwright --format markdown`
