### PR TITLE
feat: add e2e bootstrap planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## Unreleased
+
+Working scope for the first public `0.1.0` release.
+
+### Added
+
+- Repository guardrail scanning for AI-agent instructions, MCP config, committed local env files, risky scripts, broad workflow permissions, and API contract source-of-truth gaps.
+- Text, JSON, Markdown, and SARIF reporting.
+- PR-oriented `review`, `eval`, and `verify` commands for branch-aware findings, readiness scoring, validation evidence, and suggested domain tests.
+- GitHub Action entrypoint with annotations, step summary, and PR comment output.
+- Validation command discovery for JavaScript/TypeScript, Python, Go, Rust, Gradle, and Maven projects.
+- E2E planning and draft generation for Playwright, Maestro, and manual checklists.
+- Bootstrap planning for projects with little or no E2E history, including required runner setup, first-draft, fixture, selector, and validation steps.
+- Domain language, domain manifest, and core-flow manifest support through `.codeward/domains.yml` and `.codeward/flows.yml`.
+- Fixture/mock readiness and validation matrix output for generated E2E plans and drafts.
+- Local E2E run history snapshots protected by generated `.gitignore` entries.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ HIGH
 
 ## Install
 
-The package metadata is ready for the first npm release:
+The package metadata is ready for the first npm release, but the public package should wait until the E2E planning workflow is closer to the intended `0.1.0` shape.
 
 ```sh
 pnpm dlx @ivorycanvas/codeward scan .
@@ -130,7 +130,7 @@ node dist/cli.js scan /path/to/repo
 | `codeward eval . --base origin/main --head HEAD --pr-body-file pr-body.md` | Score change readiness across intent, risk, tests, and review size. |
 | `codeward github-action . --mode review --base origin/main --head HEAD` | Generate GitHub Action annotations, step summary, and PR comment body. |
 | `codeward test-plan . --base origin/main --head HEAD --include-working-tree` | Suggest domain test scenarios for changed files. |
-| `codeward e2e plan . --base origin/main --head HEAD` | Suggest E2E runner, user flows, coverage targets, existing test evidence, and missing testability hooks for changed files. |
+| `codeward e2e plan . --base origin/main --head HEAD` | Suggest E2E runner, bootstrap steps, user flows, coverage targets, existing test evidence, and missing testability hooks for changed files. |
 | `codeward e2e plan . --base origin/main --head HEAD --record-history` | Save a compact local run snapshot under `.codeward/runs/` while keeping JSON/Markdown output usable. |
 | `codeward e2e draft . --base origin/main --head HEAD` | Generate first-pass Maestro or Playwright E2E draft files from changed flows. |
 | `codeward flows init .` | Create a starter `.codeward/flows.yml` for team-approved core flow definitions. |
@@ -148,7 +148,9 @@ For monorepos, pass `--workspace-root` when scanning a package. Package-local ch
 
 `codeward test-plan` turns changed file paths into a review-ready domain test checklist. It also discovers common validation commands from `package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, Gradle files, and Maven `pom.xml`. Add `--include-working-tree` for local, uncommitted changes while iterating.
 
-`codeward e2e plan` turns changed file paths into a first-pass E2E testing plan. It detects whether a project looks like Expo/React Native or web, recommends a runner such as Maestro or Playwright, suggests domain language for the changed behavior, suggests candidate user flows, adds coverage targets, compares those targets with existing test-suite evidence when tests are present, flags API-dependent flows that need mock or fixture responses, and points out missing stable selectors such as `testID` or `data-testid` before anyone starts writing tests from a blank file.
+`codeward e2e plan` turns changed file paths into a first-pass E2E testing plan. It detects whether a project looks like Expo/React Native or web, recommends a runner such as Maestro or Playwright, suggests bootstrap steps for repos with little or no test history, suggests domain language for the changed behavior, suggests candidate user flows, adds coverage targets, compares those targets with existing test-suite evidence when tests are present, flags API-dependent flows that need mock or fixture responses, and points out missing stable selectors such as `testID` or `data-testid` before anyone starts writing tests from a blank file.
+
+The bootstrap section answers what must happen before generated drafts can be treated as real regression coverage. For example, a testless web project can get required steps for Playwright setup, first draft generation, stable selector work, fixture/mock data, and missing validation evidence, plus recommended steps for `.codeward/domains.yml`, `.codeward/flows.yml`, and local history recording.
 
 The domain language section is intentionally less implementation-oriented than the raw file list. For example, changes under `src/features/in-app-purchase/` become terms such as `In App Purchase` and scenarios such as `In App Purchase primary journey`. When `.codeward/domains.yml` exists, declared product terms and routes receive higher confidence. When `.codeward/flows.yml` exists, team-approved flow names appear as preferred scenario names.
 
@@ -297,8 +299,8 @@ CodeWard starts as a local CLI and should stay small enough that maintainers can
 
 Near-term priorities:
 
-- publish the first npm package
-- publish a versioned GitHub Action release tag
+- reach the intended `0.1.0` E2E planning coverage before the first npm release
+- publish a versioned GitHub Action release tag after the first public package is ready
 - improve branch-aware `review` changed-line locations
 - improve generated domain test plans with framework-specific test skeletons
 - refine generated Maestro and Playwright drafts with stronger app-specific selector discovery

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,7 +163,7 @@ Supported match fields:
 
 ## Domain Language Suggestions
 
-`codeward e2e plan` includes a domain language section before the lower-level E2E candidates. CodeWard derives these suggestions from:
+`codeward e2e plan` includes a bootstrap section and a domain language section before the lower-level E2E candidates. The bootstrap section separates required setup, recommended policy capture, and ready evidence, which is especially useful when a project has no existing tests yet. CodeWard derives domain language suggestions from:
 
 - team-approved `.codeward/flows.yml` names
 - shared `.codeward/domains.yml` names, aliases, routes, and scenarios

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,7 +5,7 @@ CodeWard starts as a local CLI for repo-level AI agent readiness. The project ca
 ## Now
 
 - Keep the scanner fast, static, and easy to understand.
-- Make the first public npm release.
+- Reach the intended `0.1.0` E2E planning coverage before the first public package release.
 - Improve README, adoption docs, and sample output so new maintainers can try CodeWard quickly.
 - Make `verify` the best first-run experience for AI-assisted PRs.
 - Keep `eval` explainable enough that maintainers trust the score and know what to fix.
@@ -13,7 +13,7 @@ CodeWard starts as a local CLI for repo-level AI agent readiness. The project ca
 
 ## Next
 
-- Publish a versioned GitHub Action release tag.
+- Publish a versioned GitHub Action release tag after the first public package is ready.
 - Improve `doctor` output with clearer scoring and remediation grouping.
 - Improve `review` output for changed-line locations.
 - Expand `eval` with repository-specific verification manifests and configurable taste rubrics.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ivorycanvas/codeward",
   "version": "0.1.0",
-  "description": "Preflight and workspace hygiene for AI coding agents.",
+  "description": "No-token guardrails, review checks, and E2E validation planning for AI coding agents.",
   "type": "module",
   "packageManager": "pnpm@10.32.1",
   "bin": {
@@ -9,8 +9,10 @@
   },
   "files": [
     "dist",
+    "docs",
     "schema",
     "README.md",
+    "CHANGELOG.md",
     "LICENSE"
   ],
   "scripts": {
@@ -29,6 +31,9 @@
     "ai-security",
     "mcp",
     "preflight",
+    "e2e",
+    "qa",
+    "test-planning",
     "repository-security",
     "security",
     "developer-tools",

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -27,6 +27,16 @@ export type E2eSetupHintConfidence = "high" | "medium" | "low";
 export type E2eFixtureReadinessStatus = "ready" | "partial" | "missing" | "not-needed";
 export type E2eValidationMatrixStatus = "ready" | "partial" | "missing";
 export type E2eValidationMatrixCategory = "core-flow" | "coverage" | "fixture" | "testability" | "setup";
+export type E2eBootstrapStepStatus = "required" | "recommended" | "ready";
+export type E2eBootstrapStepCategory =
+  | "runner"
+  | "draft"
+  | "domain-language"
+  | "core-flow"
+  | "fixture"
+  | "testability"
+  | "validation"
+  | "history";
 export type E2eSelectorKind =
   | "test-id"
   | "accessibility-label"
@@ -127,6 +137,26 @@ export interface E2eValidationMatrix {
   };
 }
 
+export interface E2eBootstrapStep {
+  category: E2eBootstrapStepCategory;
+  status: E2eBootstrapStepStatus;
+  title: string;
+  reason: string;
+  action: string;
+  commands: string[];
+  files: string[];
+}
+
+export interface E2eBootstrapPlan {
+  summary: string;
+  steps: E2eBootstrapStep[];
+  counts: {
+    required: number;
+    recommended: number;
+    ready: number;
+  };
+}
+
 export interface E2ePlanResult {
   tool: {
     name: string;
@@ -151,6 +181,7 @@ export interface E2ePlanResult {
   localHistory?: LocalHistoryReference;
   flows: E2eFlow[];
   validationMatrix: E2eValidationMatrix;
+  bootstrap: E2eBootstrapPlan;
   missingTestability: string[];
   setupNotes: string[];
 }
@@ -211,11 +242,28 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
   const domains = matchDomains(domainManifest, coreFlowChangedFiles);
   const domainLanguage = await buildDomainLanguageSummary(root, testPlan.changedFiles, coreFlows, domains);
   const flows = await buildFlows(root, testPlan.changedFiles, recommendedRunner.name, project.type, testSuiteInventory);
+  const testSuite = summarizeTestSuiteInventory(testSuiteInventory);
   const missingTestability = uniqueStrings([
     ...flows.flatMap((flow) => flow.missingTestability),
     ...(await buildGlobalTestabilityGaps(root, recommendedRunner.name)),
   ]);
   const validationMatrix = buildE2eValidationMatrix(flows, coreFlows);
+  const setupNotes = await buildSetupNotes(root, recommendedRunner.name, project);
+  const bootstrap = buildE2eBootstrapPlan({
+    base: testPlan.base,
+    head: testPlan.head,
+    recommendedRunner,
+    testSuite,
+    coreFlowManifestPath: coreFlowManifest.path,
+    domainManifestPath: domainManifest.path,
+    coreFlows,
+    domains,
+    domainLanguage,
+    flows,
+    validationMatrix,
+    missingTestability,
+    suggestedCommands: testPlan.suggestedCommands,
+  });
 
   return {
     tool: {
@@ -230,7 +278,7 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
     includeWorkingTree: testPlan.includeWorkingTree,
     project,
     recommendedRunner,
-    testSuite: summarizeTestSuiteInventory(testSuiteInventory),
+    testSuite,
     coreFlowManifestPath: coreFlowManifest.path,
     coreFlows,
     domainManifestPath: domainManifest.path,
@@ -240,8 +288,9 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
     suggestedCommands: testPlan.suggestedCommands,
     flows,
     validationMatrix,
+    bootstrap,
     missingTestability,
-    setupNotes: await buildSetupNotes(root, recommendedRunner.name, project),
+    setupNotes,
   };
 }
 
@@ -572,6 +621,356 @@ function buildE2eValidationMatrix(
   };
 }
 
+interface E2eBootstrapPlanInput {
+  base: string;
+  head: string;
+  recommendedRunner: E2eRunnerRecommendation;
+  testSuite: TestSuiteSummary;
+  coreFlowManifestPath?: string;
+  domainManifestPath?: string;
+  coreFlows: MatchedCoreFlow[];
+  domains: MatchedDomain[];
+  domainLanguage: DomainLanguageSummary;
+  flows: E2eFlow[];
+  validationMatrix: E2eValidationMatrix;
+  missingTestability: string[];
+  suggestedCommands: string[];
+}
+
+function buildE2eBootstrapPlan(input: E2eBootstrapPlanInput): E2eBootstrapPlan {
+  const steps: E2eBootstrapStep[] = [];
+  const runnerGap = input.missingTestability.find((gap) => /No \.maestro|No Playwright config/i.test(gap));
+  const draftCommand = `codeward e2e draft . --base ${input.base} --head ${input.head}`;
+  const planHistoryCommand = `codeward e2e plan . --base ${input.base} --head ${input.head} --record-history`;
+
+  if (input.recommendedRunner.name === "manual") {
+    steps.push(
+      bootstrapStep(
+        "runner",
+        "required",
+        "Choose the first runnable E2E runner",
+        "CodeWard could not detect a web, Expo, or React Native app surface, so generated output should start as a manual checklist.",
+        "Document the app entrypoint and pick Playwright, Maestro, or a project-specific runner before requiring generated drafts in CI.",
+        [],
+        [],
+      ),
+    );
+  } else if (runnerGap) {
+    steps.push(
+      bootstrapStep(
+        "runner",
+        "required",
+        `Configure ${formatRunnerName(input.recommendedRunner.name)} before making drafts required`,
+        runnerGap,
+        input.recommendedRunner.name === "playwright"
+          ? "Add a Playwright config, baseURL, and app serve command, then run the generated spec locally."
+          : "Add a .maestro directory or documented Maestro setup, app id, and simulator launch command.",
+        [],
+        [],
+      ),
+    );
+  } else {
+    steps.push(
+      bootstrapStep(
+        "runner",
+        "ready",
+        `${formatRunnerName(input.recommendedRunner.name)} setup signal detected`,
+        "CodeWard found enough runner setup evidence to generate runnable drafts.",
+        "Keep runner setup documented and linked from PR validation notes.",
+        [],
+        [],
+      ),
+    );
+  }
+
+  if (!input.testSuite.hasTestSuite) {
+    steps.push(
+      bootstrapStep(
+        "draft",
+        "required",
+        "Create the first changed-flow E2E draft",
+        "No existing test files were detected, so this branch needs a concrete first draft before CodeWard can compare coverage evidence.",
+        "Generate the first draft, replace TODO selectors and setup values, then decide which paths should become required regression coverage.",
+        [draftCommand],
+        input.flows.flatMap((flow) => flow.files).slice(0, maxFilesPerFlow),
+      ),
+    );
+  } else {
+    steps.push(
+      bootstrapStep(
+        "draft",
+        "ready",
+        "Existing test suite detected",
+        `${input.testSuite.testFileCount} test file${input.testSuite.testFileCount === 1 ? "" : "s"} can be used as coverage evidence.`,
+        "Use the validation matrix to expand existing tests or generated drafts only where evidence is weak.",
+        [],
+        [],
+      ),
+    );
+  }
+
+  if (!input.domainManifestPath && input.domainLanguage.terms.length > 0) {
+    steps.push(
+      bootstrapStep(
+        "domain-language",
+        "recommended",
+        "Promote repeated product words into a domain manifest",
+        `CodeWard inferred ${input.domainLanguage.terms.length} domain term${input.domainLanguage.terms.length === 1 ? "" : "s"} from changed files, but no shared domain manifest was found.`,
+        "Create or update .codeward/domains.yml with the terms reviewers already use for this behavior.",
+        ["codeward domains init ."],
+        input.domainLanguage.terms.flatMap((term) => term.files).slice(0, maxFilesPerFlow),
+      ),
+    );
+  } else if (input.domainManifestPath || input.domains.length > 0) {
+    steps.push(
+      bootstrapStep(
+        "domain-language",
+        "ready",
+        "Domain language has shared policy evidence",
+        input.domainManifestPath
+          ? `Domain manifest found at ${input.domainManifestPath}.`
+          : "Matched domain definitions were found.",
+        "Keep committed domain language aligned with the names used in generated E2E drafts.",
+        [],
+        [],
+      ),
+    );
+  }
+
+  if (!input.coreFlowManifestPath) {
+    steps.push(
+      bootstrapStep(
+        "core-flow",
+        input.flows.length > 0 ? "recommended" : "required",
+        "Capture the first durable core flows",
+        "No .codeward/flows.yml manifest was found, so CodeWard can infer changed-flow candidates but cannot distinguish team-critical journeys yet.",
+        "Add the highest-value product journeys to .codeward/flows.yml so future PRs can be evaluated against team-approved lifecycle checks.",
+        ["codeward flows init ."],
+        input.flows.flatMap((flow) => flow.files).slice(0, maxFilesPerFlow),
+      ),
+    );
+  } else {
+    steps.push(
+      bootstrapStep(
+        "core-flow",
+        input.coreFlows.length > 0 ? "ready" : "recommended",
+        input.coreFlows.length > 0 ? "Core flow manifest matched this change" : "Review core flow manifest coverage",
+        input.coreFlows.length > 0
+          ? `${input.coreFlows.length} declared core flow${input.coreFlows.length === 1 ? "" : "s"} matched the changed files.`
+          : `Core flow manifest found at ${input.coreFlowManifestPath}, but this change did not match a declared flow.`,
+        input.coreFlows.length > 0
+          ? "Keep the matched flow checks as explicit PR validation evidence."
+          : "Add or adjust flow file patterns, routes, domains, or tags if this change touches a critical journey.",
+        [],
+        input.coreFlows.flatMap((flow) => flow.matchedFiles).slice(0, maxFilesPerFlow),
+      ),
+    );
+  }
+
+  const fixtureRows = input.validationMatrix.rows.filter((row) => row.category === "fixture");
+  const missingFixtureRows = fixtureRows.filter((row) => row.status === "missing");
+  const partialFixtureRows = fixtureRows.filter((row) => row.status === "partial");
+  if (missingFixtureRows.length > 0 || partialFixtureRows.length > 0) {
+    steps.push(
+      bootstrapStep(
+        "fixture",
+        missingFixtureRows.length > 0 ? "required" : "recommended",
+        "Add deterministic fixture or mock responses",
+        missingFixtureRows.length > 0
+          ? `${missingFixtureRows.length} API-dependent flow${missingFixtureRows.length === 1 ? "" : "s"} lack fixture evidence.`
+          : `${partialFixtureRows.length} API-dependent flow${partialFixtureRows.length === 1 ? "" : "s"} have only partial fixture evidence.`,
+        "Cover success plus one empty, unauthorized, timeout, rejected, or server-error response before requiring the generated draft.",
+        [],
+        uniqueStrings([...missingFixtureRows, ...partialFixtureRows].flatMap((row) => row.files)).slice(0, maxFilesPerFlow),
+      ),
+    );
+  }
+
+  const nonRunnerTestabilityGaps = input.missingTestability.filter((gap) => !/No \.maestro|No Playwright config/i.test(gap));
+  if (nonRunnerTestabilityGaps.length > 0) {
+    steps.push(
+      bootstrapStep(
+        "testability",
+        "required",
+        "Add stable selectors for changed user actions",
+        `${nonRunnerTestabilityGaps.length} selector or interaction gap${nonRunnerTestabilityGaps.length === 1 ? "" : "s"} were detected.`,
+        "Add stable test ids, accessibility labels, roles, or durable visible copy for the controls the draft must tap, type into, or assert.",
+        [],
+        input.flows.flatMap((flow) => flow.files).slice(0, maxFilesPerFlow),
+      ),
+    );
+  } else if (input.flows.some((flow) => flow.selectors.length > 0 || flow.entrypoints.length > 0)) {
+    steps.push(
+      bootstrapStep(
+        "testability",
+        "ready",
+        "Entrypoint or selector evidence detected",
+        "Generated drafts can reuse detected routes, screens, selectors, labels, or visible copy.",
+        "Review the generated locators and replace weak TODO placeholders before promoting the draft.",
+        [],
+        input.flows.flatMap((flow) => flow.selectors.map((selector) => selector.file)).slice(0, maxFilesPerFlow),
+      ),
+    );
+  }
+
+  if (input.validationMatrix.summary.missing > 0) {
+    steps.push(
+      bootstrapStep(
+        "validation",
+        "required",
+        "Close missing validation matrix rows",
+        `${input.validationMatrix.summary.missing} validation row${input.validationMatrix.summary.missing === 1 ? "" : "s"} are missing evidence.`,
+        "Resolve missing coverage, fixture, setup, and testability rows before calling generated E2E coverage sufficient.",
+        [],
+        input.validationMatrix.rows.filter((row) => row.status === "missing").flatMap((row) => row.files).slice(0, maxFilesPerFlow),
+      ),
+    );
+  } else if (input.validationMatrix.summary.partial > 0) {
+    steps.push(
+      bootstrapStep(
+        "validation",
+        "recommended",
+        "Strengthen partial validation evidence",
+        `${input.validationMatrix.summary.partial} validation row${input.validationMatrix.summary.partial === 1 ? "" : "s"} are only partial.`,
+        "Expand the generated draft or existing tests until the critical rows have concrete evidence.",
+        [],
+        input.validationMatrix.rows.filter((row) => row.status === "partial").flatMap((row) => row.files).slice(0, maxFilesPerFlow),
+      ),
+    );
+  } else if (input.validationMatrix.rows.length > 0) {
+    steps.push(
+      bootstrapStep(
+        "validation",
+        "ready",
+        "Validation matrix is ready",
+        "All validation matrix rows currently have ready evidence.",
+        "Keep the matrix linked in PR evidence when the generated draft is promoted.",
+        [],
+        [],
+      ),
+    );
+  }
+
+  steps.push(
+    bootstrapStep(
+      "history",
+      "recommended",
+      "Record local plan history while iterating",
+      "Local run history lets the team compare how domain language, core flows, fixtures, and validation gaps evolve without spending more agent tokens.",
+      "Run the plan with --record-history after important draft or manifest changes.",
+      [planHistoryCommand],
+      [],
+    ),
+  );
+
+  if (input.suggestedCommands.length === 0) {
+    steps.push(
+      bootstrapStep(
+        "validation",
+        "recommended",
+        "Expose at least one validation command",
+        "No test, typecheck, lint, build, or E2E command was discovered for this project.",
+        "Add a project script or CodeWard validation command so PR evidence can include repeatable checks.",
+        [],
+        [],
+      ),
+    );
+  }
+
+  const sortedSteps = dedupeBootstrapSteps(steps).sort(compareBootstrapSteps).slice(0, 12);
+  const counts = {
+    required: sortedSteps.filter((step) => step.status === "required").length,
+    recommended: sortedSteps.filter((step) => step.status === "recommended").length,
+    ready: sortedSteps.filter((step) => step.status === "ready").length,
+  };
+  return {
+    summary: bootstrapSummary(counts, sortedSteps),
+    steps: sortedSteps,
+    counts,
+  };
+}
+
+function bootstrapStep(
+  category: E2eBootstrapStepCategory,
+  status: E2eBootstrapStepStatus,
+  title: string,
+  reason: string,
+  action: string,
+  commands: string[],
+  files: string[],
+): E2eBootstrapStep {
+  return {
+    category,
+    status,
+    title,
+    reason,
+    action,
+    commands,
+    files: uniqueStrings(files).slice(0, maxFilesPerFlow),
+  };
+}
+
+function dedupeBootstrapSteps(steps: E2eBootstrapStep[]): E2eBootstrapStep[] {
+  const seen = new Set<string>();
+  const deduped: E2eBootstrapStep[] = [];
+  for (const step of steps) {
+    const key = `${step.category}:${step.title}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(step);
+  }
+  return deduped;
+}
+
+function compareBootstrapSteps(left: E2eBootstrapStep, right: E2eBootstrapStep): number {
+  const statusDiff = bootstrapStatusRank(left.status) - bootstrapStatusRank(right.status);
+  if (statusDiff !== 0) {
+    return statusDiff;
+  }
+  return bootstrapCategoryRank(left.category) - bootstrapCategoryRank(right.category);
+}
+
+function bootstrapStatusRank(status: E2eBootstrapStepStatus): number {
+  if (status === "required") {
+    return 0;
+  }
+  if (status === "recommended") {
+    return 1;
+  }
+  return 2;
+}
+
+function bootstrapCategoryRank(category: E2eBootstrapStepCategory): number {
+  const order: E2eBootstrapStepCategory[] = [
+    "runner",
+    "draft",
+    "testability",
+    "fixture",
+    "validation",
+    "domain-language",
+    "core-flow",
+    "history",
+  ];
+  return order.indexOf(category);
+}
+
+function bootstrapSummary(
+  counts: E2eBootstrapPlan["counts"],
+  steps: E2eBootstrapStep[],
+): string {
+  const firstRequired = steps.find((step) => step.status === "required");
+  if (firstRequired) {
+    return `${counts.required} required bootstrap step${counts.required === 1 ? "" : "s"} must be resolved before generated E2E drafts should be treated as regression coverage. Start with: ${firstRequired.title}.`;
+  }
+  const firstRecommended = steps.find((step) => step.status === "recommended");
+  if (firstRecommended) {
+    return `${counts.recommended} recommended bootstrap step${counts.recommended === 1 ? "" : "s"} remain before the E2E workflow feels durable. Start with: ${firstRecommended.title}.`;
+  }
+  return "The detected E2E bootstrap signals look ready for this change.";
+}
+
 function coverageTargetRequirement(flow: E2eFlow, targetTitle: string): string {
   const target = flow.coverage.find((item) => item.title === targetTitle);
   if (!target) {
@@ -762,6 +1161,25 @@ export function formatMarkdownE2ePlan(result: E2ePlanResult): string {
     }
   }
   lines.push("");
+
+  if (result.bootstrap.steps.length > 0) {
+    lines.push("## Bootstrap Plan");
+    lines.push("");
+    lines.push(result.bootstrap.summary);
+    lines.push("");
+    lines.push(
+      `Summary: ${result.bootstrap.counts.required} required, ${result.bootstrap.counts.recommended} recommended, ${result.bootstrap.counts.ready} ready.`,
+    );
+    lines.push("");
+    lines.push("| Status | Area | Reason | Action | Commands |");
+    lines.push("| --- | --- | --- | --- | --- |");
+    for (const step of result.bootstrap.steps) {
+      lines.push(
+        `| ${step.status} | ${escapeMarkdownTableCell(step.title)} | ${escapeMarkdownTableCell(step.reason)} | ${escapeMarkdownTableCell(step.action)} | ${escapeMarkdownTableCell(step.commands.length > 0 ? step.commands.join("<br>") : "")} |`,
+      );
+    }
+    lines.push("");
+  }
 
   if (result.domainLanguage.terms.length > 0 || result.domainLanguage.scenarios.length > 0) {
     lines.push("## Domain Language");
@@ -3111,6 +3529,13 @@ function buildDraftNextSteps(plan: E2ePlanResult, runner: E2eRunnerName): string
     steps.push("Run `npx playwright test` after the app can be served locally.");
   } else {
     steps.push("Choose a runnable E2E framework once the primary app surface is documented.");
+  }
+  if (plan.bootstrap.counts.required > 0) {
+    const requiredTitles = plan.bootstrap.steps
+      .filter((step) => step.status === "required")
+      .map((step) => step.title)
+      .slice(0, 3);
+    steps.push(`Resolve required bootstrap steps before treating drafts as regression coverage: ${formatHumanList(requiredTitles)}.`);
   }
   if (plan.missingTestability.length > 0) {
     steps.push("Address the listed testability gaps before treating the generated drafts as stable regression tests.");

--- a/src/history.ts
+++ b/src/history.ts
@@ -88,6 +88,22 @@ export interface E2ePlanHistorySnapshot {
         nextAction: string;
       }>;
     };
+    bootstrap: {
+      summary: string;
+      counts: {
+        required: number;
+        recommended: number;
+        ready: number;
+      };
+      steps: Array<{
+        category: string;
+        status: string;
+        title: string;
+        action: string;
+        commands: string[];
+        files: string[];
+      }>;
+    };
     changedFilesCount: number;
     changedFiles: string[];
     suggestedCommands: string[];
@@ -136,6 +152,11 @@ export interface E2ePlanHistorySnapshot {
       ready: number;
       partial: number;
       missing: number;
+    };
+    bootstrap: {
+      required: number;
+      recommended: number;
+      ready: number;
     };
     missingTestability: number;
   };
@@ -253,6 +274,18 @@ function buildE2ePlanHistorySnapshot(historyRoot: string, plan: E2ePlanResult): 
           nextAction: row.nextAction,
         })),
       },
+      bootstrap: {
+        summary: plan.bootstrap.summary,
+        counts: plan.bootstrap.counts,
+        steps: plan.bootstrap.steps.slice(0, 12).map((step) => ({
+          category: step.category,
+          status: step.status,
+          title: step.title,
+          action: step.action,
+          commands: step.commands.slice(0, 5),
+          files: step.files.slice(0, 8),
+        })),
+      },
       changedFilesCount: plan.changedFiles.length,
       changedFiles: plan.changedFiles.map((file) => file.path).slice(0, 50),
       suggestedCommands: plan.suggestedCommands.slice(0, 20),
@@ -298,6 +331,7 @@ function buildE2ePlanHistorySnapshot(historyRoot: string, plan: E2ePlanResult): 
         missing: plan.flows.filter((flow) => flow.fixtureReadiness.status === "missing").length,
       },
       validationMatrix: plan.validationMatrix.summary,
+      bootstrap: plan.bootstrap.counts,
       missingTestability: plan.missingTestability.length,
     },
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,10 @@ export type {
 export type {
   E2eCoveragePriority,
   E2eCoverageTarget,
+  E2eBootstrapPlan,
+  E2eBootstrapStep,
+  E2eBootstrapStepCategory,
+  E2eBootstrapStepStatus,
   E2eEntrypoint,
   E2eEntrypointConfidence,
   E2eEntrypointKind,

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -911,6 +911,70 @@ test("generateE2ePlan flags missing mock fixtures for API-dependent UI flows", a
   assert.match(spec, /\[missing\].*fixture\/mock readiness/);
 });
 
+test("generateE2ePlan builds a bootstrap plan for projects without tests", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src/pages/billing"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      dependencies: {
+        vite: "^7.0.0",
+        "react-dom": "^19.0.0",
+      },
+    }),
+  );
+  await writeFile(
+    path.join(root, "src/pages/billing/BillingPage.tsx"),
+    [
+      "export function BillingPage() {",
+      "  return <button onClick={() => undefined}>Load billing</button>;",
+      "}",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/billing-api"]);
+  await writeFile(
+    path.join(root, "src/pages/billing/BillingPage.tsx"),
+    [
+      "export async function loadBilling() {",
+      "  const response = await fetch('/api/billing/current');",
+      "  return response.json();",
+      "}",
+      "export function BillingPage() {",
+      "  return <button onClick={() => undefined}>Load billing</button>;",
+      "}",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "load billing data"]);
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const markdown = formatMarkdownE2ePlan(plan);
+  const draft = await generateE2eDraft(root, { base: "main", head: "HEAD", output: "tests/e2e" });
+
+  assert.equal(plan.testSuite.hasTestSuite, false);
+  assert.equal(plan.recommendedRunner.name, "playwright");
+  assert.ok(plan.bootstrap.counts.required >= 4);
+  assert.ok(plan.bootstrap.steps.some((step) => step.category === "runner" && step.status === "required"));
+  assert.ok(plan.bootstrap.steps.some((step) => step.category === "draft" && step.status === "required"));
+  assert.ok(plan.bootstrap.steps.some((step) => step.category === "fixture" && step.status === "required"));
+  assert.ok(plan.bootstrap.steps.some((step) => step.category === "testability" && step.status === "required"));
+  assert.ok(plan.bootstrap.steps.some((step) => step.category === "domain-language" && step.status === "recommended"));
+  assert.ok(plan.bootstrap.steps.some((step) => step.category === "core-flow" && step.status === "recommended"));
+  assert.ok(plan.bootstrap.steps.some((step) => step.commands.includes("codeward domains init .")));
+  assert.ok(plan.bootstrap.steps.some((step) => step.commands.includes("codeward flows init .")));
+  assert.match(plan.bootstrap.summary, /required bootstrap step/);
+  assert.match(markdown, /## Bootstrap Plan/);
+  assert.match(markdown, /Create the first changed-flow E2E draft/);
+  assert.match(markdown, /Add deterministic fixture or mock responses/);
+  assert.match(markdown, /codeward e2e draft \. --base main --head HEAD/);
+  assert.match(formatMarkdownE2eDraft(draft), /Resolve required bootstrap steps/);
+});
+
 test("generateE2eDraft uses web selectors in Playwright specs", async () => {
   const root = await makeTempRepo();
   await initGitRepo(root);
@@ -1831,9 +1895,13 @@ test("e2e plan can record compact local history without breaking JSON output", a
   assert.equal(snapshot.plan.scope, ".");
   assert.equal(snapshot.plan.recommendedRunner, "playwright");
   assert.equal(typeof plan.validationMatrix.summary.partial, "number");
+  assert.equal(typeof plan.bootstrap.counts.recommended, "number");
   assert.equal(typeof snapshot.plan.validationMatrix.summary.partial, "number");
+  assert.equal(typeof snapshot.plan.bootstrap.counts.recommended, "number");
   assert.equal(snapshot.plan.validationMatrix.rows.length > 0, true);
+  assert.equal(snapshot.plan.bootstrap.steps.length > 0, true);
   assert.equal(snapshot.summary.validationMatrix.partial > 0, true);
+  assert.equal(typeof snapshot.summary.bootstrap.recommended, "number");
   assert.equal(snapshot.summary.changedFiles, 1);
   assert.equal(JSON.stringify(snapshot).includes(root), false);
   for (const pattern of localHistoryGitignorePatterns) {


### PR DESCRIPTION
## Summary

- add an E2E bootstrap plan to `codeward e2e plan` so testless or under-instrumented projects get required/recommended/ready setup steps
- persist bootstrap summaries in local E2E history snapshots
- document the bootstrap output and keep release wording pre-release oriented

## Validation

- `pnpm test`
- `git diff --check`
- `pnpm scan`
- `node dist/cli.js e2e plan . --base main --head HEAD --include-working-tree --format markdown` smoke output
