### PR TITLE
feat: add e2e execution profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ For monorepos, pass `--workspace-root` when scanning a package. Package-local ch
 
 `codeward e2e plan` turns changed file paths into a first-pass E2E testing plan. It detects whether a project looks like Expo/React Native, web, or an API/service repo, recommends a runner such as Maestro or Playwright, starts backend services with an API contract checklist, suggests bootstrap steps for repos with little or no test history, suggests domain language for the changed behavior, suggests candidate user flows, adds coverage targets, compares those targets with existing test-suite evidence when tests are present, flags API-dependent flows that need mock or fixture responses, and points out missing stable selectors such as `testID` or `data-testid` before anyone starts writing tests from a blank file.
 
+The plan also includes an execution profile: detected start command, test command, Playwright `baseURL`, mobile app id, runner config files, env fixture files, confidence, and blockers. This keeps generated E2E drafts honest about whether they are runnable candidates or still review-only scaffolds.
+
 When run at a monorepo root, the E2E plan also reports changed app/package targets. This helps a maintainer move from a broad workspace diff to scoped commands such as `codeward e2e plan services/offer --workspace-root . --base origin/main --head HEAD`, where package-specific runner detection and flow naming are usually sharper.
 
 Each candidate flow also includes a flow language brief: actor, trigger, goal, success signal, reviewer question, and edge cases. The brief keeps generated tests tied to product behavior rather than only changed file names.
@@ -212,6 +214,7 @@ The draft result is meant to be useful as a PR artifact, not only as generated f
 
 - `languageBrief`: actor, trigger, goal, success signal, reviewer question, and edge cases for each draft file
 - `promotionStatus`: whether the draft is a `commit-candidate`, `needs-review`, or `low-signal`
+- `runnableStatus`: whether the draft is a `runnable-candidate`, `near-runnable`, or `review-only`
 - `actionItems`: required and recommended follow-up work, grouped by assertion, fixture, selector, runner, validation, and manifest
 - `actionSummary`: total required/recommended action counts, ready file count, and the most common action categories
 

--- a/docs/e2e-output-examples.md
+++ b/docs/e2e-output-examples.md
@@ -25,6 +25,10 @@ flows:
 ```txt
 Project: Web
 Recommended runner: Playwright
+Execution profile: high
+Start command: pnpm run dev
+Test command: pnpm run test:e2e
+Base URL: http://127.0.0.1:4173
 Matched core flows: 1
 
 Flow: Checkout purchase UI smoke flow
@@ -117,6 +121,7 @@ Draft action items should make the next developer action explicit:
 
 ```txt
 Action summary:
+- runnable status: near-runnable
 - required assertion: Turn generated TODOs into runnable assertions
 - required fixture: Add deterministic fixture or mock data
 - required validation: Resolve missing validation evidence

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -57,6 +57,7 @@ node dist/cli.js e2e draft <package> --workspace-root <repo-root> --base <base> 
 The E2E plan should show:
 
 - runner recommendation with clear evidence
+- execution profile with start command, test command, base URL or app id when discoverable, confidence, and blockers
 - bootstrap steps when the project lacks E2E setup
 - domain language and candidate user scenarios
 - matched `.codeward/domains.yml` or `.codeward/flows.yml` entries when present
@@ -67,6 +68,7 @@ The E2E draft should show:
 - generated Maestro, Playwright, or manual draft files
 - `languageBrief` for each draft file
 - `promotionStatus` for each draft file
+- `runnableStatus` and execution blockers for each draft file
 - `actionItems` grouped by assertion, fixture, selector, runner, validation, or manifest
 - `actionSummary` with required and recommended action counts
 - Playwright `test.step()` names that read like the product journey
@@ -77,8 +79,8 @@ The matrix below is public, fixture-backed evidence from the repository test sui
 
 | Target | Fixture-backed coverage | Expected output |
 | --- | --- | --- |
-| Web app with Playwright routes | `generateE2ePlan matches committed core flow definitions`; `generateE2eDraft uses web selectors in Playwright specs` | `Web` project profile, `playwright` runner, core-flow names such as `Checkout purchase`, route-aware Playwright drafts, stable selector hints, action items, and validation gaps. |
-| Expo / React Native mobile app | `generateE2ePlan recommends mobile flows for Expo changes`; `generateE2eDraft scopes entrypoint hints to each domain scenario` | `Expo / React Native` project profile, `maestro` runner, Maestro YAML drafts, `testID`/`accessibilityLabel` selector hints, and mobile setup actions. |
+| Web app with Playwright routes | `generateE2ePlan matches committed core flow definitions`; `generateE2eDraft uses web selectors in Playwright specs`; `generateE2ePlan captures Playwright execution profile for runnable drafts` | `Web` project profile, `playwright` runner, core-flow names such as `Checkout purchase`, route-aware Playwright drafts, stable selector hints, execution profile, action items, and validation gaps. |
+| Expo / React Native mobile app | `generateE2ePlan recommends mobile flows for Expo changes`; `generateE2eDraft scopes entrypoint hints to each domain scenario` | `Expo / React Native` project profile, `maestro` runner, app id and launch command hints, Maestro YAML drafts, `testID`/`accessibilityLabel` selector hints, and mobile setup actions. |
 | API or backend service | `generateE2ePlan detects API service projects and suggests contract checklists`; `generateE2ePlan names versioned API service paths with domain language`; `generateE2ePlan uses matched core flow names for API service contracts` | `API / service` project profile, manual contract checklist, domain-aware titles such as `Offer API contract`, API consumer actor, endpoint/handler/service-path trigger, and contract failure coverage. |
 | Monorepo root and package targeting | `generateE2ePlan surfaces package-scoped targets for monorepo root changes`; `generateE2ePlan matches workspace core flows for package scans`; `generateTestPlan scopes monorepo changes to the requested package` | Root plans list changed app/package targets with package names, project type, runner, and scoped commands; package scans keep package-local changed files, workspace-level `.codeward/flows.yml` matches, package-local generated drafts, and no leaked workspace path prefixes in package drafts. |
 | Test-light project | `generateE2ePlan builds a bootstrap plan for projects without tests`; `generateE2eDraft creates a fallback smoke draft without changed files` | Required bootstrap steps for runner setup, first draft generation, fixture/mock data, testability, and validation evidence before generated drafts are treated as regression coverage. |
@@ -102,6 +104,7 @@ Before publishing the package, run the fixture-backed suite plus at least one re
 Do not publish `0.1.0` if any representative target shows one of these problems:
 
 - generated flow names are dominated by generic folder names instead of product language
+- execution profiles hide missing start commands, base URLs, app ids, or runner config needed to run generated drafts
 - monorepo package scans report workspace-root paths in generated package-local drafts
 - Playwright drafts cannot express dynamic route parameters with fixture placeholders
 - API-dependent flows fail to produce fixture or mock readiness actions

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -24,6 +24,7 @@ export type E2eEntrypointKind = "route" | "screen" | "command";
 export type E2eEntrypointConfidence = "high" | "medium" | "low";
 export type E2eSetupHintKind = "auth" | "network" | "fixture" | "environment" | "payment" | "state";
 export type E2eSetupHintConfidence = "high" | "medium" | "low";
+export type E2eExecutionProfileConfidence = "high" | "medium" | "low";
 export type E2eFixtureReadinessStatus = "ready" | "partial" | "missing" | "not-needed";
 export type E2eValidationMatrixStatus = "ready" | "partial" | "missing";
 export type E2eValidationMatrixCategory = "core-flow" | "coverage" | "fixture" | "testability" | "setup";
@@ -63,6 +64,19 @@ export interface E2eProjectProfile {
 export interface E2eRunnerRecommendation {
   name: E2eRunnerName;
   reason: string;
+}
+
+export interface E2eExecutionProfile {
+  runner: E2eRunnerName;
+  confidence: E2eExecutionProfileConfidence;
+  startCommand?: string;
+  testCommand?: string;
+  baseUrl?: string;
+  appId?: string;
+  configFiles: string[];
+  envFiles: string[];
+  evidence: string[];
+  blockers: string[];
 }
 
 export interface E2eWorkspaceTarget {
@@ -191,6 +205,7 @@ export interface E2ePlanResult {
   includeWorkingTree: boolean;
   project: E2eProjectProfile;
   recommendedRunner: E2eRunnerRecommendation;
+  executionProfile: E2eExecutionProfile;
   testSuite: TestSuiteSummary;
   coreFlowManifestPath?: string;
   coreFlows: MatchedCoreFlow[];
@@ -220,6 +235,8 @@ export interface E2eDraftFile {
   promotionReason?: string;
   promotionAction?: string;
   stability?: "ready" | "needs-selector" | "needs-setup" | "needs-selector-and-setup";
+  runnableStatus?: "runnable-candidate" | "near-runnable" | "review-only";
+  executionBlockers?: string[];
   todoCount?: number;
   entrypointCount?: number;
   primaryEntrypoint?: string;
@@ -278,6 +295,7 @@ export interface E2eDraftResult {
 
 interface PackageJson {
   name?: string;
+  packageManager?: string;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   scripts?: Record<string, string>;
@@ -305,6 +323,7 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
   const testPlan = await generateTestPlan(root, options);
   const project = await detectProjectProfile(root);
   const recommendedRunner = options.runner ? overrideRunner(project, options.runner) : recommendRunner(project);
+  const executionProfile = await buildExecutionProfile(root, testPlan.workspaceRoot, project, recommendedRunner.name);
   const testSuiteInventory = await collectTestSuiteInventory(root);
   const coreFlowRoot = testPlan.workspaceRoot ?? root;
   const coreFlowManifest = await loadCoreFlowManifest(coreFlowRoot);
@@ -334,6 +353,7 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
     head: testPlan.head,
     projectType: project.type,
     recommendedRunner,
+    executionProfile,
     testSuite,
     coreFlowManifestPath: coreFlowManifest.path,
     domainManifestPath: domainManifest.path,
@@ -360,6 +380,7 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
     includeWorkingTree: testPlan.includeWorkingTree,
     project,
     recommendedRunner,
+    executionProfile,
     testSuite,
     coreFlowManifestPath: coreFlowManifest.path,
     coreFlows,
@@ -393,6 +414,8 @@ export async function generateE2eDraft(rootInput: string, options: E2eDraftOptio
     const validationSummary = summarizeDraftValidation(flow);
     const promotionGuidance = buildDraftPromotionGuidance(flow);
     const actionItems = buildDraftActionItems(plan, flow, runner, validationSummary, promotionGuidance);
+    const executionBlockers = draftExecutionBlockers(plan, flow, runner, validationSummary);
+    const runnableStatus = draftRunnableStatus(plan, flow, runner, validationSummary, executionBlockers);
     if ((await exists(filePath)) && !options.force) {
       files.push({
         path: displayPath,
@@ -406,6 +429,8 @@ export async function generateE2eDraft(rootInput: string, options: E2eDraftOptio
         promotionReason: promotionGuidance.reason,
         promotionAction: promotionGuidance.action,
         stability: draftStability(plan, flow),
+        runnableStatus,
+        executionBlockers,
         entrypointCount: flow.entrypoints.length,
         primaryEntrypoint: primaryEntrypointLabel(flow),
         setupHintCount: flow.setupHints.length,
@@ -432,6 +457,8 @@ export async function generateE2eDraft(rootInput: string, options: E2eDraftOptio
       promotionReason: promotionGuidance.reason,
       promotionAction: promotionGuidance.action,
       stability: draftStability(plan, flow),
+      runnableStatus,
+      executionBlockers,
       todoCount: countTodos(content),
       entrypointCount: flow.entrypoints.length,
       primaryEntrypoint: primaryEntrypointLabel(flow),
@@ -722,6 +749,7 @@ interface E2eBootstrapPlanInput {
   head: string;
   projectType: E2eProjectType;
   recommendedRunner: E2eRunnerRecommendation;
+  executionProfile: E2eExecutionProfile;
   testSuite: TestSuiteSummary;
   coreFlowManifestPath?: string;
   domainManifestPath?: string;
@@ -742,6 +770,7 @@ function buildE2eBootstrapPlan(input: E2eBootstrapPlanInput): E2eBootstrapPlan {
   const planHistoryCommand = `codeward e2e plan . --base ${input.base} --head ${input.head} --record-history`;
   const domainsSuggestCommand = `codeward domains suggest . --base ${input.base} --head ${input.head}`;
   const flowsSuggestCommand = `codeward flows suggest . --base ${input.base} --head ${input.head}`;
+  const executionProfileBlockers = remainingExecutionProfileBlockers(input.executionProfile.blockers, runnerGap);
 
   if (input.workspaceTargets.length > 0) {
     const concreteTargets = input.workspaceTargets.filter((target) => target.project.type !== "unknown");
@@ -802,6 +831,20 @@ function buildE2eBootstrapPlan(input: E2eBootstrapPlanInput): E2eBootstrapPlan {
         "Keep runner setup documented and linked from PR validation notes.",
         [],
         [],
+      ),
+    );
+  }
+
+  if (input.recommendedRunner.name !== "manual" && executionProfileBlockers.length > 0) {
+    steps.push(
+      bootstrapStep(
+        "runner",
+        "required",
+        "Complete the E2E execution profile",
+        executionProfileBlockers.slice(0, 3).join(" "),
+        "Document or configure the missing command, URL, app id, or runner file before treating generated drafts as runnable regression coverage.",
+        uniqueStrings([input.executionProfile.startCommand, input.executionProfile.testCommand].filter(Boolean) as string[]),
+        input.executionProfile.configFiles,
       ),
     );
   }
@@ -1328,6 +1371,15 @@ function buildDraftActionItems(
       runnerGap,
     ));
   }
+  const executionBlockers = remainingExecutionProfileBlockers(plan.executionProfile.blockers, runnerGap);
+  if (runner !== "manual" && executionBlockers.length > 0) {
+    items.push(draftActionItem(
+      "runner",
+      "required",
+      "Complete execution profile",
+      executionBlockers.slice(0, 3).join(" "),
+    ));
+  }
 
   const route = primaryRouteEntrypoint(flow);
   if (runner === "playwright" && route) {
@@ -1419,6 +1471,27 @@ function runnerSetupGap(plan: E2ePlanResult, runner: E2eRunnerName): string | un
     return plan.missingTestability.find((gap) => /No \.maestro/i.test(gap));
   }
   return undefined;
+}
+
+function remainingExecutionProfileBlockers(blockers: string[], runnerGap?: string): string[] {
+  return blockers.filter((blocker) => {
+    if (/No runnable E2E runner/i.test(blocker)) {
+      return false;
+    }
+    if (!runnerGap) {
+      return true;
+    }
+    if (blocker === runnerGap) {
+      return false;
+    }
+    if (/No Playwright config/i.test(runnerGap) && /Playwright config/i.test(blocker)) {
+      return false;
+    }
+    if (/No \.maestro/i.test(runnerGap) && /(\.maestro|Maestro.*(config|flow))/i.test(blocker)) {
+      return false;
+    }
+    return true;
+  });
 }
 
 function draftActionItem(
@@ -1708,6 +1781,8 @@ export function formatMarkdownE2ePlan(result: E2ePlanResult): string {
     }
   }
   lines.push("");
+
+  appendExecutionProfileMarkdown(lines, result.executionProfile);
 
   if (result.workspaceTargets.length > 0) {
     lines.push("## Changed App/Package Targets");
@@ -2210,6 +2285,301 @@ function overrideRunner(project: E2eProjectProfile, runner: E2eRunnerName): E2eR
     name: runner,
     reason: `Use a manual checklist because no runnable E2E runner was selected for this ${formatProjectType(project.type)} project.`,
   };
+}
+
+async function buildExecutionProfile(
+  root: string,
+  workspaceRoot: string | undefined,
+  project: E2eProjectProfile,
+  runner: E2eRunnerName,
+): Promise<E2eExecutionProfile> {
+  const packageJson = await readPackageJson(root);
+  const scripts = packageJson?.scripts ?? {};
+  const packageManager = await detectPackageManager(root, packageJson?.packageManager, workspaceRoot);
+  const configFiles = await existingFiles(root, executionConfigCandidates(runner));
+  const envFiles = await existingFiles(root, [
+    ".env.example",
+    ".env.local.example",
+    ".env.test",
+    ".env.e2e",
+    ".env.development",
+  ]);
+  const startScript = chooseScript(scripts, startScriptCandidates(runner, project.type));
+  const testScript = chooseScript(scripts, testScriptCandidates(runner));
+  const startCommand = startScript ? commandForScript(packageManager, startScript) : undefined;
+  const testCommand = testScript ? commandForScript(packageManager, testScript) : defaultRunnerCommand(runner);
+  const baseUrl = runner === "playwright" ? await detectPlaywrightBaseUrl(root, configFiles, envFiles) : undefined;
+  const appId = runner === "maestro" ? await detectMobileAppId(root) : undefined;
+  const evidence = executionProfileEvidence({
+    runner,
+    startCommand,
+    testCommand,
+    baseUrl,
+    appId,
+    configFiles,
+    envFiles,
+  });
+  const blockers = executionProfileBlockers({
+    runner,
+    startCommand,
+    testCommand,
+    baseUrl,
+    appId,
+    configFiles,
+    projectType: project.type,
+  });
+
+  return {
+    runner,
+    confidence: executionProfileConfidence(runner, evidence, blockers),
+    startCommand,
+    testCommand,
+    baseUrl,
+    appId,
+    configFiles,
+    envFiles,
+    evidence,
+    blockers,
+  };
+}
+
+function executionConfigCandidates(runner: E2eRunnerName): string[] {
+  if (runner === "playwright") {
+    return [
+      "playwright.config.ts",
+      "playwright.config.js",
+      "playwright.config.mjs",
+      "playwright.config.cjs",
+    ];
+  }
+  if (runner === "maestro") {
+    return [".maestro", "maestro.yaml", "maestro.yml"];
+  }
+  return ["openapi.yml", "openapi.yaml", "swagger.yml", "swagger.yaml", "serverless.yml", "serverless.yaml"];
+}
+
+function startScriptCandidates(runner: E2eRunnerName, projectType: E2eProjectType): string[] {
+  if (runner === "maestro") {
+    return ["ios", "android", "start", "dev"];
+  }
+  if (runner === "playwright") {
+    return ["dev", "start", "preview", "serve"];
+  }
+  if (projectType === "api-service") {
+    return ["dev", "start", "serve", "local"];
+  }
+  return ["dev", "start"];
+}
+
+function testScriptCandidates(runner: E2eRunnerName): string[] {
+  if (runner === "playwright") {
+    return ["test:e2e", "e2e", "playwright", "test"];
+  }
+  if (runner === "maestro") {
+    return ["test:e2e", "e2e", "maestro"];
+  }
+  return ["test:e2e", "e2e", "test"];
+}
+
+function chooseScript(scripts: Record<string, string>, candidates: string[]): string | undefined {
+  return candidates.find((script) => isUsablePackageScript(scripts[script]));
+}
+
+function isUsablePackageScript(script: string | undefined): boolean {
+  return Boolean(script && !/no test specified|exit\s+1/i.test(script));
+}
+
+function commandForScript(packageManager: string, script: string): string {
+  if (script === "start" || script === "test") {
+    return `${packageManager} ${script}`;
+  }
+  return `${packageManager} run ${script}`;
+}
+
+function defaultRunnerCommand(runner: E2eRunnerName): string | undefined {
+  if (runner === "playwright") {
+    return "npx playwright test";
+  }
+  if (runner === "maestro") {
+    return "maestro test .maestro";
+  }
+  return undefined;
+}
+
+async function detectPackageManager(
+  root: string,
+  packageManager: string | undefined,
+  workspaceRoot: string | undefined,
+): Promise<string> {
+  const workspacePackageManager =
+    workspaceRoot && workspaceRoot !== root ? (await readPackageJson(workspaceRoot))?.packageManager : undefined;
+  const declaredPackageManager = packageManager ?? workspacePackageManager;
+  if (declaredPackageManager?.startsWith("pnpm@")) {
+    return "pnpm";
+  }
+  if (declaredPackageManager?.startsWith("yarn@")) {
+    return "yarn";
+  }
+  if (declaredPackageManager?.startsWith("bun@")) {
+    return "bun";
+  }
+  if (await existsInRoots("pnpm-lock.yaml", root, workspaceRoot)) {
+    return "pnpm";
+  }
+  if (await existsInRoots("yarn.lock", root, workspaceRoot)) {
+    return "yarn";
+  }
+  if (await existsInRoots("bun.lockb", root, workspaceRoot)) {
+    return "bun";
+  }
+  return "npm";
+}
+
+async function existsInRoots(fileName: string, root: string, workspaceRoot: string | undefined): Promise<boolean> {
+  if (await exists(path.join(root, fileName))) {
+    return true;
+  }
+  return Boolean(workspaceRoot && workspaceRoot !== root && (await exists(path.join(workspaceRoot, fileName))));
+}
+
+async function existingFiles(root: string, candidates: string[]): Promise<string[]> {
+  const files: string[] = [];
+  for (const candidate of candidates) {
+    if (await exists(path.join(root, candidate))) {
+      files.push(candidate);
+    }
+  }
+  return files;
+}
+
+async function detectPlaywrightBaseUrl(root: string, configFiles: string[], envFiles: string[]): Promise<string | undefined> {
+  for (const configFile of configFiles) {
+    const text = await readTextIfExists(path.join(root, configFile));
+    const baseUrl = text?.match(/\bbaseURL\s*:\s*["'`]([^"'`]+)["'`]/)?.[1];
+    if (baseUrl) {
+      return baseUrl;
+    }
+  }
+
+  for (const envFile of envFiles) {
+    const text = await readTextIfExists(path.join(root, envFile));
+    const baseUrl = text?.match(/^(?:PLAYWRIGHT_BASE_URL|BASE_URL|E2E_BASE_URL|NEXT_PUBLIC_SITE_URL)=(.+)$/m)?.[1]?.trim();
+    if (baseUrl && !/\$\{|<|TODO/i.test(baseUrl)) {
+      return baseUrl.replace(/^["']|["']$/g, "");
+    }
+  }
+
+  return undefined;
+}
+
+async function detectMobileAppId(root: string): Promise<string | undefined> {
+  const appJson = await readTextIfExists(path.join(root, "app.json"));
+  if (!appJson) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(appJson) as {
+      expo?: {
+        android?: { package?: string };
+        ios?: { bundleIdentifier?: string };
+        slug?: string;
+        name?: string;
+      };
+    };
+    return parsed.expo?.android?.package ?? parsed.expo?.ios?.bundleIdentifier ?? parsed.expo?.slug ?? parsed.expo?.name;
+  } catch {
+    return undefined;
+  }
+}
+
+function executionProfileEvidence(input: {
+  runner: E2eRunnerName;
+  startCommand?: string;
+  testCommand?: string;
+  baseUrl?: string;
+  appId?: string;
+  configFiles: string[];
+  envFiles: string[];
+}): string[] {
+  const evidence: string[] = [];
+  if (input.startCommand) {
+    evidence.push(`start command: ${input.startCommand}`);
+  }
+  if (input.testCommand) {
+    evidence.push(`test command: ${input.testCommand}`);
+  }
+  if (input.baseUrl) {
+    evidence.push(`base URL: ${input.baseUrl}`);
+  }
+  if (input.appId) {
+    evidence.push(`app id: ${input.appId}`);
+  }
+  for (const file of input.configFiles) {
+    evidence.push(`config file: ${file}`);
+  }
+  for (const file of input.envFiles) {
+    evidence.push(`env fixture file: ${file}`);
+  }
+  if (input.runner === "manual" && evidence.length === 0) {
+    evidence.push("manual checklist profile");
+  }
+  return uniqueStrings(evidence);
+}
+
+function executionProfileBlockers(input: {
+  runner: E2eRunnerName;
+  startCommand?: string;
+  testCommand?: string;
+  baseUrl?: string;
+  appId?: string;
+  configFiles: string[];
+  projectType: E2eProjectType;
+}): string[] {
+  const blockers: string[] = [];
+  if (input.runner === "manual") {
+    if (input.projectType !== "api-service") {
+      blockers.push("No runnable E2E runner was selected for this project surface.");
+    }
+    if (input.projectType === "api-service" && !input.startCommand) {
+      blockers.push("No local API/service start command was detected.");
+    }
+    return blockers;
+  }
+
+  if (input.configFiles.length === 0) {
+    blockers.push(
+      input.runner === "playwright"
+        ? "No Playwright config file was detected."
+        : "No Maestro flow directory or config file was detected.",
+    );
+  }
+  if (!input.startCommand) {
+    blockers.push("No local app start or launch command was detected.");
+  }
+  if (input.runner === "playwright" && !input.baseUrl) {
+    blockers.push("No Playwright baseURL or E2E base URL was detected.");
+  }
+  if (input.runner === "maestro" && !input.appId) {
+    blockers.push("No mobile app id was detected from app.json.");
+  }
+  if (!input.testCommand) {
+    blockers.push(`No ${formatRunnerName(input.runner)} test command was detected.`);
+  }
+  return blockers;
+}
+
+function executionProfileConfidence(
+  runner: E2eRunnerName,
+  evidence: string[],
+  blockers: string[],
+): E2eExecutionProfileConfidence {
+  if (runner === "manual") {
+    return blockers.length === 0 && evidence.length > 0 ? "medium" : "low";
+  }
+  if (blockers.length === 0) {
+    return "high";
+  }
+  return evidence.length >= 3 ? "medium" : "low";
 }
 
 async function buildWorkspaceTargets(root: string, testPlan: TestPlanResult): Promise<E2eWorkspaceTarget[]> {
@@ -3894,6 +4264,52 @@ function draftStability(
   return "ready";
 }
 
+function draftExecutionBlockers(
+  plan: E2ePlanResult,
+  flow: E2eFlow,
+  runner: E2eRunnerName,
+  validationSummary: ReturnType<typeof summarizeDraftValidation>,
+): string[] {
+  const blockers = [...plan.executionProfile.blockers];
+  if (runner !== "manual" && flow.entrypoints.length === 0) {
+    blockers.push("No runnable route, screen, or command entrypoint was inferred for this flow.");
+  }
+  if (flow.missingTestability.length > 0) {
+    blockers.push(flow.missingTestability[0]);
+  }
+  if (flow.fixtureReadiness.status === "missing") {
+    blockers.push(flow.fixtureReadiness.nextActions[0] ?? flow.fixtureReadiness.reason);
+  }
+  if (validationSummary.blockingGapCount > 0) {
+    blockers.push(`${validationSummary.blockingGapCount} blocking validation gap${validationSummary.blockingGapCount === 1 ? "" : "s"} remain.`);
+  }
+  return uniqueStrings(blockers).slice(0, 8);
+}
+
+function draftRunnableStatus(
+  plan: E2ePlanResult,
+  flow: E2eFlow,
+  runner: E2eRunnerName,
+  validationSummary: ReturnType<typeof summarizeDraftValidation>,
+  executionBlockers: string[],
+): "runnable-candidate" | "near-runnable" | "review-only" {
+  if (runner === "manual") {
+    return "review-only";
+  }
+  if (
+    executionBlockers.length === 0 &&
+    validationSummary.blockingGapCount === 0 &&
+    flow.missingTestability.length === 0 &&
+    (flow.fixtureReadiness.status === "ready" || flow.fixtureReadiness.status === "not-needed")
+  ) {
+    return "runnable-candidate";
+  }
+  if (plan.executionProfile.confidence !== "low" && flow.entrypoints.length > 0) {
+    return "near-runnable";
+  }
+  return "review-only";
+}
+
 function buildFallbackFlow(plan: E2ePlanResult): E2eFlow {
   const coverage = buildCoverageTargets("changed-file", [], plan.recommendedRunner.name);
   const flow: Omit<E2eFlow, "languageBrief"> = {
@@ -3977,6 +4393,7 @@ function buildMaestroDraft(plan: E2ePlanResult, flow: E2eFlow): string {
   lines.push(`# Base: ${plan.base}`);
   lines.push(`# Head: ${plan.head}`);
   appendDraftBriefComments(lines, flow, "maestro", "#");
+  appendExecutionProfileComments(lines, plan.executionProfile, "#");
   lines.push("# Replace ${APP_ID} with the app id or export APP_ID before running Maestro.");
   lines.push("");
   lines.push("appId: ${APP_ID}");
@@ -4056,6 +4473,7 @@ function buildPlaywrightDraft(plan: E2ePlanResult, flow: E2eFlow): string {
     lines.push(`// Intent: ${scenario.intent}`);
   }
   appendDraftBriefComments(lines, flow, "playwright", "//");
+  appendExecutionProfileComments(lines, plan.executionProfile, "//");
   lines.push("");
   lines.push('import { expect, test } from "@playwright/test";');
   lines.push("");
@@ -4136,6 +4554,7 @@ function buildManualDraft(plan: E2ePlanResult, flow: E2eFlow): string {
   lines.push(`- Head: \`${plan.head}\``);
   lines.push("");
   appendManualDraftBrief(lines, flow, "manual");
+  appendManualExecutionProfile(lines, plan.executionProfile);
   lines.push("");
   lines.push("## Steps");
   lines.push("");
@@ -4237,6 +4656,39 @@ function appendFlowLanguageBriefMarkdown(lines: string[], brief: E2eFlowLanguage
   if (brief.edgeCases.length > 0) {
     lines.push(`- Edge cases: ${escapeMarkdownInline(brief.edgeCases.join("; "))}`);
   }
+}
+
+function appendExecutionProfileMarkdown(lines: string[], profile: E2eExecutionProfile): void {
+  lines.push("## Execution Profile");
+  lines.push("");
+  lines.push(`- Runner: ${formatRunnerName(profile.runner)}`);
+  lines.push(`- Confidence: ${profile.confidence}`);
+  if (profile.startCommand) {
+    lines.push(`- Start command: \`${escapeMarkdownInline(profile.startCommand)}\``);
+  }
+  if (profile.testCommand) {
+    lines.push(`- Test command: \`${escapeMarkdownInline(profile.testCommand)}\``);
+  }
+  if (profile.baseUrl) {
+    lines.push(`- Base URL: \`${escapeMarkdownInline(profile.baseUrl)}\``);
+  }
+  if (profile.appId) {
+    lines.push(`- App id: \`${escapeMarkdownInline(profile.appId)}\``);
+  }
+  if (profile.configFiles.length > 0) {
+    lines.push(`- Config files: ${profile.configFiles.map((file) => `\`${escapeMarkdownInline(file)}\``).join(", ")}`);
+  }
+  if (profile.envFiles.length > 0) {
+    lines.push(`- Env fixture files: ${profile.envFiles.map((file) => `\`${escapeMarkdownInline(file)}\``).join(", ")}`);
+  }
+  if (profile.blockers.length > 0) {
+    lines.push("");
+    lines.push("Execution blockers:");
+    for (const blocker of profile.blockers) {
+      lines.push(`- ${escapeMarkdownInline(blocker)}`);
+    }
+  }
+  lines.push("");
 }
 
 function appendFlowLanguageBriefComments(
@@ -4370,6 +4822,31 @@ function appendDraftBriefComments(
   }
 }
 
+function appendExecutionProfileComments(
+  lines: string[],
+  profile: E2eExecutionProfile,
+  commentPrefix: string,
+): void {
+  lines.push("");
+  lines.push(`${commentPrefix} Execution profile:`);
+  lines.push(`${commentPrefix} - Confidence: ${profile.confidence}`);
+  if (profile.startCommand) {
+    lines.push(`${commentPrefix} - Start command: ${profile.startCommand}`);
+  }
+  if (profile.testCommand) {
+    lines.push(`${commentPrefix} - Test command: ${profile.testCommand}`);
+  }
+  if (profile.baseUrl) {
+    lines.push(`${commentPrefix} - Base URL: ${profile.baseUrl}`);
+  }
+  if (profile.appId) {
+    lines.push(`${commentPrefix} - App id: ${profile.appId}`);
+  }
+  for (const blocker of profile.blockers.slice(0, 4)) {
+    lines.push(`${commentPrefix} - Blocker: ${blocker}`);
+  }
+}
+
 function appendManualDraftBrief(lines: string[], flow: E2eFlow, runner: E2eRunnerName): void {
   const brief = buildDraftBrief(flow, runner);
   lines.push("## Draft Brief");
@@ -4379,6 +4856,32 @@ function appendManualDraftBrief(lines: string[], flow: E2eFlow, runner: E2eRunne
   lines.push("- Human fixture inputs:");
   for (const input of brief.humanFixtureInputs) {
     lines.push(`  - ${input}`);
+  }
+}
+
+function appendManualExecutionProfile(lines: string[], profile: E2eExecutionProfile): void {
+  lines.push("");
+  lines.push("## Execution Profile");
+  lines.push("");
+  lines.push(`- Runner: ${formatRunnerName(profile.runner)}`);
+  lines.push(`- Confidence: ${profile.confidence}`);
+  if (profile.startCommand) {
+    lines.push(`- Start command: \`${profile.startCommand}\``);
+  }
+  if (profile.testCommand) {
+    lines.push(`- Test command: \`${profile.testCommand}\``);
+  }
+  if (profile.baseUrl) {
+    lines.push(`- Base URL: \`${profile.baseUrl}\``);
+  }
+  if (profile.appId) {
+    lines.push(`- App id: \`${profile.appId}\``);
+  }
+  if (profile.blockers.length > 0) {
+    lines.push("- Blockers:");
+    for (const blocker of profile.blockers.slice(0, 4)) {
+      lines.push(`  - ${blocker}`);
+    }
   }
 }
 
@@ -4635,13 +5138,23 @@ function formatDraftActionKindSummary(summary: E2eDraftActionKindSummary[]): str
 function buildDraftNextSteps(plan: E2ePlanResult, runner: E2eRunnerName): string[] {
   const steps: string[] = [];
   if (runner === "maestro") {
-    steps.push("Replace ${APP_ID} or export APP_ID before running Maestro.");
+    steps.push(plan.executionProfile.appId
+      ? `Use app id ${plan.executionProfile.appId} or export APP_ID before running Maestro.`
+      : "Replace ${APP_ID} or export APP_ID before running Maestro.");
     steps.push("Replace TODO text selectors with visible copy, testID, or accessibilityLabel selectors.");
-    steps.push("Run the app with the launch command that matches your simulator or device, then run `maestro test .maestro`.");
+    steps.push(plan.executionProfile.startCommand
+      ? `Launch the app with \`${plan.executionProfile.startCommand}\`, then run \`${plan.executionProfile.testCommand ?? "maestro test .maestro"}\`.`
+      : `Run the app with the launch command that matches your simulator or device, then run \`${plan.executionProfile.testCommand ?? "maestro test .maestro"}\`.`);
   } else if (runner === "playwright") {
     steps.push("Replace TODO locators with role, text, or data-testid locators from the app.");
-    steps.push("Configure baseURL in Playwright before making the specs required in CI.");
-    steps.push("Run `npx playwright test` after the app can be served locally.");
+    if (plan.executionProfile.baseUrl) {
+      steps.push(`Confirm Playwright baseURL \`${plan.executionProfile.baseUrl}\` points at the target environment.`);
+    } else {
+      steps.push("Configure baseURL in Playwright before making the specs required in CI.");
+    }
+    steps.push(plan.executionProfile.startCommand
+      ? `Serve the app with \`${plan.executionProfile.startCommand}\`, then run \`${plan.executionProfile.testCommand ?? "npx playwright test"}\`.`
+      : `Run \`${plan.executionProfile.testCommand ?? "npx playwright test"}\` after the app can be served locally.`);
   } else {
     steps.push("Choose a runnable E2E framework once the primary app surface is documented.");
   }
@@ -4671,6 +5184,12 @@ function formatDraftFileQuality(file: E2eDraftFile): string | undefined {
   }
   if (file.actionItems !== undefined && file.actionItems.length > 0) {
     details.push(`${file.actionItems.length} action item${file.actionItems.length === 1 ? "" : "s"}`);
+  }
+  if (file.runnableStatus !== undefined) {
+    details.push(file.runnableStatus);
+  }
+  if (file.executionBlockers !== undefined && file.executionBlockers.length > 0) {
+    details.push(`${file.executionBlockers.length} execution blocker${file.executionBlockers.length === 1 ? "" : "s"}`);
   }
   if (file.stability !== undefined) {
     details.push(file.stability);

--- a/src/history.ts
+++ b/src/history.ts
@@ -47,6 +47,18 @@ export interface E2ePlanHistorySnapshot {
     includeWorkingTree: boolean;
     projectType: string;
     recommendedRunner: string;
+    executionProfile: {
+      runner: string;
+      confidence: string;
+      startCommand?: string;
+      testCommand?: string;
+      baseUrl?: string;
+      appId?: string;
+      configFiles: string[];
+      envFiles: string[];
+      evidence: string[];
+      blockers: string[];
+    };
     coreFlowManifestPath?: string;
     coreFlows: Array<{
       id: string;
@@ -246,6 +258,18 @@ function buildE2ePlanHistorySnapshot(historyRoot: string, plan: E2ePlanResult): 
       includeWorkingTree: plan.includeWorkingTree,
       projectType: plan.project.type,
       recommendedRunner: plan.recommendedRunner.name,
+      executionProfile: {
+        runner: plan.executionProfile.runner,
+        confidence: plan.executionProfile.confidence,
+        startCommand: plan.executionProfile.startCommand,
+        testCommand: plan.executionProfile.testCommand,
+        baseUrl: plan.executionProfile.baseUrl,
+        appId: plan.executionProfile.appId,
+        configFiles: plan.executionProfile.configFiles.slice(0, 10),
+        envFiles: plan.executionProfile.envFiles.slice(0, 10),
+        evidence: plan.executionProfile.evidence.slice(0, 12),
+        blockers: plan.executionProfile.blockers.slice(0, 12),
+      },
       coreFlowManifestPath: plan.coreFlowManifestPath,
       coreFlows: plan.coreFlows.map((flow) => ({
         id: flow.id,

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -598,6 +598,11 @@ test("generateE2ePlan recommends mobile flows for Expo changes", async () => {
 
   assert.equal(plan.project.type, "expo-react-native");
   assert.equal(plan.recommendedRunner.name, "maestro");
+  assert.equal(plan.executionProfile.runner, "maestro");
+  assert.equal(plan.executionProfile.startCommand, "pnpm run ios");
+  assert.equal(plan.executionProfile.testCommand, "maestro test .maestro");
+  assert.equal(plan.executionProfile.appId, "Fixture");
+  assert.ok(plan.executionProfile.blockers.some((blocker) => /Maestro/.test(blocker)));
   assert.ok(uiFlow.title.endsWith("UI smoke flow"));
   assert.ok(plan.flows.every((flow) => flow.coverage.length > 0));
   assert.ok(plan.flows.some((flow) => flow.coverage.some((target) => target.title === "Loading, empty, error, and success states")));
@@ -614,6 +619,8 @@ test("generateE2ePlan recommends mobile flows for Expo changes", async () => {
   assert.deepEqual(plan.suggestedCommands, ["pnpm run lint"]);
   assert.match(markdown, /# CodeWard E2E Plan/);
   assert.match(markdown, /Recommended runner: Maestro/);
+  assert.match(markdown, /## Execution Profile/);
+  assert.match(markdown, /App id: `Fixture`/);
   assert.match(markdown, /Coverage targets:/);
   assert.equal(draft.runner, "maestro");
   assert.ok(draft.files.some((file) => file.source === "domain-language"));
@@ -635,6 +642,8 @@ test("generateE2ePlan recommends mobile flows for Expo changes", async () => {
   assert.match(uiDraft, new RegExp(`Flow: ${uiDraftFile.flowTitle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
   assert.match(uiDraft, /Domain scenario:/);
   assert.match(uiDraft, /Draft brief:/);
+  assert.match(uiDraft, /Execution profile:/);
+  assert.match(uiDraft, /App id: Fixture/);
   assert.match(uiDraft, /Changed behavior:/);
   assert.match(uiDraft, /Why this flow matters:/);
   assert.match(uiDraft, /Human fixture inputs:/);
@@ -1559,6 +1568,70 @@ test("generateE2eDraft uses web selectors in Playwright specs", async () => {
   assert.match(spec, /Coverage matrix/);
   assert.match(spec, /Browser viewport regression/);
   assert.match(spec, /Inferred selectors/);
+});
+
+test("generateE2ePlan captures Playwright execution profile for runnable drafts", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src/pages/profile"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      packageManager: "pnpm@10.32.1",
+      scripts: {
+        dev: "vite --host 127.0.0.1",
+        "test:e2e": "playwright test",
+      },
+      dependencies: {
+        "@playwright/test": "^1.56.0",
+        vite: "^7.0.0",
+        "react-dom": "^19.0.0",
+      },
+    }),
+  );
+  await writeFile(
+    path.join(root, "playwright.config.ts"),
+    "export default { use: { baseURL: 'http://127.0.0.1:4173' } };\n",
+  );
+  await writeFile(
+    path.join(root, "src/pages/profile/ProfilePage.tsx"),
+    "export function ProfilePage() { return <button data-testid=\"profile-save\">Save profile</button>; }\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/profile-save"]);
+  await writeFile(
+    path.join(root, "src/pages/profile/ProfilePage.tsx"),
+    "export function ProfilePage() { return <button data-testid=\"profile-save\" aria-label=\"Save profile\">Save profile</button>; }\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "update profile save"]);
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const markdown = formatMarkdownE2ePlan(plan);
+  const draft = await generateE2eDraft(root, { base: "main", head: "HEAD", output: ".generated-e2e" });
+  const draftFile = draft.files.find((file) => file.flowTitle === "Profile primary journey");
+  assert.ok(draftFile);
+  const spec = await readFile(path.join(root, draftFile.path), "utf8");
+
+  assert.equal(plan.executionProfile.runner, "playwright");
+  assert.equal(plan.executionProfile.confidence, "high");
+  assert.equal(plan.executionProfile.startCommand, "pnpm run dev");
+  assert.equal(plan.executionProfile.testCommand, "pnpm run test:e2e");
+  assert.equal(plan.executionProfile.baseUrl, "http://127.0.0.1:4173");
+  assert.deepEqual(plan.executionProfile.blockers, []);
+  assert.match(markdown, /## Execution Profile/);
+  assert.match(markdown, /Start command: `pnpm run dev`/);
+  assert.match(markdown, /Base URL: `http:\/\/127\.0\.0\.1:4173`/);
+  assert.equal(draftFile.runnableStatus, "near-runnable");
+  assert.deepEqual(draftFile.executionBlockers?.filter((blocker) => /Playwright|baseURL|start command/i.test(blocker)), []);
+  assert.match(formatMarkdownE2eDraft(draft), /near-runnable/);
+  assert.match(spec, /Execution profile:/);
+  assert.match(spec, /Start command: pnpm run dev/);
+  assert.match(spec, /Test command: pnpm run test:e2e/);
+  assert.match(spec, /Base URL: http:\/\/127\.0\.0\.1:4173/);
 });
 
 test("generateE2eDraft normalizes dynamic routes without creating id domain scenarios", async () => {


### PR DESCRIPTION
## Summary
- Add an E2E execution profile to plan and draft output, including runner confidence, start/test commands, base URL, app id, config/env evidence, and blockers.
- Mark generated E2E drafts as runnable-candidate, near-runnable, or review-only so reviewers can tell whether the output is executable or still needs setup.
- Store compact execution profile snapshots in local history and refresh README, output examples, release validation docs, and coverage tests.

## Validation
- pnpm test: 59 tests passed
- pnpm scan: 0 findings
- git diff --check
- Desktop spot check on /Users/khs/Desktop/inpock-frontend/services/offer: detected Playwright with pnpm run dev and npx playwright test, correctly blocked runnable status on missing Playwright config/baseURL, and generated review-only drafts with validation gaps surfaced.