### PR TITLE
feat: structure playwright drafts by flow steps

### DIFF
--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -3294,16 +3294,19 @@ function buildPlaywrightDraft(plan: E2ePlanResult, flow: E2eFlow): string {
     lines.push("  };");
     lines.push("  // TODO: Replace routeParams with fixture ids, tabs, or slugs from the target environment.");
   }
-  lines.push(`  await page.goto(${routeDraft.expression});`);
+  appendPlaywrightTestStep(lines, flow.languageBrief.trigger, [
+    `await page.goto(${routeDraft.expression});`,
+  ]);
   for (const step of flow.steps) {
     const selector = takeSelectorForStep(selectorQueue, step);
     const locator = selector ? playwrightLocator(selector) : 'page.getByText("TODO")';
-    lines.push(`  // TODO: ${step}`);
-    if (isVerificationStep(step) && !isInteractionStep(step)) {
-      lines.push(`  await expect(${locator}).toBeVisible();`);
-    } else {
-      lines.push(`  await ${locator}.click();`);
-    }
+    const body = [`// TODO: ${step}`];
+    body.push(
+      isVerificationStep(step) && !isInteractionStep(step)
+        ? `await expect(${locator}).toBeVisible();`
+        : `await ${locator}.click();`,
+    );
+    appendPlaywrightTestStep(lines, step, body);
   }
   appendDomainScenarioComments(lines, flow, "  //");
   appendPlaywrightCoverageComments(lines, flow);
@@ -3723,6 +3726,23 @@ function appendPlaywrightCoverageComments(lines: string[], flow: E2eFlow): void 
       lines.push(`  //   - [ ] ${check}`);
     }
   }
+}
+
+function appendPlaywrightTestStep(lines: string[], title: string, body: string[]): void {
+  lines.push("");
+  lines.push(`  await test.step("${quoteJs(playwrightStepTitle(title))}", async () => {`);
+  for (const line of body) {
+    lines.push(`    ${line}`);
+  }
+  lines.push("  });");
+}
+
+function playwrightStepTitle(value: string): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return "Run generated flow step";
+  }
+  return normalized.length > 96 ? `${normalized.slice(0, 93).trim()}...` : normalized;
 }
 
 function sameStringList(left: string[], right: string[]): boolean {

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -1212,6 +1212,9 @@ test("generateE2ePlan matches committed core flow definitions", async () => {
   assert.match(spec, /Manifest promotion guidance/);
   assert.match(spec, /Status: commit-candidate/);
   assert.match(spec, /\[partial\] Checkout purchase: Make the matched core flow checks required validation evidence/);
+  assert.match(spec, /await test\.step\("Open route \/checkout\.", async \(\) => \{/);
+  assert.match(spec, /await test\.step\("Complete checkout with a valid payment method\.", async \(\) => \{/);
+  assert.match(spec, /await test\.step\("Verify declined payment recovery\.", async \(\) => \{/);
   assert.match(spec, /page\.goto\("\/checkout"\)/);
   assert.match(spec, /TODO: Complete checkout with a valid payment method\./);
 });
@@ -1307,6 +1310,8 @@ test("generateE2ePlan uses committed domain manifests for language and draft rou
   assert.match(spec, /Actor: Customer/);
   assert.match(spec, /Manifest promotion guidance/);
   assert.match(spec, /Status: commit-candidate/);
+  assert.match(spec, /await test\.step\("Open route \/membership\/renewal\.", async \(\) => \{/);
+  assert.match(spec, /await test\.step\("Renew an active membership with realistic billing data\.", async \(\) => \{/);
   assert.match(spec, /page\.goto\("\/membership\/renewal"\)/);
   assert.match(spec, /TODO: Renew an active membership with realistic billing data\./);
 });
@@ -1527,6 +1532,7 @@ test("generateE2eDraft creates a fallback smoke draft without changed files", as
   assert.match(spec, /Flow: App launch smoke flow/);
   assert.match(spec, /Flow language brief/);
   assert.match(spec, /Status: low-signal/);
+  assert.match(spec, /await test\.step\("Launch the app and wait for the first stable screen\.", async \(\) => \{/);
   assert.match(spec, /page\.goto\("\/"\)/);
 });
 


### PR DESCRIPTION
## Summary
- wrap generated Playwright draft navigation in a language-brief trigger test.step
- wrap each generated flow action/assertion in a named test.step
- verify core-flow, domain-manifest, and fallback smoke drafts keep structured step names

## Verification
- pnpm test
- pnpm scan
- git diff --check