### PR TITLE
feat: prioritize manifest suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,5 +15,6 @@ Working scope for the first public `0.1.0` release.
 - Bootstrap planning for projects with little or no E2E history, including required runner setup, first-draft, fixture, selector, and validation steps.
 - Domain language, domain manifest, and core-flow manifest support through `.codeward/domains.yml` and `.codeward/flows.yml`.
 - Change-aware `domains suggest` and `flows suggest` commands that draft manifest entries from branch context before teams commit durable policy.
+- Manifest suggestion promotion plans that classify candidates as `commit-candidate`, `needs-review`, or `low-signal`.
 - Fixture/mock readiness and validation matrix output for generated E2E plans and drafts.
 - Local E2E run history snapshots protected by generated `.gitignore` entries.

--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ node dist/cli.js scan /path/to/repo
 | `codeward e2e plan . --base origin/main --head HEAD --record-history` | Save a compact local run snapshot under `.codeward/runs/` while keeping JSON/Markdown output usable. |
 | `codeward e2e draft . --base origin/main --head HEAD` | Generate first-pass Maestro or Playwright E2E draft files from changed flows. |
 | `codeward flows init .` | Create a starter `.codeward/flows.yml` for team-approved core flow definitions. |
-| `codeward flows suggest . --base origin/main --head HEAD` | Generate suggested `.codeward/flows.yml` entries from changed files and E2E plan context. |
+| `codeward flows suggest . --base origin/main --head HEAD` | Generate suggested `.codeward/flows.yml` entries with commit-readiness guidance from changed files and E2E plan context. |
 | `codeward domains init .` | Create a starter `.codeward/domains.yml` for shared product/domain language. |
-| `codeward domains suggest . --base origin/main --head HEAD` | Generate suggested `.codeward/domains.yml` entries from changed files and inferred product language. |
+| `codeward domains suggest . --base origin/main --head HEAD` | Generate suggested `.codeward/domains.yml` entries with commit-readiness guidance from changed files and inferred product language. |
 | `codeward history init .` | Create local CodeWard history directories and protect generated run history with `.gitignore`. |
 | `codeward doctor services/offer --workspace-root .` | Scan a monorepo package while using root guardrails. |
 | `codeward context . --write AGENTS.md` | Generate starter agent instructions for the repo. |
@@ -176,7 +176,7 @@ domains:
           - Complete the primary billing action with realistic data.
 ```
 
-Run `codeward domains init .` to create a starter domain manifest. Run `codeward domains suggest . --base origin/main --head HEAD` when you want CodeWard to draft manifest entries from the current branch. Use domains for naming and route hints; use core flows when the team wants to define a durable verification journey.
+Run `codeward domains init .` to create a starter domain manifest. Run `codeward domains suggest . --base origin/main --head HEAD` when you want CodeWard to draft manifest entries from the current branch and classify each candidate as `commit-candidate`, `needs-review`, or `low-signal`. Use domains for naming and route hints; use core flows when the team wants to define a durable verification journey.
 
 If `.codeward/flows.yml` exists, `codeward e2e plan` also matches changed files against team-approved core flows. This lets maintainers encode the product or domain flows humans already care about:
 
@@ -197,7 +197,7 @@ flows:
       - Verify declined payment recovery.
 ```
 
-Run `codeward flows init .` to create a starter manifest. Run `codeward flows suggest . --base origin/main --head HEAD` when you want CodeWard to draft flow entries from changed files, inferred domain language, routes, and E2E checks. Unlike generated run history, `.codeward/flows.yml` is meant to be reviewed and committed when those flow definitions should become team policy.
+Run `codeward flows init .` to create a starter manifest. Run `codeward flows suggest . --base origin/main --head HEAD` when you want CodeWard to draft flow entries from changed files, inferred domain language, routes, and E2E checks, then classify which entries are close enough to review as shared policy. Unlike generated run history, `.codeward/flows.yml` is meant to be reviewed and committed when those flow definitions should become team policy.
 
 Pass `--record-history` when you want CodeWard to keep a compact local snapshot of an E2E plan under `.codeward/runs/`. CodeWard automatically protects `.codeward/runs/`, `.codeward/cache/`, `.codeward/tmp/`, and `.codeward/*.local.json` with `.gitignore` so generated history stays local by default. Shared project policy, such as `codeward.config.json`, `.codeward/domains.yml`, and `.codeward/flows.yml`, remains commit-friendly.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,7 @@ codeward domains suggest . --base origin/main --head HEAD
 ```
 
 `.codeward/domains.yml` is meant to be committed when the team wants CodeWard to use shared product language during E2E planning.
+The `suggest` command prints candidate YAML plus a promotion plan that separates `commit-candidate`, `needs-review`, and `low-signal` entries.
 
 ```yaml
 domains:
@@ -131,6 +132,7 @@ codeward flows suggest . --base origin/main --head HEAD
 ```
 
 `.codeward/flows.yml` is meant to be committed when the team wants CodeWard to understand project-specific flows during E2E planning.
+The `suggest` command prints candidate YAML plus a promotion plan that helps teams decide which flows are durable enough to commit.
 
 ```yaml
 flows:

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -642,6 +642,8 @@ function buildE2eBootstrapPlan(input: E2eBootstrapPlanInput): E2eBootstrapPlan {
   const runnerGap = input.missingTestability.find((gap) => /No \.maestro|No Playwright config/i.test(gap));
   const draftCommand = `codeward e2e draft . --base ${input.base} --head ${input.head}`;
   const planHistoryCommand = `codeward e2e plan . --base ${input.base} --head ${input.head} --record-history`;
+  const domainsSuggestCommand = `codeward domains suggest . --base ${input.base} --head ${input.head}`;
+  const flowsSuggestCommand = `codeward flows suggest . --base ${input.base} --head ${input.head}`;
 
   if (input.recommendedRunner.name === "manual") {
     steps.push(
@@ -716,8 +718,8 @@ function buildE2eBootstrapPlan(input: E2eBootstrapPlanInput): E2eBootstrapPlan {
         "recommended",
         "Promote repeated product words into a domain manifest",
         `CodeWard inferred ${input.domainLanguage.terms.length} domain term${input.domainLanguage.terms.length === 1 ? "" : "s"} from changed files, but no shared domain manifest was found.`,
-        "Create or update .codeward/domains.yml with the terms reviewers already use for this behavior.",
-        ["codeward domains init ."],
+        "Generate a suggested domain manifest from this branch, review names and routes with the team, then commit only the terms that match team language.",
+        [domainsSuggestCommand, `${domainsSuggestCommand} --write .codeward/domains.yml`],
         input.domainLanguage.terms.flatMap((term) => term.files).slice(0, maxFilesPerFlow),
       ),
     );
@@ -744,8 +746,8 @@ function buildE2eBootstrapPlan(input: E2eBootstrapPlanInput): E2eBootstrapPlan {
         input.flows.length > 0 ? "recommended" : "required",
         "Capture the first durable core flows",
         "No .codeward/flows.yml manifest was found, so CodeWard can infer changed-flow candidates but cannot distinguish team-critical journeys yet.",
-        "Add the highest-value product journeys to .codeward/flows.yml so future PRs can be evaluated against team-approved lifecycle checks.",
-        ["codeward flows init ."],
+        "Generate suggested flow entries from this branch, keep only the journeys humans agree are durable, then commit them as team policy.",
+        [flowsSuggestCommand, `${flowsSuggestCommand} --write .codeward/flows.yml`],
         input.flows.flatMap((flow) => flow.files).slice(0, maxFilesPerFlow),
       ),
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,14 @@ export type {
 } from "./flows.js";
 export type { GitHubActionMode, GitHubActionOptions, GitHubActionResult } from "./github.js";
 export type { E2ePlanHistorySnapshot, LocalHistoryInitResult, LocalHistoryReference } from "./history.js";
-export type { DomainManifestSuggestionResult, FlowManifestSuggestionResult, ManifestSuggestionOptions } from "./manifest-suggestions.js";
+export type {
+  DomainManifestSuggestionResult,
+  FlowManifestSuggestionResult,
+  ManifestPromotionCandidate,
+  ManifestPromotionPlan,
+  ManifestPromotionStatus,
+  ManifestSuggestionOptions,
+} from "./manifest-suggestions.js";
 export type { ChangedFile, ChangedRiskyFinding, ReviewOptions, ReviewResult } from "./review.js";
 export type { TestPlanChangedFile, TestPlanItem, TestPlanOptions, TestPlanResult } from "./test-plan.js";
 export type { CodeWardConfig, Finding, ScanCounts, ScanOptions, ScanResult, Severity } from "./types.js";

--- a/src/manifest-suggestions.ts
+++ b/src/manifest-suggestions.ts
@@ -12,6 +12,28 @@ import type { CoreFlowDefinition, CoreFlowPriority } from "./flows.js";
 
 export interface ManifestSuggestionOptions extends E2ePlanOptions {}
 
+export type ManifestPromotionStatus = "commit-candidate" | "needs-review" | "low-signal";
+
+export interface ManifestPromotionCandidate {
+  id: string;
+  name: string;
+  status: ManifestPromotionStatus;
+  reason: string;
+  action: string;
+  files: string[];
+  routes: string[];
+}
+
+export interface ManifestPromotionPlan {
+  summary: string;
+  candidates: ManifestPromotionCandidate[];
+  counts: {
+    commitCandidate: number;
+    needsReview: number;
+    lowSignal: number;
+  };
+}
+
 export interface DomainManifestSuggestionResult {
   tool: {
     name: string;
@@ -27,6 +49,7 @@ export interface DomainManifestSuggestionResult {
   includeWorkingTree: boolean;
   changedFiles: string[];
   domains: DomainDefinition[];
+  promotionPlan: ManifestPromotionPlan;
   yaml: string;
 }
 
@@ -45,6 +68,7 @@ export interface FlowManifestSuggestionResult {
   includeWorkingTree: boolean;
   changedFiles: string[];
   flows: CoreFlowDefinition[];
+  promotionPlan: ManifestPromotionPlan;
   yaml: string;
 }
 
@@ -54,6 +78,7 @@ export async function generateDomainManifestSuggestion(
 ): Promise<DomainManifestSuggestionResult> {
   const plan = await generateE2ePlan(rootInput, options);
   const domains = buildSuggestedDomains(plan);
+  const promotionPlan = buildDomainPromotionPlan(domains);
   return {
     tool: {
       name: TOOL_NAME,
@@ -69,6 +94,7 @@ export async function generateDomainManifestSuggestion(
     includeWorkingTree: plan.includeWorkingTree,
     changedFiles: plan.changedFiles.map((file) => manifestRelativeFile(plan, file.path)),
     domains,
+    promotionPlan,
     yaml: formatSuggestedDomainManifestYaml(domains),
   };
 }
@@ -80,6 +106,7 @@ export async function generateFlowManifestSuggestion(
   const plan = await generateE2ePlan(rootInput, options);
   const domains = buildSuggestedDomains(plan);
   const flows = buildSuggestedFlows(plan, domains);
+  const promotionPlan = buildFlowPromotionPlan(flows);
   return {
     tool: {
       name: TOOL_NAME,
@@ -95,6 +122,7 @@ export async function generateFlowManifestSuggestion(
     includeWorkingTree: plan.includeWorkingTree,
     changedFiles: plan.changedFiles.map((file) => manifestRelativeFile(plan, file.path)),
     flows,
+    promotionPlan,
     yaml: formatSuggestedFlowManifestYaml(flows),
   };
 }
@@ -105,6 +133,7 @@ export function formatDomainManifestSuggestion(result: DomainManifestSuggestionR
   }
   if (format === "markdown") {
     const lines = manifestSuggestionHeader("Domain Manifest Suggestion", result);
+    appendPromotionPlan(lines, result.promotionPlan);
     lines.push("## Suggested Domains");
     lines.push("");
     if (result.domains.length === 0) {
@@ -133,6 +162,7 @@ export function formatFlowManifestSuggestion(result: FlowManifestSuggestionResul
   }
   if (format === "markdown") {
     const lines = manifestSuggestionHeader("Core Flow Manifest Suggestion", result);
+    appendPromotionPlan(lines, result.promotionPlan);
     lines.push("## Suggested Flows");
     lines.push("");
     if (result.flows.length === 0) {
@@ -280,6 +310,165 @@ function buildSuggestedFlows(plan: E2ePlanResult, domains: DomainDefinition[]): 
   }
 
   return dedupeFlows(flows).slice(0, 8);
+}
+
+function buildDomainPromotionPlan(domains: DomainDefinition[]): ManifestPromotionPlan {
+  const candidates = domains.map((domain) => {
+    const status = domainPromotionStatus(domain);
+    return {
+      id: domain.id,
+      name: domain.name,
+      status,
+      reason: domainPromotionReason(domain, status),
+      action: domainPromotionAction(status),
+      files: domain.files,
+      routes: domain.routes,
+    };
+  });
+  return buildPromotionPlan(candidates);
+}
+
+function buildFlowPromotionPlan(flows: CoreFlowDefinition[]): ManifestPromotionPlan {
+  const candidates = flows.map((flow) => {
+    const status = flowPromotionStatus(flow);
+    return {
+      id: flow.id,
+      name: flow.name,
+      status,
+      reason: flowPromotionReason(flow, status),
+      action: flowPromotionAction(status),
+      files: flow.files,
+      routes: flow.routes,
+    };
+  });
+  return buildPromotionPlan(candidates);
+}
+
+function buildPromotionPlan(candidates: ManifestPromotionCandidate[]): ManifestPromotionPlan {
+  const sortedCandidates = [...candidates].sort(comparePromotionCandidates);
+  const counts = {
+    commitCandidate: sortedCandidates.filter((candidate) => candidate.status === "commit-candidate").length,
+    needsReview: sortedCandidates.filter((candidate) => candidate.status === "needs-review").length,
+    lowSignal: sortedCandidates.filter((candidate) => candidate.status === "low-signal").length,
+  };
+  return {
+    summary: promotionSummary(counts),
+    candidates: sortedCandidates,
+    counts,
+  };
+}
+
+function domainPromotionStatus(domain: DomainDefinition): ManifestPromotionStatus {
+  const hasScenarioChecks = domain.scenarios.some((scenario) => scenario.checks.length >= 3);
+  if (domain.routes.length > 0 && hasScenarioChecks) {
+    return "commit-candidate";
+  }
+  if (domain.files.length > 0 && domain.scenarios.length > 0) {
+    return "needs-review";
+  }
+  return "low-signal";
+}
+
+function flowPromotionStatus(flow: CoreFlowDefinition): ManifestPromotionStatus {
+  if ((flow.priority === "critical" || flow.routes.length > 0) && flow.domains.length > 0 && flow.checks.length >= 3) {
+    return "commit-candidate";
+  }
+  if (flow.files.length > 0 && flow.checks.length >= 2) {
+    return "needs-review";
+  }
+  return "low-signal";
+}
+
+function domainPromotionReason(domain: DomainDefinition, status: ManifestPromotionStatus): string {
+  if (status === "commit-candidate") {
+    return "The candidate has route evidence plus scenario checks, so it is close to commit-ready if the name matches team language.";
+  }
+  if (status === "needs-review") {
+    return "The candidate has file and scenario evidence, but routes or stronger checks should be reviewed before committing.";
+  }
+  return "The candidate is mostly path-derived and should stay as an exploration note until the team confirms the language.";
+}
+
+function flowPromotionReason(flow: CoreFlowDefinition, status: ManifestPromotionStatus): string {
+  if (status === "commit-candidate") {
+    return "The candidate has domains, route or criticality evidence, and multiple checks, so it can be reviewed as team policy.";
+  }
+  if (status === "needs-review") {
+    return "The candidate has changed-file evidence and checks, but needs human confirmation of priority, domains, or routes.";
+  }
+  return "The candidate is low-signal and should not be committed until it is tied to a real user journey.";
+}
+
+function domainPromotionAction(status: ManifestPromotionStatus): string {
+  if (status === "commit-candidate") {
+    return "Review the name with the team, remove the suggested tag if accepted, then commit it to .codeward/domains.yml.";
+  }
+  if (status === "needs-review") {
+    return "Add aliases, routes, or better scenario checks before committing this domain.";
+  }
+  return "Keep this out of shared policy until repeated PRs prove the term is durable.";
+}
+
+function flowPromotionAction(status: ManifestPromotionStatus): string {
+  if (status === "commit-candidate") {
+    return "Confirm this is a durable journey, adjust priority if needed, then commit it to .codeward/flows.yml.";
+  }
+  if (status === "needs-review") {
+    return "Confirm owner, route, priority, and failure-path checks before committing this flow.";
+  }
+  return "Keep this as a temporary note until the journey is tied to a stable product flow.";
+}
+
+function promotionSummary(counts: ManifestPromotionPlan["counts"]): string {
+  if (counts.commitCandidate > 0) {
+    return `${counts.commitCandidate} candidate${counts.commitCandidate === 1 ? "" : "s"} look close enough to review for shared policy.`;
+  }
+  if (counts.needsReview > 0) {
+    return `${counts.needsReview} candidate${counts.needsReview === 1 ? "" : "s"} need human review before they should be committed.`;
+  }
+  return "No candidates are strong enough to commit as shared policy yet.";
+}
+
+function comparePromotionCandidates(left: ManifestPromotionCandidate, right: ManifestPromotionCandidate): number {
+  const statusDiff = promotionStatusRank(left.status) - promotionStatusRank(right.status);
+  if (statusDiff !== 0) {
+    return statusDiff;
+  }
+  return left.name.localeCompare(right.name);
+}
+
+function promotionStatusRank(status: ManifestPromotionStatus): number {
+  if (status === "commit-candidate") {
+    return 0;
+  }
+  if (status === "needs-review") {
+    return 1;
+  }
+  return 2;
+}
+
+function appendPromotionPlan(lines: string[], plan: ManifestPromotionPlan): void {
+  lines.push("## Promotion Plan");
+  lines.push("");
+  lines.push(plan.summary);
+  lines.push("");
+  lines.push(
+    `Summary: ${plan.counts.commitCandidate} commit-candidate, ${plan.counts.needsReview} needs-review, ${plan.counts.lowSignal} low-signal.`,
+  );
+  lines.push("");
+  if (plan.candidates.length === 0) {
+    lines.push("No candidates were produced.");
+    lines.push("");
+    return;
+  }
+  lines.push("| Status | Candidate | Reason | Action |");
+  lines.push("| --- | --- | --- | --- |");
+  for (const candidate of plan.candidates) {
+    lines.push(
+      `| ${candidate.status} | ${escapeMarkdownTableCell(candidate.name)} \`${escapeMarkdownInline(candidate.id)}\` | ${escapeMarkdownTableCell(candidate.reason)} | ${escapeMarkdownTableCell(candidate.action)} |`,
+    );
+  }
+  lines.push("");
 }
 
 function manifestSuggestionHeader(
@@ -599,6 +788,10 @@ function uniqueStrings(values: string[]): string[] {
 
 function escapeMarkdownInline(value: string): string {
   return value.replaceAll("`", "'");
+}
+
+function escapeMarkdownTableCell(value: string): string {
+  return escapeMarkdownInline(value).replaceAll("|", "\\|").replace(/\r?\n/g, " ");
 }
 
 const ignoredPathSegments = new Set([

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -23,6 +23,8 @@ import {
   generateAgentContext,
   generateE2eDraft,
   generateE2ePlan,
+  generateDomainManifestSuggestion,
+  generateFlowManifestSuggestion,
   generateTestPlan,
   initializeLocalHistory,
   loadConfig,
@@ -965,8 +967,8 @@ test("generateE2ePlan builds a bootstrap plan for projects without tests", async
   assert.ok(plan.bootstrap.steps.some((step) => step.category === "testability" && step.status === "required"));
   assert.ok(plan.bootstrap.steps.some((step) => step.category === "domain-language" && step.status === "recommended"));
   assert.ok(plan.bootstrap.steps.some((step) => step.category === "core-flow" && step.status === "recommended"));
-  assert.ok(plan.bootstrap.steps.some((step) => step.commands.includes("codeward domains init .")));
-  assert.ok(plan.bootstrap.steps.some((step) => step.commands.includes("codeward flows init .")));
+  assert.ok(plan.bootstrap.steps.some((step) => step.commands.includes("codeward domains suggest . --base main --head HEAD")));
+  assert.ok(plan.bootstrap.steps.some((step) => step.commands.includes("codeward flows suggest . --base main --head HEAD")));
   assert.match(plan.bootstrap.summary, /required bootstrap step/);
   assert.match(markdown, /## Bootstrap Plan/);
   assert.match(markdown, /Create the first changed-flow E2E draft/);
@@ -2015,6 +2017,16 @@ test("domains and flows suggest changed-file manifests for package scopes", asyn
     ".codeward/domains.suggested.yml",
   ]);
   const writtenManifest = await readFile(path.join(workspaceRoot, ".codeward/domains.suggested.yml"), "utf8");
+  const domainSuggestion = await generateDomainManifestSuggestion(packageRoot, {
+    workspaceRoot,
+    base: "main",
+    head: "HEAD",
+  });
+  const flowSuggestion = await generateFlowManifestSuggestion(packageRoot, {
+    workspaceRoot,
+    base: "main",
+    head: "HEAD",
+  });
 
   assert.match(domainOutput.stdout, /domains:/);
   assert.match(domainOutput.stdout, /id: offer/);
@@ -2031,6 +2043,14 @@ test("domains and flows suggest changed-file manifests for package scopes", asyn
   assert.match(writeOutput.stdout, /Wrote /);
   assert.match(writtenManifest, /domains:/);
   assert.match(writtenManifest, /services\/offer\/src\/pages\/offer\/\*\*/);
+  assert.equal(domainSuggestion.promotionPlan.counts.commitCandidate, 1);
+  assert.equal(domainSuggestion.promotionPlan.candidates[0].status, "commit-candidate");
+  assert.equal(domainSuggestion.promotionPlan.candidates[0].id, "offer");
+  assert.match(domainSuggestion.promotionPlan.candidates[0].action, /\.codeward\/domains\.yml/);
+  assert.equal(flowSuggestion.promotionPlan.counts.commitCandidate, 1);
+  assert.equal(flowSuggestion.promotionPlan.candidates[0].status, "commit-candidate");
+  assert.equal(flowSuggestion.promotionPlan.candidates[0].id, "offer-primary-journey");
+  assert.match(flowSuggestion.promotionPlan.candidates[0].action, /\.codeward\/flows\.yml/);
 });
 
 test("configured validation commands feed test-plan and eval outputs", async () => {


### PR DESCRIPTION
## Summary

- add promotion plans to domain and core-flow manifest suggestions
- classify suggested entries as `commit-candidate`, `needs-review`, or `low-signal`
- update E2E bootstrap guidance to point users at `domains suggest` and `flows suggest` before committing policy

## Validation

- `pnpm test`
- `git diff --check`
- `pnpm scan`
- smoke: `node dist/cli.js domains suggest . --base main --head HEAD --include-working-tree --format markdown`
- smoke: `node dist/cli.js flows suggest . --base main --head HEAD --include-working-tree --format markdown`
