### PR TITLE
feat: add manifest suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,6 @@ Working scope for the first public `0.1.0` release.
 - E2E planning and draft generation for Playwright, Maestro, and manual checklists.
 - Bootstrap planning for projects with little or no E2E history, including required runner setup, first-draft, fixture, selector, and validation steps.
 - Domain language, domain manifest, and core-flow manifest support through `.codeward/domains.yml` and `.codeward/flows.yml`.
+- Change-aware `domains suggest` and `flows suggest` commands that draft manifest entries from branch context before teams commit durable policy.
 - Fixture/mock readiness and validation matrix output for generated E2E plans and drafts.
 - Local E2E run history snapshots protected by generated `.gitignore` entries.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ node dist/cli.js scan /path/to/repo
 | `codeward e2e plan . --base origin/main --head HEAD --record-history` | Save a compact local run snapshot under `.codeward/runs/` while keeping JSON/Markdown output usable. |
 | `codeward e2e draft . --base origin/main --head HEAD` | Generate first-pass Maestro or Playwright E2E draft files from changed flows. |
 | `codeward flows init .` | Create a starter `.codeward/flows.yml` for team-approved core flow definitions. |
+| `codeward flows suggest . --base origin/main --head HEAD` | Generate suggested `.codeward/flows.yml` entries from changed files and E2E plan context. |
 | `codeward domains init .` | Create a starter `.codeward/domains.yml` for shared product/domain language. |
+| `codeward domains suggest . --base origin/main --head HEAD` | Generate suggested `.codeward/domains.yml` entries from changed files and inferred product language. |
 | `codeward history init .` | Create local CodeWard history directories and protect generated run history with `.gitignore`. |
 | `codeward doctor services/offer --workspace-root .` | Scan a monorepo package while using root guardrails. |
 | `codeward context . --write AGENTS.md` | Generate starter agent instructions for the repo. |
@@ -174,7 +176,7 @@ domains:
           - Complete the primary billing action with realistic data.
 ```
 
-Run `codeward domains init .` to create a starter domain manifest. Use domains for naming and route hints; use core flows when the team wants to define a durable verification journey.
+Run `codeward domains init .` to create a starter domain manifest. Run `codeward domains suggest . --base origin/main --head HEAD` when you want CodeWard to draft manifest entries from the current branch. Use domains for naming and route hints; use core flows when the team wants to define a durable verification journey.
 
 If `.codeward/flows.yml` exists, `codeward e2e plan` also matches changed files against team-approved core flows. This lets maintainers encode the product or domain flows humans already care about:
 
@@ -195,7 +197,7 @@ flows:
       - Verify declined payment recovery.
 ```
 
-Run `codeward flows init .` to create a starter manifest. Unlike generated run history, `.codeward/flows.yml` is meant to be reviewed and committed when those flow definitions should become team policy.
+Run `codeward flows init .` to create a starter manifest. Run `codeward flows suggest . --base origin/main --head HEAD` when you want CodeWard to draft flow entries from changed files, inferred domain language, routes, and E2E checks. Unlike generated run history, `.codeward/flows.yml` is meant to be reviewed and committed when those flow definitions should become team policy.
 
 Pass `--record-history` when you want CodeWard to keep a compact local snapshot of an E2E plan under `.codeward/runs/`. CodeWard automatically protects `.codeward/runs/`, `.codeward/cache/`, `.codeward/tmp/`, and `.codeward/*.local.json` with `.gitignore` so generated history stays local by default. Shared project policy, such as `codeward.config.json`, `.codeward/domains.yml`, and `.codeward/flows.yml`, remains commit-friendly.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,6 +81,7 @@ Create a starter domain manifest:
 
 ```sh
 codeward domains init .
+codeward domains suggest . --base origin/main --head HEAD
 ```
 
 `.codeward/domains.yml` is meant to be committed when the team wants CodeWard to use shared product language during E2E planning.
@@ -126,6 +127,7 @@ Create a starter core flow manifest:
 
 ```sh
 codeward flows init .
+codeward flows suggest . --base origin/main --head HEAD
 ```
 
 `.codeward/flows.yml` is meant to be committed when the team wants CodeWard to understand project-specific flows during E2E planning.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,15 @@ import { evaluateChangeReadiness, formatEvalReport, formatMarkdownEvalReport } f
 import { defaultFlowManifestPath, writeDefaultCoreFlowManifest } from "./flows.js";
 import { runGitHubAction } from "./github.js";
 import { formatLocalHistoryInitResult, initializeLocalHistory, recordE2ePlanHistory } from "./history.js";
+import {
+  defaultSuggestedDomainManifestPath,
+  defaultSuggestedFlowManifestPath,
+  formatDomainManifestSuggestion,
+  formatFlowManifestSuggestion,
+  generateDomainManifestSuggestion,
+  generateFlowManifestSuggestion,
+  writeSuggestedManifest,
+} from "./manifest-suggestions.js";
 import { formatMarkdownReport, formatSarifReport, formatTextReport, hasFindingsAtOrAbove } from "./report.js";
 import { formatMarkdownReviewReport, formatReviewReport, reviewProject } from "./review.js";
 import { scanProject } from "./scanner.js";
@@ -246,10 +255,35 @@ async function main(argv: string[]): Promise<number> {
       printFlowsHelp();
       return 0;
     }
-    if (subcommand !== "init") {
+    if (subcommand !== "init" && subcommand !== "suggest") {
       throw new Error(`Unknown flows subcommand: ${subcommand}`);
     }
     const options = parseOptions(subcommandRest);
+    if (subcommand === "suggest") {
+      const loadedConfig = await loadOptionsConfig(options);
+      const result = await generateFlowManifestSuggestion(options.path, {
+        base: options.base,
+        head: options.head,
+        workspaceRoot: options.workspaceRoot,
+        includeWorkingTree: options.includeWorkingTree,
+        validationCommands: loadedConfig.config.validationCommands,
+      });
+      const format = options.format ?? (options.json ? "json" : "text");
+      const output = formatFlowManifestSuggestion(result, manifestSuggestionFormat(format, "flows"));
+      if (options.write) {
+        const manifestRoot = options.workspaceRoot ?? options.path;
+        const writePath = await writeSuggestedManifest(
+          manifestRoot,
+          manifestWritePath(options.write, defaultSuggestedFlowManifestPath),
+          result.yaml,
+          options.force,
+        );
+        await printOrWrite(`Wrote ${writePath}\nReview this generated core flow manifest before committing it.\n`, options.output);
+      } else {
+        await printOrWrite(output, options.output);
+      }
+      return 0;
+    }
     const outputPath = await writeDefaultCoreFlowManifest(
       options.path,
       options.write ?? defaultFlowManifestPath,
@@ -272,10 +306,35 @@ async function main(argv: string[]): Promise<number> {
       printDomainsHelp();
       return 0;
     }
-    if (subcommand !== "init") {
+    if (subcommand !== "init" && subcommand !== "suggest") {
       throw new Error(`Unknown domains subcommand: ${subcommand}`);
     }
     const options = parseOptions(subcommandRest);
+    if (subcommand === "suggest") {
+      const loadedConfig = await loadOptionsConfig(options);
+      const result = await generateDomainManifestSuggestion(options.path, {
+        base: options.base,
+        head: options.head,
+        workspaceRoot: options.workspaceRoot,
+        includeWorkingTree: options.includeWorkingTree,
+        validationCommands: loadedConfig.config.validationCommands,
+      });
+      const format = options.format ?? (options.json ? "json" : "text");
+      const output = formatDomainManifestSuggestion(result, manifestSuggestionFormat(format, "domains"));
+      if (options.write) {
+        const manifestRoot = options.workspaceRoot ?? options.path;
+        const writePath = await writeSuggestedManifest(
+          manifestRoot,
+          manifestWritePath(options.write, defaultSuggestedDomainManifestPath),
+          result.yaml,
+          options.force,
+        );
+        await printOrWrite(`Wrote ${writePath}\nReview this generated domain manifest before committing it.\n`, options.output);
+      } else {
+        await printOrWrite(output, options.output);
+      }
+      return 0;
+    }
     const outputPath = await writeDefaultDomainManifest(
       options.path,
       options.write ?? defaultDomainManifestPath,
@@ -605,6 +664,17 @@ function formatE2eDraftOutput(result: Awaited<ReturnType<typeof generateE2eDraft
   return formatMarkdownE2eDraft(result);
 }
 
+function manifestSuggestionFormat(format: OutputFormat, command: "domains" | "flows"): "text" | "json" | "markdown" {
+  if (format === "sarif") {
+    throw new Error(`${command} suggest supports text, json, or markdown output, not sarif`);
+  }
+  return format;
+}
+
+function manifestWritePath(writeOption: string, defaultPath: string): string {
+  return writeOption === "AGENTS.md" ? defaultPath : writeOption;
+}
+
 function formatEvalOutput(result: Awaited<ReturnType<typeof evaluateChangeReadiness>>, format: OutputFormat): string {
   if (format === "json") {
     return `${JSON.stringify(result, null, 2)}\n`;
@@ -678,7 +748,9 @@ Usage:
   codeward e2e plan [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--record-history] [--format <format>]
   codeward e2e draft [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--runner maestro|playwright|manual] [--output <dir>] [--force]
   codeward flows init [path] [--write <file>] [--force]
+  codeward flows suggest [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--format <format>] [--output <file>] [--write <file>] [--force]
   codeward domains init [path] [--write <file>] [--force]
+  codeward domains suggest [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--format <format>] [--output <file>] [--write <file>] [--force]
   codeward history init [path]
   codeward context [path] [--write [file]] [--force]
   codeward init [path] [--write <file>] [--force]
@@ -705,7 +777,9 @@ Examples:
   codeward e2e plan . --base origin/main --head HEAD --record-history
   codeward e2e draft . --base origin/main --head HEAD
   codeward flows init .
+  codeward flows suggest . --base origin/main --head HEAD
   codeward domains init .
+  codeward domains suggest . --base origin/main --head HEAD
   codeward history init .
   codeward test-plan services/offer --workspace-root . --base origin/main --head HEAD --include-working-tree
   codeward context . --write AGENTS.md
@@ -750,9 +824,12 @@ Core flow definitions for project-specific E2E planning.
 
 Usage:
   codeward flows init [path] [--write <file>] [--force]
+  codeward flows suggest [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--format text|json|markdown] [--output <file>] [--write <file>] [--force]
 
 Examples:
   codeward flows init .
+  codeward flows suggest . --base origin/main --head HEAD
+  codeward flows suggest services/offer --workspace-root . --include-working-tree
 `);
 }
 
@@ -763,9 +840,12 @@ Domain definitions for project-specific E2E naming and route hints.
 
 Usage:
   codeward domains init [path] [--write <file>] [--force]
+  codeward domains suggest [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--format text|json|markdown] [--output <file>] [--write <file>] [--force]
 
 Examples:
   codeward domains init .
+  codeward domains suggest . --base origin/main --head HEAD
+  codeward domains suggest services/offer --workspace-root . --include-working-tree
 `);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,15 @@ export {
   localTmpDirectory,
   recordE2ePlanHistory,
 } from "./history.js";
+export {
+  defaultSuggestedDomainManifestPath,
+  defaultSuggestedFlowManifestPath,
+  formatDomainManifestSuggestion,
+  formatFlowManifestSuggestion,
+  generateDomainManifestSuggestion,
+  generateFlowManifestSuggestion,
+  writeSuggestedManifest,
+} from "./manifest-suggestions.js";
 export { formatMarkdownReport, formatSarifReport, formatTextReport, hasFindingsAtOrAbove } from "./report.js";
 export { formatMarkdownReviewReport, formatReviewReport, reviewProject } from "./review.js";
 export { scanProject } from "./scanner.js";
@@ -97,6 +106,7 @@ export type {
 } from "./flows.js";
 export type { GitHubActionMode, GitHubActionOptions, GitHubActionResult } from "./github.js";
 export type { E2ePlanHistorySnapshot, LocalHistoryInitResult, LocalHistoryReference } from "./history.js";
+export type { DomainManifestSuggestionResult, FlowManifestSuggestionResult, ManifestSuggestionOptions } from "./manifest-suggestions.js";
 export type { ChangedFile, ChangedRiskyFinding, ReviewOptions, ReviewResult } from "./review.js";
 export type { TestPlanChangedFile, TestPlanItem, TestPlanOptions, TestPlanResult } from "./test-plan.js";
 export type { CodeWardConfig, Finding, ScanCounts, ScanOptions, ScanResult, Severity } from "./types.js";

--- a/src/manifest-suggestions.ts
+++ b/src/manifest-suggestions.ts
@@ -1,0 +1,623 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
+import { defaultDomainManifestPath } from "./domains.js";
+import { generateE2ePlan } from "./e2e.js";
+import { defaultFlowManifestPath } from "./flows.js";
+import { pathExists, toPosixPath } from "./fs.js";
+import { TOOL_NAME, VERSION } from "./version.js";
+import type { DomainDefinition, DomainScenarioDefinition } from "./domains.js";
+import type { E2eFlow, E2ePlanOptions, E2ePlanResult } from "./e2e.js";
+import type { CoreFlowDefinition, CoreFlowPriority } from "./flows.js";
+
+export interface ManifestSuggestionOptions extends E2ePlanOptions {}
+
+export interface DomainManifestSuggestionResult {
+  tool: {
+    name: string;
+    version: string;
+  };
+  kind: "domain-manifest-suggestion";
+  root: string;
+  workspaceRoot?: string;
+  manifestRoot: string;
+  generatedAt: string;
+  base: string;
+  head: string;
+  includeWorkingTree: boolean;
+  changedFiles: string[];
+  domains: DomainDefinition[];
+  yaml: string;
+}
+
+export interface FlowManifestSuggestionResult {
+  tool: {
+    name: string;
+    version: string;
+  };
+  kind: "flow-manifest-suggestion";
+  root: string;
+  workspaceRoot?: string;
+  manifestRoot: string;
+  generatedAt: string;
+  base: string;
+  head: string;
+  includeWorkingTree: boolean;
+  changedFiles: string[];
+  flows: CoreFlowDefinition[];
+  yaml: string;
+}
+
+export async function generateDomainManifestSuggestion(
+  rootInput: string,
+  options: ManifestSuggestionOptions = {},
+): Promise<DomainManifestSuggestionResult> {
+  const plan = await generateE2ePlan(rootInput, options);
+  const domains = buildSuggestedDomains(plan);
+  return {
+    tool: {
+      name: TOOL_NAME,
+      version: VERSION,
+    },
+    kind: "domain-manifest-suggestion",
+    root: plan.root,
+    workspaceRoot: plan.workspaceRoot,
+    manifestRoot: plan.workspaceRoot ?? plan.root,
+    generatedAt: new Date().toISOString(),
+    base: plan.base,
+    head: plan.head,
+    includeWorkingTree: plan.includeWorkingTree,
+    changedFiles: plan.changedFiles.map((file) => manifestRelativeFile(plan, file.path)),
+    domains,
+    yaml: formatSuggestedDomainManifestYaml(domains),
+  };
+}
+
+export async function generateFlowManifestSuggestion(
+  rootInput: string,
+  options: ManifestSuggestionOptions = {},
+): Promise<FlowManifestSuggestionResult> {
+  const plan = await generateE2ePlan(rootInput, options);
+  const domains = buildSuggestedDomains(plan);
+  const flows = buildSuggestedFlows(plan, domains);
+  return {
+    tool: {
+      name: TOOL_NAME,
+      version: VERSION,
+    },
+    kind: "flow-manifest-suggestion",
+    root: plan.root,
+    workspaceRoot: plan.workspaceRoot,
+    manifestRoot: plan.workspaceRoot ?? plan.root,
+    generatedAt: new Date().toISOString(),
+    base: plan.base,
+    head: plan.head,
+    includeWorkingTree: plan.includeWorkingTree,
+    changedFiles: plan.changedFiles.map((file) => manifestRelativeFile(plan, file.path)),
+    flows,
+    yaml: formatSuggestedFlowManifestYaml(flows),
+  };
+}
+
+export function formatDomainManifestSuggestion(result: DomainManifestSuggestionResult, format: "text" | "json" | "markdown"): string {
+  if (format === "json") {
+    return `${JSON.stringify(result, null, 2)}\n`;
+  }
+  if (format === "markdown") {
+    const lines = manifestSuggestionHeader("Domain Manifest Suggestion", result);
+    lines.push("## Suggested Domains");
+    lines.push("");
+    if (result.domains.length === 0) {
+      lines.push("No durable domain candidates were detected from the changed files.");
+      lines.push("");
+    } else {
+      for (const domain of result.domains) {
+        lines.push(`- ${domain.name} \`${domain.id}\`: ${domain.files.join(", ")}`);
+      }
+      lines.push("");
+    }
+    lines.push("## YAML");
+    lines.push("");
+    lines.push("```yaml");
+    lines.push(result.yaml.trimEnd());
+    lines.push("```");
+    lines.push("");
+    return lines.join("\n");
+  }
+  return result.yaml;
+}
+
+export function formatFlowManifestSuggestion(result: FlowManifestSuggestionResult, format: "text" | "json" | "markdown"): string {
+  if (format === "json") {
+    return `${JSON.stringify(result, null, 2)}\n`;
+  }
+  if (format === "markdown") {
+    const lines = manifestSuggestionHeader("Core Flow Manifest Suggestion", result);
+    lines.push("## Suggested Flows");
+    lines.push("");
+    if (result.flows.length === 0) {
+      lines.push("No durable core flow candidates were detected from the changed files.");
+      lines.push("");
+    } else {
+      for (const flow of result.flows) {
+        lines.push(`- ${flow.name} \`${flow.id}\` [${flow.priority}]: ${flow.files.join(", ")}`);
+      }
+      lines.push("");
+    }
+    lines.push("## YAML");
+    lines.push("");
+    lines.push("```yaml");
+    lines.push(result.yaml.trimEnd());
+    lines.push("```");
+    lines.push("");
+    return lines.join("\n");
+  }
+  return result.yaml;
+}
+
+export async function writeSuggestedManifest(
+  rootInput: string,
+  fileName: string,
+  content: string,
+  force = false,
+): Promise<string> {
+  const root = path.resolve(rootInput);
+  const outputPath = path.resolve(root, fileName);
+  if (!force && (await pathExists(outputPath))) {
+    throw new Error(`Refusing to overwrite ${outputPath}. Pass --force to replace it.`);
+  }
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, content, "utf8");
+  return outputPath;
+}
+
+function buildSuggestedDomains(plan: E2ePlanResult): DomainDefinition[] {
+  const domains: DomainDefinition[] = [];
+  const terms = plan.domainLanguage.terms.filter((term) => term.files.length > 0).slice(0, 8);
+
+  for (const term of terms) {
+    const files = uniqueStrings(term.files.map((file) => manifestRelativeFile(plan, file)).filter(isBehaviorFile));
+    const patterns = uniqueStrings(files.map(domainFilePattern)).slice(0, 4);
+    if (patterns.length === 0) {
+      continue;
+    }
+    const id = slugify(term.term);
+    const scenarios = scenariosForTerm(plan, term.term, files);
+    domains.push({
+      id,
+      name: term.term,
+      aliases: [],
+      files: patterns,
+      routes: routeHintsForFiles(plan, term.files).slice(0, 4),
+      tags: ["suggested"],
+      scenarios,
+    });
+  }
+
+  if (domains.length === 0) {
+    for (const flow of plan.flows.slice(0, 4)) {
+      const subject = durableSubject(flow.title);
+      const files = uniqueStrings(flow.files.map((file) => manifestRelativeFile(plan, file)).filter(isBehaviorFile));
+      const patterns = uniqueStrings(files.map(domainFilePattern)).slice(0, 4);
+      if (!subject || patterns.length === 0) {
+        continue;
+      }
+      domains.push({
+        id: slugify(subject),
+        name: subject,
+        aliases: [],
+        files: patterns,
+        routes: routeHintsForFiles(plan, flow.files).slice(0, 4),
+        tags: ["suggested"],
+        scenarios: [
+          {
+            title: `${subject} primary journey`,
+            checks: checksForFlow(flow),
+          },
+        ],
+      });
+    }
+  }
+
+  return dedupeDomains(domains).slice(0, 8);
+}
+
+function buildSuggestedFlows(plan: E2ePlanResult, domains: DomainDefinition[]): CoreFlowDefinition[] {
+  const flows: CoreFlowDefinition[] = [];
+  const scenarios = plan.domainLanguage.scenarios.length > 0
+    ? plan.domainLanguage.scenarios
+    : plan.flows.map((flow) => ({
+        title: flow.title,
+        intent: flow.reason,
+        checks: flow.steps,
+        files: flow.files,
+        source: "changed-file" as const,
+      }));
+
+  for (const scenario of scenarios.slice(0, 8)) {
+    const baseFlow = bestFlowForFiles(plan.flows, scenario.files);
+    const localFiles = scenario.files.length > 0 ? scenario.files : (baseFlow?.files ?? []);
+    const files = uniqueStrings(localFiles.map((file) => manifestRelativeFile(plan, file)).filter(isBehaviorFile));
+    const patterns = uniqueStrings(files.map(domainFilePattern)).slice(0, 5);
+    if (patterns.length === 0) {
+      continue;
+    }
+    const flowDomains = domainIdsForFiles(files, domains);
+    const checks = scenario.checks.length > 0 ? scenario.checks : baseFlow ? checksForFlow(baseFlow) : genericFlowChecks(scenario.title);
+    flows.push({
+      id: slugify(scenario.title),
+      name: scenario.title,
+      priority: priorityForFlow(scenario.title, baseFlow),
+      domains: flowDomains,
+      files: patterns,
+      routes: uniqueStrings([
+        ...routesForScenario(scenario),
+        ...routeHintsForFiles(plan, localFiles),
+      ]).slice(0, 4),
+      tags: ["suggested"],
+      checks: checks.slice(0, 6),
+    });
+  }
+
+  if (flows.length === 0) {
+    for (const flow of plan.flows.slice(0, 4)) {
+      const files = uniqueStrings(flow.files.map((file) => manifestRelativeFile(plan, file)).filter(isBehaviorFile));
+      const patterns = uniqueStrings(files.map(domainFilePattern)).slice(0, 5);
+      if (patterns.length === 0) {
+        continue;
+      }
+      flows.push({
+        id: slugify(flow.title),
+        name: flow.title,
+        priority: priorityForFlow(flow.title, flow),
+        domains: domainIdsForFiles(files, domains),
+        files: patterns,
+        routes: routeHintsForFiles(plan, flow.files).slice(0, 4),
+        tags: ["suggested"],
+        checks: checksForFlow(flow),
+      });
+    }
+  }
+
+  return dedupeFlows(flows).slice(0, 8);
+}
+
+function manifestSuggestionHeader(
+  title: string,
+  result: DomainManifestSuggestionResult | FlowManifestSuggestionResult,
+): string[] {
+  const lines: string[] = [];
+  lines.push(`# CodeWard ${title}`);
+  lines.push("");
+  lines.push(`- Root: \`${escapeMarkdownInline(result.root)}\``);
+  if (result.workspaceRoot) {
+    lines.push(`- Workspace root: \`${escapeMarkdownInline(result.workspaceRoot)}\``);
+  }
+  lines.push(`- Manifest root: \`${escapeMarkdownInline(result.manifestRoot)}\``);
+  lines.push(`- Base: \`${escapeMarkdownInline(result.base)}\``);
+  lines.push(`- Head: \`${escapeMarkdownInline(result.head)}\``);
+  if (result.includeWorkingTree) {
+    lines.push("- Includes working tree changes: yes");
+  }
+  lines.push(`- Changed files considered: ${result.changedFiles.length}`);
+  lines.push("");
+  return lines;
+}
+
+function formatSuggestedDomainManifestYaml(domains: DomainDefinition[]): string {
+  return [
+    "# Suggested by CodeWard. Review names, routes, and checks before committing.",
+    "# Commit this file as .codeward/domains.yml only when these words match team language.",
+    YAML.stringify({ domains }, { lineWidth: 0 }).trimEnd(),
+    "",
+  ].join("\n");
+}
+
+function formatSuggestedFlowManifestYaml(flows: CoreFlowDefinition[]): string {
+  return [
+    "# Suggested by CodeWard. Review priorities, routes, and checks before committing.",
+    "# Commit this file as .codeward/flows.yml only when these journeys are team-approved.",
+    YAML.stringify({ flows }, { lineWidth: 0 }).trimEnd(),
+    "",
+  ].join("\n");
+}
+
+function scenariosForTerm(plan: E2ePlanResult, term: string, manifestFiles: string[]): DomainScenarioDefinition[] {
+  const normalizedTerm = normalizeToken(term);
+  const scenario = plan.domainLanguage.scenarios.find((item) => {
+    const normalizedTitle = normalizeToken(item.title);
+    return normalizedTitle === normalizedTerm || normalizedTitle.startsWith(`${normalizedTerm}-`) || normalizedTitle.includes(normalizedTerm);
+  });
+  if (scenario) {
+    return [
+      {
+        title: scenario.title,
+        checks: scenario.checks.length > 0 ? scenario.checks.slice(0, 6) : genericFlowChecks(scenario.title),
+      },
+    ];
+  }
+
+  const localFiles = manifestFiles.map((file) => localRelativeFile(plan, file));
+  const flow = bestFlowForFiles(plan.flows, localFiles);
+  return [
+    {
+      title: `${term} primary journey`,
+      checks: flow ? checksForFlow(flow) : genericFlowChecks(term),
+    },
+  ];
+}
+
+function routesForScenario(scenario: unknown): string[] {
+  if (!scenario || typeof scenario !== "object" || !("routes" in scenario)) {
+    return [];
+  }
+  const routes = (scenario as { routes?: unknown }).routes;
+  return Array.isArray(routes) ? routes.filter((route): route is string => typeof route === "string") : [];
+}
+
+function checksForFlow(flow: E2eFlow): string[] {
+  const checks = uniqueStrings([
+    ...flow.steps,
+    ...flow.coverage.filter((target) => target.priority === "critical").flatMap((target) => target.checks),
+  ]);
+  return checks.length > 0 ? checks.slice(0, 6) : genericFlowChecks(flow.title);
+}
+
+function genericFlowChecks(subject: string): string[] {
+  return [
+    `Start from the normal entry point for ${subject}.`,
+    `Complete the main ${subject} action with realistic data.`,
+    `Confirm the visible result, saved state, navigation, or emitted event.`,
+    `Try one empty, blocked, rejected, or failed ${subject} path that a real user could hit.`,
+  ];
+}
+
+function priorityForFlow(title: string, flow: E2eFlow | undefined): CoreFlowPriority {
+  const text = `${title}\n${flow?.files.join("\n") ?? ""}`.toLowerCase();
+  if (/(checkout|billing|payment|purchase|subscription|auth|login|signup|permission|security|settlement)/.test(text)) {
+    return "critical";
+  }
+  if (flow?.coverage.some((target) => target.priority === "critical")) {
+    return "recommended";
+  }
+  return "optional";
+}
+
+function routeHintsForFiles(plan: E2ePlanResult, files: string[]): string[] {
+  const routes = new Set<string>();
+  const relatedFlows = plan.flows.filter((flow) => overlaps(flow.files, files));
+  for (const flow of relatedFlows) {
+    for (const entrypoint of flow.entrypoints) {
+      if (entrypoint.kind === "route") {
+        routes.add(entrypoint.value);
+      }
+    }
+  }
+  for (const file of files) {
+    const route = routeFromFile(file);
+    if (route) {
+      routes.add(route);
+    }
+  }
+  return [...routes].slice(0, 6);
+}
+
+function bestFlowForFiles(flows: E2eFlow[], files: string[]): E2eFlow | undefined {
+  let best: { flow: E2eFlow; score: number } | undefined;
+  for (const flow of flows) {
+    const score = overlapScore(flow.files, files);
+    if (!best || score > best.score) {
+      best = { flow, score };
+    }
+  }
+  return best && best.score > 0 ? best.flow : flows[0];
+}
+
+function domainIdsForFiles(files: string[], domains: DomainDefinition[]): string[] {
+  return domains
+    .filter((domain) =>
+      files.some((file) => domain.files.some((pattern) => fileMatchesPattern(file, pattern))) ||
+      files.some((file) => normalizeToken(file).includes(domain.id)),
+    )
+    .map((domain) => domain.id)
+    .slice(0, 4);
+}
+
+function dedupeDomains(domains: DomainDefinition[]): DomainDefinition[] {
+  const seen = new Set<string>();
+  const result: DomainDefinition[] = [];
+  for (const domain of domains) {
+    if (seen.has(domain.id)) {
+      continue;
+    }
+    seen.add(domain.id);
+    result.push(domain);
+  }
+  return result;
+}
+
+function dedupeFlows(flows: CoreFlowDefinition[]): CoreFlowDefinition[] {
+  const seen = new Set<string>();
+  const result: CoreFlowDefinition[] = [];
+  for (const flow of flows) {
+    if (seen.has(flow.id)) {
+      continue;
+    }
+    seen.add(flow.id);
+    result.push(flow);
+  }
+  return result;
+}
+
+function domainFilePattern(file: string): string {
+  const segments = file.split("/");
+  const anchors = ["features", "domains", "modules", "pages", "app", "routes", "screens", "services", "entities", "packages", "apps"];
+  for (const anchor of anchors) {
+    const index = segments.lastIndexOf(anchor);
+    if (index >= 0) {
+      const nextSegment = meaningfulSegmentAfter(segments, index);
+      if (nextSegment) {
+        const nextIndex = segments.indexOf(nextSegment, index + 1);
+        return `${segments.slice(0, nextIndex + 1).join("/")}/**`;
+      }
+    }
+  }
+  const directory = path.posix.dirname(file);
+  return directory === "." || directory === "src" ? file : `${directory}/**`;
+}
+
+function meaningfulSegmentAfter(segments: string[], index: number): string | undefined {
+  for (const segment of segments.slice(index + 1)) {
+    const normalized = normalizeToken(segment.replace(/\.[^.]+$/g, ""));
+    if (normalized && !ignoredPathSegments.has(normalized) && !/^\[.+\]$/.test(segment) && !/^\(.+\)$/.test(segment)) {
+      return segment;
+    }
+  }
+  return undefined;
+}
+
+function routeFromFile(file: string): string | undefined {
+  const segments = file.split("/");
+  const rootIndex = Math.max(segments.lastIndexOf("app"), segments.lastIndexOf("pages"), segments.lastIndexOf("routes"));
+  if (rootIndex < 0) {
+    return undefined;
+  }
+  const routeSegments = segments.slice(rootIndex + 1).map(normalizeRouteSegment).filter(Boolean);
+  const visibleSegments = routeSegments.filter((segment) => !["index", "page", "route", "layout"].includes(segment));
+  return visibleSegments.length > 0 ? `/${visibleSegments.join("/")}` : "/";
+}
+
+function normalizeRouteSegment(segment: string): string {
+  const stem = segment
+    .replace(/\.(?:d\.)?(?:[cm]?[jt]sx?|vue|svelte|mdx?)$/i, "")
+    .replace(/Page$/i, "");
+  const dynamic = stem.match(/^\[([^[\].]+)\]$/)?.[1];
+  if (dynamic) {
+    return `:${normalizeRouteParam(dynamic)}`;
+  }
+  if (/^\([^)]*\)$/.test(stem) || stem.startsWith("_")) {
+    return "";
+  }
+  return slugify(stem);
+}
+
+function normalizeRouteParam(value: string): string {
+  const normalized = value.replace(/[^A-Za-z0-9_$]+/g, "");
+  return normalized || "param";
+}
+
+function overlaps(left: string[], right: string[]): boolean {
+  return overlapScore(left, right) > 0;
+}
+
+function overlapScore(left: string[], right: string[]): number {
+  let score = 0;
+  for (const leftFile of left) {
+    for (const rightFile of right) {
+      if (leftFile === rightFile || leftFile.endsWith(`/${rightFile}`) || rightFile.endsWith(`/${leftFile}`)) {
+        score += 3;
+      } else if (path.posix.dirname(leftFile) === path.posix.dirname(rightFile)) {
+        score += 1;
+      }
+    }
+  }
+  return score;
+}
+
+function manifestRelativeFile(plan: E2ePlanResult, file: string): string {
+  if (!plan.workspaceRoot) {
+    return file;
+  }
+  const packagePrefix = toPosixPath(path.relative(plan.workspaceRoot, plan.root));
+  if (!packagePrefix || packagePrefix.startsWith("..") || path.isAbsolute(packagePrefix)) {
+    return file;
+  }
+  return toPosixPath(path.posix.join(packagePrefix, file));
+}
+
+function localRelativeFile(plan: E2ePlanResult, manifestFile: string): string {
+  if (!plan.workspaceRoot) {
+    return manifestFile;
+  }
+  const packagePrefix = toPosixPath(path.relative(plan.workspaceRoot, plan.root));
+  if (!packagePrefix || packagePrefix.startsWith("..") || path.isAbsolute(packagePrefix)) {
+    return manifestFile;
+  }
+  return manifestFile.startsWith(`${packagePrefix}/`) ? manifestFile.slice(packagePrefix.length + 1) : manifestFile;
+}
+
+function fileMatchesPattern(file: string, pattern: string): boolean {
+  const prefix = pattern.endsWith("/**") ? pattern.slice(0, -3) : pattern;
+  return file === prefix || file.startsWith(`${prefix}/`);
+}
+
+function durableSubject(title: string): string | undefined {
+  const cleaned = title
+    .replace(/\b(?:ui smoke flow|api contract smoke checklist|api contract smoke flow|state transition flow|workflow smoke checklist|workflow smoke flow|configuration verification checklist|configuration verification flow|content and theme smoke flow)\b/gi, "")
+    .trim();
+  return cleaned.length > 1 ? titleCase(cleaned) : undefined;
+}
+
+function isBehaviorFile(file: string): boolean {
+  return (
+    !/(?:^|\/)(?:__tests__|tests?|specs?|e2e)\//i.test(file) &&
+    !/(?:\.|-)(?:test|spec)\.[cm]?[jt]sx?$/i.test(file) &&
+    !/(?:^|\/)(?:docs?|\.github)\//i.test(file) &&
+    !/(?:^|\/)(?:README|CHANGELOG|LICENSE|CONTRIBUTING|CODE_OF_CONDUCT|SECURITY)\.md$/i.test(file) &&
+    !/(?:^|\/)(?:package|tsconfig|codeward\.config)\.json$/i.test(file)
+  );
+}
+
+function slugify(value: string): string {
+  const slug = value
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "suggested-flow";
+}
+
+function normalizeToken(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function titleCase(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[-_]+/g, " ")
+    .replace(/[^a-zA-Z0-9 ]+/g, " ")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function escapeMarkdownInline(value: string): string {
+  return value.replaceAll("`", "'");
+}
+
+const ignoredPathSegments = new Set([
+  "api",
+  "app",
+  "apps",
+  "component",
+  "components",
+  "index",
+  "layout",
+  "page",
+  "pages",
+  "route",
+  "routes",
+  "screen",
+  "screens",
+  "src",
+  "ui",
+]);
+
+export const defaultSuggestedDomainManifestPath = defaultDomainManifestPath;
+export const defaultSuggestedFlowManifestPath = defaultFlowManifestPath;

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -1931,6 +1931,108 @@ test("domains init creates a commit-friendly domain manifest", async () => {
   assert.match(manifest, /Billing primary journey/);
 });
 
+test("domains and flows suggest changed-file manifests for package scopes", async () => {
+  const workspaceRoot = await makeTempRepo();
+  const packageRoot = path.join(workspaceRoot, "services/offer");
+  await initGitRepo(workspaceRoot);
+  await mkdir(path.join(packageRoot, "src/pages/offer"), { recursive: true });
+  await writeFile(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify({
+      scripts: {
+        test: "node --test",
+      },
+      dependencies: {
+        vite: "^7.0.0",
+        "react-dom": "^19.0.0",
+      },
+    }),
+  );
+  await writeFile(
+    path.join(packageRoot, "src/pages/offer/[offerId].tsx"),
+    [
+      "export default function OfferPage() {",
+      "  return <button data-testid=\"apply-offer\">Apply</button>;",
+      "}",
+    ].join("\n"),
+  );
+  await git(workspaceRoot, ["add", "."]);
+  await git(workspaceRoot, ["commit", "-m", "base"]);
+  await git(workspaceRoot, ["branch", "-M", "main"]);
+
+  await git(workspaceRoot, ["switch", "-c", "feature/offer-apply"]);
+  await writeFile(
+    path.join(packageRoot, "src/pages/offer/[offerId].tsx"),
+    [
+      "export async function loadOffer(offerId) {",
+      "  const response = await fetch(`/api/offers/${offerId}`);",
+      "  return response.json();",
+      "}",
+      "export default function OfferPage() {",
+      "  return <button data-testid=\"apply-offer\">Apply offer</button>;",
+      "}",
+    ].join("\n"),
+  );
+  await git(workspaceRoot, ["add", "."]);
+  await git(workspaceRoot, ["commit", "-m", "update offer apply"]);
+
+  const domainOutput = await execFileAsync(process.execPath, [
+    cliPath,
+    "domains",
+    "suggest",
+    packageRoot,
+    "--workspace-root",
+    workspaceRoot,
+    "--base",
+    "main",
+    "--head",
+    "HEAD",
+  ]);
+  const flowOutput = await execFileAsync(process.execPath, [
+    cliPath,
+    "flows",
+    "suggest",
+    packageRoot,
+    "--workspace-root",
+    workspaceRoot,
+    "--base",
+    "main",
+    "--head",
+    "HEAD",
+  ]);
+  const writeOutput = await execFileAsync(process.execPath, [
+    cliPath,
+    "domains",
+    "suggest",
+    packageRoot,
+    "--workspace-root",
+    workspaceRoot,
+    "--base",
+    "main",
+    "--head",
+    "HEAD",
+    "--write",
+    ".codeward/domains.suggested.yml",
+  ]);
+  const writtenManifest = await readFile(path.join(workspaceRoot, ".codeward/domains.suggested.yml"), "utf8");
+
+  assert.match(domainOutput.stdout, /domains:/);
+  assert.match(domainOutput.stdout, /id: offer/);
+  assert.match(domainOutput.stdout, /name: Offer/);
+  assert.match(domainOutput.stdout, /services\/offer\/src\/pages\/offer\/\*\*/);
+  assert.match(domainOutput.stdout, /\/offer\/:offerId/);
+  assert.match(domainOutput.stdout, /Offer primary journey/);
+  assert.match(flowOutput.stdout, /flows:/);
+  assert.match(flowOutput.stdout, /id: offer-primary-journey/);
+  assert.match(flowOutput.stdout, /domains:/);
+  assert.match(flowOutput.stdout, /- offer/);
+  assert.match(flowOutput.stdout, /routes:/);
+  assert.match(flowOutput.stdout, /\/offer\/:offerId/);
+  assert.match(writeOutput.stdout, /Wrote /);
+  assert.match(writtenManifest, /domains:/);
+  assert.match(writtenManifest, /services\/offer\/src\/pages\/offer\/\*\*/);
+});
+
 test("configured validation commands feed test-plan and eval outputs", async () => {
   const root = await makeTempRepo();
   await initGitRepo(root);


### PR DESCRIPTION
## Summary

- add `domains suggest` and `flows suggest` commands for branch-aware manifest drafts
- generate YAML, Markdown, or JSON suggestions from E2E plan context without committing policy automatically
- support workspace-root package scans so suggested manifest file patterns stay relative to the workspace

## Validation

- `pnpm test`
- `pnpm build && git diff --check`
- `pnpm scan`
- smoke: `node dist/cli.js domains suggest . --base main --head HEAD --include-working-tree --format markdown`
- smoke: `node dist/cli.js flows suggest . --base main --head HEAD --include-working-tree --format markdown`
