### PR TITLE
docs: add release validation evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ HIGH
 
 ## Install
 
-The package metadata is ready for the first npm release, but the public package should wait until release validation covers representative web, mobile, monorepo, and test-light repositories. See [0.1.0 release validation](docs/release-validation.md).
+The package metadata is ready for the first npm release, but the public package should wait until release validation covers representative web, mobile, API/service, monorepo, and test-light repositories. See [0.1.0 release validation](docs/release-validation.md) and [E2E output examples](docs/e2e-output-examples.md).
 
 ```sh
 pnpm dlx @ivorycanvas/codeward scan .
@@ -213,6 +213,8 @@ The draft result is meant to be useful as a PR artifact, not only as generated f
 - `actionItems`: required and recommended follow-up work, grouped by assertion, fixture, selector, runner, validation, and manifest
 - `actionSummary`: total required/recommended action counts, ready file count, and the most common action categories
 
+See [docs/e2e-output-examples.md](docs/e2e-output-examples.md) for compact examples of web, mobile, API/service, test-light, and monorepo output.
+
 Generated Playwright drafts use the flow language as `test.step()` names so the file reads like the user journey it protects:
 
 ```ts
@@ -324,7 +326,7 @@ CodeWard starts as a local CLI and should stay small enough that maintainers can
 
 Near-term priorities:
 
-- finish the [0.1.0 release validation](docs/release-validation.md) checklist across representative web, mobile, monorepo, and test-light repositories
+- finish the [0.1.0 release validation](docs/release-validation.md) checklist across representative web, mobile, API/service, monorepo, and test-light repositories
 - publish a versioned GitHub Action release tag after the first public package is ready
 - improve branch-aware `review` changed-line locations
 - improve generated domain test plans with framework-specific test skeletons

--- a/docs/e2e-output-examples.md
+++ b/docs/e2e-output-examples.md
@@ -1,0 +1,162 @@
+# E2E Output Examples
+
+These examples show the shape of CodeWard output that should be good enough for the first public release. They are intentionally short snippets, not full generated files. The important property is that they are derived from repository structure, git changes, manifests, and test evidence without an LLM call.
+
+## Web Core Flow
+
+When a web app declares a core flow:
+
+```yaml
+flows:
+  - id: checkout-purchase
+    name: Checkout purchase
+    priority: critical
+    files:
+      - src/pages/checkout/**
+    routes:
+      - /checkout
+    checks:
+      - Complete checkout with a valid payment method.
+      - Verify declined payment recovery.
+```
+
+`codeward e2e plan` should prefer the team-approved name:
+
+```txt
+Project: Web
+Recommended runner: Playwright
+Matched core flows: 1
+
+Flow: Checkout purchase UI smoke flow
+Actor: Customer
+Trigger: Open route /checkout.
+Success signal: Verify declined payment recovery
+```
+
+The Playwright draft should read like the product journey:
+
+```ts
+test("Checkout purchase", async ({ page }) => {
+  await test.step("Open route /checkout.", async () => {
+    await page.goto("/checkout");
+  });
+
+  await test.step("Complete checkout with a valid payment method.", async () => {
+    await page.getByTestId("checkout-submit").click();
+  });
+});
+```
+
+## Expo / React Native Flow
+
+For an Expo or React Native change, CodeWard should recommend Maestro and carry mobile selectors into the draft:
+
+```txt
+Project: Expo / React Native
+Recommended runner: Maestro
+
+Flow: Ink Drawing UI smoke flow
+Actor: User
+Trigger: Open the Ink Drawing screen.
+Selectors: testID=ink-save-button, testID=record-mode-ink
+```
+
+Example Maestro draft shape:
+
+```yaml
+appId: ${APP_ID}
+---
+- launchApp
+- tapOn: { id: "record-mode-ink" }
+- tapOn: { id: "ink-save-button" }
+```
+
+## API / Service Contract
+
+For backend changes such as `src/v1/offer/utils.ts`, CodeWard should not invent a browser journey. It should infer the domain word and stay contract-focused:
+
+```txt
+Project: API / service
+Recommended runner: Manual
+
+Flow: Offer API contract smoke checklist
+Actor: API consumer or upstream service
+Trigger: Call the endpoint, handler, or service path affected by src/v1/offer/utils.ts.
+Success signal: the changed contract returns the expected status, response shape, auth behavior, and failure handling
+```
+
+The manual draft should stay actionable:
+
+```md
+# Offer API contract
+
+## Steps
+
+- [ ] Call the changed endpoint, client, command, or handler with a valid request.
+- [ ] Verify the response shape, status, and parsed data match the public contract.
+- [ ] Verify invalid input, authorization failure, timeout, and server-error handling.
+- [ ] Check backward compatibility for existing callers.
+```
+
+## Test-Light Project
+
+When a project has little or no E2E setup, CodeWard should be honest about what must happen before a draft becomes regression coverage:
+
+```txt
+Bootstrap summary:
+4 required bootstrap steps must be resolved before generated E2E drafts should be treated as regression coverage.
+
+Required:
+- Configure Playwright before making drafts required
+- Create the first changed-flow E2E draft
+- Add deterministic fixture or mock responses
+- Add stable selectors for changed UI surfaces
+```
+
+Draft action items should make the next developer action explicit:
+
+```txt
+Action summary:
+- required assertion: Turn generated TODOs into runnable assertions
+- required fixture: Add deterministic fixture or mock data
+- required validation: Resolve missing validation evidence
+- recommended manifest: Promote durable product language
+```
+
+## Monorepo Package
+
+For package scans, CodeWard should use workspace policy without leaking workspace-root paths into package-local drafts:
+
+```sh
+codeward e2e plan services/offer --workspace-root . --base main --head HEAD
+```
+
+Expected behavior:
+
+```txt
+Workspace root: .
+Package root: services/offer
+Matched core flow: Offer submit
+Changed files: src/features/offer/submit.ts
+Generated draft path: docs/e2e/offer-submit.md
+```
+
+The draft should mention package-local files:
+
+```md
+Related Changed Files
+
+- `src/features/offer/submit.ts`
+```
+
+## What Good Output Feels Like
+
+Good CodeWard output should answer these questions quickly:
+
+- What behavior did this branch probably change?
+- What does the team call that behavior?
+- Who or what exercises it?
+- Which runner or checklist is the right first shape?
+- Which setup, selector, fixture, or validation gap blocks this from becoming real regression coverage?
+
+If the output only says "make an E2E test" without these answers, it is not ready for `0.1.0`.

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -70,6 +70,32 @@ The E2E draft should show:
 - `actionSummary` with required and recommended action counts
 - Playwright `test.step()` names that read like the product journey
 
+## Current Fixture Evidence Matrix
+
+The matrix below is public, fixture-backed evidence from the repository test suite. It is not a substitute for final manual validation against real projects, but it proves the release bar with reproducible scenarios that can run in CI without an LLM call.
+
+| Target | Fixture-backed coverage | Expected output |
+| --- | --- | --- |
+| Web app with Playwright routes | `generateE2ePlan matches committed core flow definitions`; `generateE2eDraft uses web selectors in Playwright specs` | `Web` project profile, `playwright` runner, core-flow names such as `Checkout purchase`, route-aware Playwright drafts, stable selector hints, action items, and validation gaps. |
+| Expo / React Native mobile app | `generateE2ePlan recommends mobile flows for Expo changes`; `generateE2eDraft scopes entrypoint hints to each domain scenario` | `Expo / React Native` project profile, `maestro` runner, Maestro YAML drafts, `testID`/`accessibilityLabel` selector hints, and mobile setup actions. |
+| API or backend service | `generateE2ePlan detects API service projects and suggests contract checklists`; `generateE2ePlan names versioned API service paths with domain language`; `generateE2ePlan uses matched core flow names for API service contracts` | `API / service` project profile, manual contract checklist, domain-aware titles such as `Offer API contract`, API consumer actor, endpoint/handler/service-path trigger, and contract failure coverage. |
+| Monorepo package with workspace policy | `generateE2ePlan matches workspace core flows for package scans`; `generateTestPlan scopes monorepo changes to the requested package` | Package-local changed files, workspace-level `.codeward/flows.yml` matches, package-local generated drafts, and no leaked workspace path prefixes in package drafts. |
+| Test-light project | `generateE2ePlan builds a bootstrap plan for projects without tests`; `generateE2eDraft creates a fallback smoke draft without changed files` | Required bootstrap steps for runner setup, first draft generation, fixture/mock data, testability, and validation evidence before generated drafts are treated as regression coverage. |
+| API-dependent UI flow | `generateE2ePlan flags missing mock fixtures for API-dependent UI flows` | Playwright-compatible UI flow plus fixture/mock readiness actions for success, empty, unauthorized, timeout, and server-error responses. |
+| Existing test evidence | `generateE2ePlan evaluates existing test suite coverage evidence`; `generateE2ePlan keeps generic test filenames from overmatching unrelated services` | Coverage evidence rows that distinguish covered, partial, and missing targets without matching unrelated generic test filenames. |
+
+See [E2E output examples](e2e-output-examples.md) for the kind of plan and draft snippets users should see before `0.1.0`.
+
+## Remaining 0.1.0 Validation Work
+
+Before publishing the package, run the fixture-backed suite plus at least one representative real project per row above. Record only public-safe notes in this document or in release notes:
+
+- whether the generated flow names match the team's domain language
+- whether the recommended runner is plausible
+- whether generated drafts identify the right actor, trigger, success signal, and edge cases
+- whether action items are concrete enough for a developer to convert into runnable tests
+- whether false positives are caused by missing manifests, weak selectors, or unsupported project structure
+
 ## Stop Conditions
 
 Do not publish `0.1.0` if any representative target shows one of these problems:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,7 +5,7 @@ CodeWard starts as a local CLI for repo-level AI agent readiness. The project ca
 ## Now
 
 - Keep the scanner fast, static, and easy to understand.
-- Finish the [`0.1.0` release validation checklist](release-validation.md) before the first public package release.
+- Finish the [`0.1.0` release validation checklist](release-validation.md) and public [E2E output examples](e2e-output-examples.md) before the first package release.
 - Improve adoption docs and sample output so new maintainers can try CodeWard quickly.
 - Make `verify` the best first-run experience for AI-assisted PRs.
 - Keep `eval` explainable enough that maintainers trust the score and know what to fix.


### PR DESCRIPTION
## Summary
- add a fixture-backed release validation matrix for the 0.1.0 E2E planning bar
- add public E2E output examples for web, mobile, API/service, test-light, and monorepo cases
- link the examples from README and roadmap so new users can see the expected output shape quickly

## Validation
- `pnpm test` (54 tests passed)
- `pnpm scan`
- `git diff --check`
- `pnpm pack --dry-run`

## Notes
This is documentation-only. It avoids private repo paths and uses public fixture-backed evidence plus compact output snippets.
