### PR TITLE
fix: improve web detection and metadata filtering

### DIFF
--- a/src/domain-language.ts
+++ b/src/domain-language.ts
@@ -317,6 +317,18 @@ function isDomainLanguageFile(file: string): boolean {
   if (/(?:^|\/)(?:assets?|images?|icons?|fonts?)\//i.test(file)) {
     return false;
   }
+  if (/(?:^|\/)(?:\.agents?|\.claude|\.cursor|\.dev|\.gemini|\.github|docs?)\//i.test(file)) {
+    return false;
+  }
+  if (/(?:^|\/)(?:AGENTS|CLAUDE|CODEX|DECISIONS|GEMINI|README|SKILL)\.md$/i.test(file)) {
+    return false;
+  }
+  if (/(?:^|\/)\.gitignore$/i.test(file)) {
+    return false;
+  }
+  if (/(?:^|\/)(?:CHANGELOG|RELEASES?|release-notes?|\.release-please-manifest)\.(?:md|json)$/i.test(file)) {
+    return false;
+  }
   if (/(?:package\.json|pnpm-lock\.yaml|yarn\.lock|package-lock\.json|bun\.lockb|Podfile\.lock|\.xcodeproj|eas\.json|app\.config\.)/i.test(file)) {
     return false;
   }

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -1988,8 +1988,23 @@ async function detectProjectProfile(root: string): Promise<E2eProjectProfile> {
   const hasExpoDependency = "expo" in dependencies;
   const hasReactNativeDependency = "react-native" in dependencies;
   const hasPlaywrightDependency = "@playwright/test" in dependencies || "playwright" in dependencies;
-  const hasWebDependency =
-    "next" in dependencies || "vite" in dependencies || "react-dom" in dependencies || hasPlaywrightDependency;
+  const webDependencies = [
+    "@angular/core",
+    "@remix-run/react",
+    "@storybook/react",
+    "@storybook/react-vite",
+    "@storybook/vue",
+    "@storybook/vue3",
+    "astro",
+    "next",
+    "nuxt",
+    "react-dom",
+    "svelte",
+    "vue",
+    "vite",
+  ];
+  const webDependency = webDependencies.find((dependency) => dependency in dependencies);
+  const hasWebDependency = Boolean(webDependency) || hasPlaywrightDependency;
   const apiServiceDependencies = [
     "@apollo/server",
     "@nestjs/core",
@@ -2007,6 +2022,21 @@ async function detectProjectProfile(root: string): Promise<E2eProjectProfile> {
   const apiServiceDependency = apiServiceDependencies.find((dependency) => dependency in dependencies);
   const hasExpoConfig = await hasAnyFile(root, ["app.json", "app.config.js", "app.config.ts"]);
   const hasNativeDirs = (await exists(path.join(root, "ios"))) || (await exists(path.join(root, "android")));
+  const hasWebConfig = await hasAnyFile(root, [
+    "angular.json",
+    "astro.config.js",
+    "astro.config.mjs",
+    "astro.config.ts",
+    "next.config.js",
+    "next.config.mjs",
+    "nuxt.config.js",
+    "nuxt.config.ts",
+    "svelte.config.js",
+    "vite.config.js",
+    "vite.config.mjs",
+    "vite.config.ts",
+    "vue.config.js",
+  ]);
   const hasApiServiceConfig = await hasAnyFile(root, [
     "serverless.yml",
     "serverless.yaml",
@@ -2024,6 +2054,12 @@ async function detectProjectProfile(root: string): Promise<E2eProjectProfile> {
   }
   if (hasPlaywrightDependency) {
     evidence.push("package.json dependency: Playwright");
+  }
+  if (webDependency) {
+    evidence.push(`package.json dependency: ${webDependency}`);
+  }
+  if (hasWebConfig) {
+    evidence.push("Web app or component configuration file found");
   }
   if (hasExpoConfig) {
     evidence.push("Expo app configuration file found");
@@ -2044,7 +2080,7 @@ async function detectProjectProfile(root: string): Promise<E2eProjectProfile> {
   if (hasReactNativeDependency || hasNativeDirs) {
     return { type: "react-native", evidence };
   }
-  if (hasWebDependency) {
+  if (hasWebDependency || hasWebConfig) {
     return { type: "web", evidence };
   }
   if (apiServiceDependency || hasApiServiceConfig) {
@@ -3005,7 +3041,7 @@ function isContentOrStyleFile(file: string): boolean {
 }
 
 function isConfigLikeFile(file: string): boolean {
-  return /(?:package\.json|pnpm-lock\.yaml|yarn\.lock|package-lock\.json|bun\.lockb|pyproject\.toml|requirements\.txt|go\.mod|go\.sum|Cargo\.toml|Cargo\.lock|pom\.xml|build\.gradle|gradle\.properties|vite|webpack|babel|tsconfig|next\.config|app\.config|eas\.json|docker|env|feature-?flags?|experiments?)/i.test(
+  return /(?:(?:^|\/)(?:\.agents?|\.claude|\.cursor|\.dev|\.gemini|\.github|docs?)\/|(?:^|\/)(?:AGENTS|CLAUDE|CODEX|DECISIONS|GEMINI|PLAN|README|SKILL)\.md$|\.gitignore|package\.json|pnpm-lock\.yaml|yarn\.lock|package-lock\.json|bun\.lockb|pyproject\.toml|requirements\.txt|go\.mod|go\.sum|Cargo\.toml|Cargo\.lock|pom\.xml|build\.gradle|gradle\.properties|vite|webpack|babel|tsconfig|next\.config|app\.config|eas\.json|release-please|docker|env|feature-?flags?|experiments?)/i.test(
     file,
   );
 }
@@ -3249,9 +3285,13 @@ function isMeaningfulLabel(value: string): boolean {
   const ignored = new Set([
     "api",
     "apis",
+    "agent",
+    "agents",
     "app",
     "apps",
     "client",
+    "changelog",
+    "claude",
     "component",
     "components",
     "config",
@@ -3262,7 +3302,10 @@ function isMeaningfulLabel(value: string): boolean {
     "contexts",
     "default",
     "development",
+    "decisions",
     "env",
+    "gemini",
+    "gitignore",
     "hook",
     "hooks",
     "index",
@@ -3276,9 +3319,12 @@ function isMeaningfulLabel(value: string): boolean {
     "page",
     "pages",
     "package",
+    "plan",
     "production",
     "provider",
     "providers",
+    "readme",
+    "release",
     "route",
     "routes",
     "screen",
@@ -3286,6 +3332,7 @@ function isMeaningfulLabel(value: string): boolean {
     "server",
     "service",
     "services",
+    "skill",
     "src",
     "staging",
     "state",

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -626,6 +626,42 @@ test("generateE2ePlan detects API service projects and suggests contract checkli
   assert.match(markdown, /Start with API contract validation/);
 });
 
+test("generateE2ePlan detects Nuxt and Vue projects as web before API service dependencies", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src/pages/admin"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      dependencies: {
+        express: "^4.18.0",
+        nuxt: "^2.17.0",
+        vue: "^2.7.0",
+      },
+      devDependencies: {
+        webpack: "^5.0.0",
+      },
+    }),
+  );
+  await writeFile(path.join(root, "nuxt.config.js"), "export default { srcDir: 'src/' };\n");
+  await writeFile(path.join(root, "src/pages/admin/index.vue"), "<template><button>Save</button></template>\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/admin-page"]);
+  await writeFile(path.join(root, "src/pages/admin/index.vue"), "<template><button data-testid=\"save-admin\">Save</button></template>\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "update admin page"]);
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+
+  assert.equal(plan.project.type, "web");
+  assert.equal(plan.recommendedRunner.name, "playwright");
+  assert.ok(plan.project.evidence.some((item) => item.includes("nuxt")));
+  assert.ok(plan.flows.some((flow) => flow.title === "Admin UI smoke flow"));
+});
+
 test("generateE2ePlan assigns configuration changes to release operators", async () => {
   const root = await makeTempRepo();
   await initGitRepo(root);
@@ -664,6 +700,90 @@ test("generateE2ePlan assigns configuration changes to release operators", async
   assert.match(flow.languageBrief.trigger, /Run the build, startup, or release path/);
   assert.match(flow.languageBrief.successSignal, /build or runtime variant/);
   assert.match(flow.languageBrief.reviewQuestion, /affected build, startup, or release variant/);
+});
+
+test("generateE2ePlan avoids turning release metadata into domain journeys", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      version: "1.0.0",
+      dependencies: {
+        express: "^4.18.0",
+      },
+    }),
+  );
+  await writeFile(path.join(root, "CHANGELOG.md"), "# Changelog\n\n## 1.0.0\n");
+  await writeFile(path.join(root, ".release-please-manifest.json"), JSON.stringify({ ".": "1.0.0" }));
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/release-metadata"]);
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      version: "1.0.1",
+      dependencies: {
+        express: "^4.18.0",
+      },
+    }),
+  );
+  await writeFile(path.join(root, "CHANGELOG.md"), "# Changelog\n\n## 1.0.1\n");
+  await writeFile(path.join(root, ".release-please-manifest.json"), JSON.stringify({ ".": "1.0.1" }));
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "update release metadata"]);
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const draft = await generateE2eDraft(root, { base: "main", head: "HEAD", output: "docs/e2e" });
+
+  assert.equal(plan.domainLanguage.terms.some((term) => /changelog|release please/i.test(term.term)), false);
+  assert.equal(draft.files.some((file) => /changelog|release-please/i.test(file.flowTitle)), false);
+  assert.ok(plan.flows.some((flow) => /configuration verification/.test(flow.title)));
+});
+
+test("generateE2ePlan treats agent and repo metadata as configuration, not product journeys", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, ".agents/review"), { recursive: true });
+  await mkdir(path.join(root, ".github/workflows"), { recursive: true });
+  await mkdir(path.join(root, ".dev/specs/qa-sync"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      dependencies: {
+        express: "^4.18.0",
+      },
+    }),
+  );
+  await writeFile(path.join(root, "CLAUDE.md"), "# Agent notes\n");
+  await writeFile(path.join(root, ".agents/review/SKILL.md"), "# Review skill\n");
+  await writeFile(path.join(root, ".github/workflows/deploy.yml"), "name: Deploy\n");
+  await writeFile(path.join(root, ".dev/specs/qa-sync/PLAN.md"), "# Plan\n");
+  await writeFile(path.join(root, ".gitignore"), "node_modules\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/repo-metadata"]);
+  await writeFile(path.join(root, "CLAUDE.md"), "# Agent notes\n\n- Use safe commands.\n");
+  await writeFile(path.join(root, ".agents/review/SKILL.md"), "# Review skill\n\nCheck changes.\n");
+  await writeFile(path.join(root, ".github/workflows/deploy.yml"), "name: Deploy\non: push\n");
+  await writeFile(path.join(root, ".dev/specs/qa-sync/PLAN.md"), "# Plan\n\nUpdated.\n");
+  await writeFile(path.join(root, ".gitignore"), "node_modules\n.env\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "update repo metadata"]);
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const draft = await generateE2eDraft(root, { base: "main", head: "HEAD", output: "docs/e2e" });
+  const unwanted = /agent|claude|deploy|gitignore|plan|skill/i;
+
+  assert.equal(plan.domainLanguage.terms.some((term) => unwanted.test(term.term)), false);
+  assert.equal(draft.files.some((file) => file.source === "domain-language" && unwanted.test(file.flowTitle)), false);
+  assert.equal(draft.files.some((file) => /primary journey/i.test(file.flowTitle)), false);
+  assert.ok(plan.flows.every((flow) => /configuration verification/.test(flow.title)));
+  assert.ok(plan.flows.every((flow) => flow.languageBrief.actor === "Maintainer or release operator"));
 });
 
 test("generateE2ePlan treats API service source utilities as contract-impacting changes", async () => {


### PR DESCRIPTION
## Summary

- Prefer web project detection for Nuxt, Vue, Storybook, Astro, Svelte, Remix, Angular, and common web config files before falling back to API-service detection.
- Treat release notes, repo docs, local assistant metadata, and gitignore-style files as configuration context instead of product domain language.
- Add regression tests for mixed Nuxt/API repositories, release metadata-only changes, and repository metadata-only changes.

## Validation

- `pnpm test` -> 57 tests passed
- `pnpm scan` -> 0 findings
- `git diff --check` -> clean
- Desktop validation across 13 targets under `/Users/khs/Desktop`: `e2e plan` and `e2e draft` succeeded for all targets.
- Desktop spot checks: `link-client` now resolves to `web` + `playwright`; `ids` resolves to `web` + `playwright`; `.agents/.../SKILL.md` changes resolve to configuration verification instead of a product journey.
