### PR TITLE
feat: improve runnable playwright drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Run `codeward flows init .` to create a starter manifest. Run `codeward flows su
 
 Pass `--record-history` when you want CodeWard to keep a compact local snapshot of an E2E plan under `.codeward/runs/`. CodeWard automatically protects `.codeward/runs/`, `.codeward/cache/`, `.codeward/tmp/`, and `.codeward/*.local.json` with `.gitignore` so generated history stays local by default. Shared project policy, such as `codeward.config.json`, `.codeward/domains.yml`, and `.codeward/flows.yml`, remains commit-friendly.
 
-`codeward e2e draft` writes draft files from that plan. Expo and React Native projects get Maestro YAML flows under `.maestro/` by default, web projects get Playwright specs under `tests/e2e/`, and API/service projects get contract checklist drafts until a project-specific API runner is documented. Drafts infer stable selectors such as `testID`, `accessibilityLabel`, `data-testid`, `aria-label`, and visible text where possible. They also carry fixture/mock readiness notes so client flows can be tested with deterministic data before a real server path exists. They keep `TODO` placeholders where selectors, fixtures, assertions, or project-specific launch details are still needed, and existing files are not overwritten unless `--force` is passed.
+`codeward e2e draft` writes draft files from that plan. Expo and React Native projects get Maestro YAML flows under `.maestro/` by default, web projects get Playwright specs under `tests/e2e/`, and API/service projects get contract checklist drafts until a project-specific API runner is documented. Drafts infer stable selectors such as `testID`, `accessibilityLabel`, `data-testid`, `aria-label`, placeholder text, role-based buttons or links, and visible text where possible. They also carry fixture/mock readiness notes so client flows can be tested with deterministic data before a real server path exists. They keep `TODO` placeholders where selectors, fixtures, assertions, or project-specific launch details are still needed, and existing files are not overwritten unless `--force` is passed.
 
 The draft result is meant to be useful as a PR artifact, not only as generated files. Markdown and JSON output include:
 
@@ -228,8 +228,13 @@ await test.step("Open route /checkout.", async () => {
 });
 
 await test.step("Complete checkout with a valid payment method.", async () => {
-  // TODO: Complete checkout with a valid payment method.
+  // Step intent: Complete checkout with a valid payment method.
   await page.getByTestId("checkout-submit").click();
+});
+
+await test.step("Fill profile email.", async () => {
+  // Step intent: Fill profile email.
+  await page.getByPlaceholder("Profile email").fill("codeward@example.com");
 });
 ```
 
@@ -335,7 +340,7 @@ Near-term priorities:
 - publish a versioned GitHub Action release tag after the first public package is ready
 - improve branch-aware `review` changed-line locations
 - improve generated domain test plans with framework-specific test skeletons
-- refine generated Maestro and Playwright drafts with stronger app-specific selector discovery
+- refine generated Maestro and Playwright drafts with stronger app-specific selector discovery and self-check loops
 - expand `eval` into repository-specific verification manifests and taste rubrics
 - continue expanding agent surface detection across Codex, Claude Code, Cursor, Copilot, Gemini, and related tools
 - generate rule documentation from scanner metadata

--- a/docs/e2e-output-examples.md
+++ b/docs/e2e-output-examples.md
@@ -51,6 +51,20 @@ test("Checkout purchase", async ({ page }) => {
 });
 ```
 
+When CodeWard can infer durable browser controls, the draft should prefer executable Playwright locators over placeholder text:
+
+```ts
+await test.step("Fill profile email.", async () => {
+  // Step intent: Fill profile email.
+  await page.getByPlaceholder("Profile email").fill("codeward@example.com");
+});
+
+await test.step("Save settings.", async () => {
+  // Step intent: Save settings.
+  await page.getByRole("button", { name: "Save settings" }).click();
+});
+```
+
 ## Expo / React Native Flow
 
 For an Expo or React Native change, CodeWard should recommend Maestro and carry mobile selectors into the draft:

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -45,7 +45,9 @@ export type E2eSelectorKind =
   | "visible-text"
   | "web-test-id"
   | "aria-label"
-  | "placeholder";
+  | "placeholder"
+  | "role-button"
+  | "role-link";
 
 export interface E2ePlanOptions extends TestPlanOptions {
   runner?: E2eRunnerName;
@@ -4501,12 +4503,9 @@ function buildPlaywrightDraft(plan: E2ePlanResult, flow: E2eFlow): string {
   for (const step of flow.steps) {
     const selector = takeSelectorForStep(selectorQueue, step);
     const locator = selector ? playwrightLocator(selector) : 'page.getByText("TODO")';
-    const body = [`// TODO: ${step}`];
-    body.push(
-      isVerificationStep(step) && !isInteractionStep(step)
-        ? `await expect(${locator}).toBeVisible();`
-        : `await ${locator}.click();`,
-    );
+    const body = selector
+      ? playwrightActionForStep(selector, locator, step)
+      : [`// TODO: ${step}`, `await expect(${locator}).toBeVisible();`];
     appendPlaywrightTestStep(lines, step, body);
   }
   appendDomainScenarioComments(lines, flow, "  //");
@@ -5315,10 +5314,49 @@ function playwrightLocator(selector: E2eSelector): string {
   if (selector.kind === "test-id" || selector.kind === "web-test-id") {
     return `page.getByTestId("${value}")`;
   }
-  if (selector.kind === "accessibility-label" || selector.kind === "aria-label" || selector.kind === "placeholder") {
+  if (selector.kind === "role-button") {
+    return `page.getByRole("button", { name: "${value}" })`;
+  }
+  if (selector.kind === "role-link") {
+    return `page.getByRole("link", { name: "${value}" })`;
+  }
+  if (selector.kind === "placeholder") {
+    return `page.getByPlaceholder("${value}")`;
+  }
+  if (selector.kind === "accessibility-label" || selector.kind === "aria-label") {
     return `page.getByLabel("${value}")`;
   }
   return `page.getByText("${value}")`;
+}
+
+function playwrightActionForStep(selector: E2eSelector, locator: string, step: string): string[] {
+  const body = [`// Step intent: ${step}`];
+  if (isVerificationStep(step) && !isInteractionStep(step)) {
+    body.push(`await expect(${locator}).toBeVisible();`);
+    return body;
+  }
+  if (selector.kind === "placeholder") {
+    body.push(`await ${locator}.fill("${quoteJs(playwrightSampleInput(selector.value))}");`);
+    return body;
+  }
+  body.push(`await ${locator}.click();`);
+  return body;
+}
+
+function playwrightSampleInput(label: string): string {
+  if (/\b(?:email|e-mail|메일)\b/i.test(label)) {
+    return "codeward@example.com";
+  }
+  if (/\b(?:url|link|링크|주소)\b/i.test(label)) {
+    return "https://example.com/codeward";
+  }
+  if (/\b(?:code|otp|pin|코드|인증)\b/i.test(label)) {
+    return "123456";
+  }
+  if (/\b(?:name|이름)\b/i.test(label)) {
+    return "CodeWard Test";
+  }
+  return "CodeWard sample value";
 }
 
 function isGestureStep(step: string): boolean {
@@ -5347,6 +5385,7 @@ function extractSelectorsFromText(file: string, text: string, runner: E2eRunnerN
     selectors.push(
       ...extractAttributeSelectors(file, text, ["data-testid", "data-test"], "web-test-id"),
       ...extractAttributeSelectors(file, text, ["aria-label"], "aria-label"),
+      ...extractRoleSelectorsFromText(file, text),
     );
   }
 
@@ -5390,6 +5429,29 @@ function extractTextNodeSelectors(file: string, text: string): E2eSelector[] {
     selectors.push(selector);
   }
 
+  return selectors;
+}
+
+function extractRoleSelectorsFromText(file: string, text: string): E2eSelector[] {
+  const selectors: E2eSelector[] = [];
+  const roleMatchers: Array<{ matcher: RegExp; kind: E2eSelectorKind }> = [
+    {
+      matcher: /<(?:button|Button|[^<>\s]*Button)\b[^>]*>([^<>{}\n][^<>{}]*)<\/(?:button|Button|[^<>\s]*Button)>/g,
+      kind: "role-button",
+    },
+    {
+      matcher: /<(?:a|Link|NavLink)\b[^>]*>([^<>{}\n][^<>{}]*)<\/(?:a|Link|NavLink)>/g,
+      kind: "role-link",
+    },
+  ];
+  for (const { matcher, kind } of roleMatchers) {
+    for (const match of text.matchAll(matcher)) {
+      const value = normalizeSelectorValue(match[1]);
+      if (value) {
+        selectors.push({ kind, value, file });
+      }
+    }
+  }
   return selectors;
 }
 
@@ -5549,7 +5611,10 @@ function selectorRank(kind: E2eSelectorKind): number {
   if (kind === "placeholder") {
     return 2;
   }
-  return 3;
+  if (kind === "role-button" || kind === "role-link") {
+    return 3;
+  }
+  return 4;
 }
 
 function slugify(value: string): string {

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -1634,6 +1634,96 @@ test("generateE2ePlan captures Playwright execution profile for runnable drafts"
   assert.match(spec, /Base URL: http:\/\/127\.0\.0\.1:4173/);
 });
 
+test("generateE2eDraft emits runnable Playwright role and input actions", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, ".codeward"), { recursive: true });
+  await mkdir(path.join(root, "src/pages/settings"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      packageManager: "pnpm@10.32.1",
+      scripts: {
+        dev: "vite --host 127.0.0.1",
+        "test:e2e": "playwright test",
+      },
+      dependencies: {
+        "@playwright/test": "^1.56.0",
+        vite: "^7.0.0",
+        "react-dom": "^19.0.0",
+      },
+    }),
+  );
+  await writeFile(
+    path.join(root, "playwright.config.ts"),
+    "export default { use: { baseURL: 'http://127.0.0.1:4173' } };\n",
+  );
+  await writeFile(
+    path.join(root, ".codeward/flows.yml"),
+    [
+      "flows:",
+      "  - id: settings-profile",
+      "    name: Settings profile",
+      "    priority: critical",
+      "    domains:",
+      "      - settings",
+      "    files:",
+      "      - src/pages/settings/**",
+      "    routes:",
+      "      - /settings",
+      "    checks:",
+      "      - Fill profile email.",
+      "      - Save settings.",
+      "      - Confirm saved settings are visible.",
+    ].join("\n"),
+  );
+  await writeFile(
+    path.join(root, "src/pages/settings/SettingsPage.tsx"),
+    [
+      "export function SettingsPage() {",
+      "  return <main>",
+      "    <input placeholder=\"Profile email\" />",
+      "    <button>Save settings</button>",
+      "    <a href=\"/settings/history\">View history</a>",
+      "  </main>;",
+      "}",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/settings-profile"]);
+  await writeFile(
+    path.join(root, "src/pages/settings/SettingsPage.tsx"),
+    [
+      "export function SettingsPage() {",
+      "  return <main>",
+      "    <input placeholder=\"Profile email\" />",
+      "    <button>Save settings</button>",
+      "    <a href=\"/settings/history\">View history</a>",
+      "    <p>Saved settings</p>",
+      "  </main>;",
+      "}",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "update settings profile"]);
+
+  const draft = await generateE2eDraft(root, { base: "main", head: "HEAD", output: "tests/e2e" });
+  const draftFile = draft.files.find((file) => file.flowTitle === "Settings profile");
+  assert.ok(draftFile);
+  const spec = await readFile(path.join(root, draftFile.path), "utf8");
+
+  assert.match(spec, /page\.getByPlaceholder\("Profile email"\)\.fill\("codeward@example.com"\)/);
+  assert.match(spec, /page\.getByRole\("button", \{ name: "Save settings" \}\)\.click\(\)/);
+  assert.match(spec, /role-button: Save settings/);
+  assert.match(spec, /role-link: View history/);
+  assert.doesNotMatch(spec, /page\.getByLabel\("Profile email"\)/);
+  assert.doesNotMatch(spec, /\/\/ TODO: Fill profile email/);
+  assert.doesNotMatch(spec, /\/\/ TODO: Save settings/);
+});
+
 test("generateE2eDraft normalizes dynamic routes without creating id domain scenarios", async () => {
   const root = await makeTempRepo();
   await initGitRepo(root);
@@ -1797,7 +1887,8 @@ test("generateE2ePlan matches committed core flow definitions", async () => {
   assert.match(spec, /await test\.step\("Complete checkout with a valid payment method\.", async \(\) => \{/);
   assert.match(spec, /await test\.step\("Verify declined payment recovery\.", async \(\) => \{/);
   assert.match(spec, /page\.goto\("\/checkout"\)/);
-  assert.match(spec, /TODO: Complete checkout with a valid payment method\./);
+  assert.match(spec, /Step intent: Complete checkout with a valid payment method\./);
+  assert.match(spec, /page\.getByTestId\("checkout-submit"\)\.click\(\)/);
 });
 
 test("generateE2ePlan uses committed domain manifests for language and draft routes", async () => {
@@ -1894,7 +1985,8 @@ test("generateE2ePlan uses committed domain manifests for language and draft rou
   assert.match(spec, /await test\.step\("Open route \/membership\/renewal\.", async \(\) => \{/);
   assert.match(spec, /await test\.step\("Renew an active membership with realistic billing data\.", async \(\) => \{/);
   assert.match(spec, /page\.goto\("\/membership\/renewal"\)/);
-  assert.match(spec, /TODO: Renew an active membership with realistic billing data\./);
+  assert.match(spec, /Step intent: Renew an active membership with realistic billing data\./);
+  assert.match(spec, /page\.getByTestId\("renew-membership"\)\.click\(\)/);
 });
 
 test("generateE2ePlan suggests domain language from changed paths without core flows", async () => {


### PR DESCRIPTION
## Summary
- Infer role-based Playwright selectors for buttons and links in addition to existing test id, label, placeholder, and visible text signals.
- Generate more executable Playwright actions when a selector is available: placeholders use fill() with deterministic sample values, role/test-id selectors use click(), and verification steps use expect().
- Refresh README and E2E output examples so the documented draft shape matches the new runnable-oriented output.

## Validation
- pnpm test: 60 tests passed
- pnpm scan: 0 findings
- git diff --check
- Desktop spot check on /Users/khs/Desktop/inpock-frontend/services/offer: generated review-only drafts remain correctly blocked by missing Playwright config/baseURL while retaining selector and TODO evidence.