### PR TITLE
feat: add e2e draft self checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ The draft result is meant to be useful as a PR artifact, not only as generated f
 - `languageBrief`: actor, trigger, goal, success signal, reviewer question, and edge cases for each draft file
 - `promotionStatus`: whether the draft is a `commit-candidate`, `needs-review`, or `low-signal`
 - `runnableStatus`: whether the draft is a `runnable-candidate`, `near-runnable`, or `review-only`
+- `selfCheck`: static runner checks for generated draft structure, unresolved placeholders, TODO markers, and the execution profile
 - `actionItems`: required and recommended follow-up work, grouped by assertion, fixture, selector, runner, validation, and manifest
 - `actionSummary`: total required/recommended action counts, ready file count, and the most common action categories
 

--- a/docs/e2e-output-examples.md
+++ b/docs/e2e-output-examples.md
@@ -65,6 +65,14 @@ await test.step("Save settings.", async () => {
 });
 ```
 
+The draft result should also explain whether the generated file passed static runner checks:
+
+```txt
+Draft self-check: pass
+Command: pnpm run test:e2e
+Summary: Playwright draft passed static runner checks.
+```
+
 ## Expo / React Native Flow
 
 For an Expo or React Native change, CodeWard should recommend Maestro and carry mobile selectors into the draft:
@@ -136,6 +144,7 @@ Draft action items should make the next developer action explicit:
 ```txt
 Action summary:
 - runnable status: near-runnable
+- self-check: warning or fail when placeholder locators remain
 - required assertion: Turn generated TODOs into runnable assertions
 - required fixture: Add deterministic fixture or mock data
 - required validation: Resolve missing validation evidence

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -21,6 +21,7 @@ For each target, record:
 - recommended runner
 - generated flow language brief quality
 - draft readiness summary
+- draft self-check status and blockers
 - required and recommended draft action items
 - generated file paths
 - manual notes about false positives, missing context, or weak selectors
@@ -69,6 +70,7 @@ The E2E draft should show:
 - `languageBrief` for each draft file
 - `promotionStatus` for each draft file
 - `runnableStatus` and execution blockers for each draft file
+- `selfCheck` status, summary, command, warnings, and blockers for each generated draft file
 - `actionItems` grouped by assertion, fixture, selector, runner, validation, or manifest
 - `actionSummary` with required and recommended action counts
 - Playwright `test.step()` names that read like the product journey
@@ -79,7 +81,7 @@ The matrix below is public, fixture-backed evidence from the repository test sui
 
 | Target | Fixture-backed coverage | Expected output |
 | --- | --- | --- |
-| Web app with Playwright routes | `generateE2ePlan matches committed core flow definitions`; `generateE2eDraft uses web selectors in Playwright specs`; `generateE2ePlan captures Playwright execution profile for runnable drafts` | `Web` project profile, `playwright` runner, core-flow names such as `Checkout purchase`, route-aware Playwright drafts, stable selector hints, execution profile, action items, and validation gaps. |
+| Web app with Playwright routes | `generateE2ePlan matches committed core flow definitions`; `generateE2eDraft uses web selectors in Playwright specs`; `generateE2ePlan captures Playwright execution profile and self-check blockers`; `generateE2eDraft emits runnable Playwright role and input actions` | `Web` project profile, `playwright` runner, core-flow names such as `Checkout purchase`, route-aware Playwright drafts, stable selector hints, execution profile, draft self-check status, action items, and validation gaps. |
 | Expo / React Native mobile app | `generateE2ePlan recommends mobile flows for Expo changes`; `generateE2eDraft scopes entrypoint hints to each domain scenario` | `Expo / React Native` project profile, `maestro` runner, app id and launch command hints, Maestro YAML drafts, `testID`/`accessibilityLabel` selector hints, and mobile setup actions. |
 | API or backend service | `generateE2ePlan detects API service projects and suggests contract checklists`; `generateE2ePlan names versioned API service paths with domain language`; `generateE2ePlan uses matched core flow names for API service contracts` | `API / service` project profile, manual contract checklist, domain-aware titles such as `Offer API contract`, API consumer actor, endpoint/handler/service-path trigger, and contract failure coverage. |
 | Monorepo root and package targeting | `generateE2ePlan surfaces package-scoped targets for monorepo root changes`; `generateE2ePlan matches workspace core flows for package scans`; `generateTestPlan scopes monorepo changes to the requested package` | Root plans list changed app/package targets with package names, project type, runner, and scoped commands; package scans keep package-local changed files, workspace-level `.codeward/flows.yml` matches, package-local generated drafts, and no leaked workspace path prefixes in package drafts. |
@@ -105,6 +107,7 @@ Do not publish `0.1.0` if any representative target shows one of these problems:
 
 - generated flow names are dominated by generic folder names instead of product language
 - execution profiles hide missing start commands, base URLs, app ids, or runner config needed to run generated drafts
+- draft self-checks fail to report unresolved placeholder locators, route params, missing runner structure, or TODO-heavy generated files
 - monorepo package scans report workspace-root paths in generated package-local drafts
 - Playwright drafts cannot express dynamic route parameters with fixture placeholders
 - API-dependent flows fail to produce fixture or mock readiness actions

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -239,6 +239,7 @@ export interface E2eDraftFile {
   stability?: "ready" | "needs-selector" | "needs-setup" | "needs-selector-and-setup";
   runnableStatus?: "runnable-candidate" | "near-runnable" | "review-only";
   executionBlockers?: string[];
+  selfCheck?: E2eDraftSelfCheck;
   todoCount?: number;
   entrypointCount?: number;
   primaryEntrypoint?: string;
@@ -254,6 +255,22 @@ export interface E2eDraftFile {
 
 export type E2eDraftActionKind = "assertion" | "fixture" | "manifest" | "runner" | "selector" | "setup" | "validation";
 export type E2eDraftActionPriority = "required" | "recommended";
+
+export type E2eDraftSelfCheckStatus = "pass" | "warning" | "fail";
+
+export interface E2eDraftSelfCheckItem {
+  name: string;
+  status: E2eDraftSelfCheckStatus;
+  detail: string;
+}
+
+export interface E2eDraftSelfCheck {
+  status: E2eDraftSelfCheckStatus;
+  summary: string;
+  command?: string;
+  checks: E2eDraftSelfCheckItem[];
+  blockers: string[];
+}
 
 export interface E2eDraftActionItem {
   kind: E2eDraftActionKind;
@@ -415,10 +432,14 @@ export async function generateE2eDraft(rootInput: string, options: E2eDraftOptio
     const displayPath = toDisplayPath(root, filePath);
     const validationSummary = summarizeDraftValidation(flow);
     const promotionGuidance = buildDraftPromotionGuidance(flow);
-    const actionItems = buildDraftActionItems(plan, flow, runner, validationSummary, promotionGuidance);
-    const executionBlockers = draftExecutionBlockers(plan, flow, runner, validationSummary);
-    const runnableStatus = draftRunnableStatus(plan, flow, runner, validationSummary, executionBlockers);
-    if ((await exists(filePath)) && !options.force) {
+    const shouldSkip = (await exists(filePath)) && !options.force;
+    const content = shouldSkip ? ((await readTextIfExists(filePath)) ?? "") : draftContentForFlow(plan, flow, runner);
+    const todoCount = countTodos(content);
+    const selfCheck = evaluateDraftSelfCheck(plan, flow, runner, content, todoCount);
+    const actionItems = buildDraftActionItems(plan, flow, runner, validationSummary, promotionGuidance, selfCheck);
+    const executionBlockers = draftExecutionBlockers(plan, flow, runner, validationSummary, selfCheck);
+    const runnableStatus = draftRunnableStatus(plan, flow, runner, validationSummary, executionBlockers, selfCheck);
+    if (shouldSkip) {
       files.push({
         path: displayPath,
         flowTitle: flow.title,
@@ -433,6 +454,8 @@ export async function generateE2eDraft(rootInput: string, options: E2eDraftOptio
         stability: draftStability(plan, flow),
         runnableStatus,
         executionBlockers,
+        selfCheck,
+        todoCount,
         entrypointCount: flow.entrypoints.length,
         primaryEntrypoint: primaryEntrypointLabel(flow),
         setupHintCount: flow.setupHints.length,
@@ -445,7 +468,6 @@ export async function generateE2eDraft(rootInput: string, options: E2eDraftOptio
       });
       continue;
     }
-    const content = draftContentForFlow(plan, flow, runner);
     await fs.writeFile(filePath, content, "utf8");
     files.push({
       path: displayPath,
@@ -461,7 +483,8 @@ export async function generateE2eDraft(rootInput: string, options: E2eDraftOptio
       stability: draftStability(plan, flow),
       runnableStatus,
       executionBlockers,
-      todoCount: countTodos(content),
+      selfCheck,
+      todoCount,
       entrypointCount: flow.entrypoints.length,
       primaryEntrypoint: primaryEntrypointLabel(flow),
       setupHintCount: flow.setupHints.length,
@@ -1362,6 +1385,7 @@ function buildDraftActionItems(
   runner: E2eRunnerName,
   validationSummary: ReturnType<typeof summarizeDraftValidation>,
   promotionGuidance: E2eDraftPromotionGuidance,
+  selfCheck?: E2eDraftSelfCheck,
 ): E2eDraftActionItem[] {
   const items: E2eDraftActionItem[] = [];
   const runnerGap = runnerSetupGap(plan, runner);
@@ -1428,12 +1452,28 @@ function buildDraftActionItems(
     ));
   }
 
-  if (flow.steps.length > 0) {
+  if (flow.steps.length > 0 && draftNeedsAssertionWork(selfCheck)) {
     items.push(draftActionItem(
       "assertion",
       "required",
       "Turn generated TODOs into runnable assertions",
       `Preserve the success signal "${flow.languageBrief.successSignal}" while replacing placeholder interactions and expects.`,
+    ));
+  }
+
+  if (selfCheck?.status === "fail") {
+    items.push(draftActionItem(
+      "validation",
+      "required",
+      "Resolve generated draft self-check",
+      selfCheck.blockers[0] ?? selfCheck.summary,
+    ));
+  } else if (selfCheck?.status === "warning") {
+    items.push(draftActionItem(
+      "validation",
+      "recommended",
+      "Review generated draft self-check",
+      selfCheck.summary,
     ));
   }
 
@@ -1463,6 +1503,17 @@ function buildDraftActionItems(
   }
 
   return uniqueDraftActionItems(items).slice(0, 8);
+}
+
+function draftNeedsAssertionWork(selfCheck?: E2eDraftSelfCheck): boolean {
+  if (!selfCheck) {
+    return true;
+  }
+  return selfCheck.checks.some(
+    (check) =>
+      (check.name === "Unresolved placeholders" && check.status !== "pass") ||
+      (check.name === "TODO comments" && check.status !== "pass"),
+  );
 }
 
 function runnerSetupGap(plan: E2ePlanResult, runner: E2eRunnerName): string | undefined {
@@ -2073,6 +2124,26 @@ export function formatMarkdownE2eDraft(result: E2eDraftResult): string {
     lines.push(`- ${file.status}: \`${escapeMarkdownInline(file.path)}\` (${escapeMarkdownInline(file.flowTitle)})${suffix}`);
   }
   lines.push("");
+
+  const filesWithSelfChecks = result.files.filter((file) => file.selfCheck !== undefined);
+  if (filesWithSelfChecks.length > 0) {
+    lines.push("## Draft Self Checks");
+    lines.push("");
+    for (const file of filesWithSelfChecks) {
+      const selfCheck = file.selfCheck;
+      if (!selfCheck) {
+        continue;
+      }
+      lines.push(`- \`${escapeMarkdownInline(file.flowTitle)}\` (${escapeMarkdownInline(file.path)}): ${selfCheck.status} - ${escapeMarkdownInline(selfCheck.summary)}`);
+      if (selfCheck.command) {
+        lines.push(`  - Command: \`${escapeMarkdownInline(selfCheck.command)}\``);
+      }
+      for (const check of selfCheck.checks.filter((item) => item.status !== "pass").slice(0, 4)) {
+        lines.push(`  - [${check.status}] ${escapeMarkdownInline(check.name)}: ${escapeMarkdownInline(check.detail)}`);
+      }
+    }
+    lines.push("");
+  }
 
   const filesWithActionItems = result.files.filter((file) => (file.actionItems?.length ?? 0) > 0);
   if (filesWithActionItems.length > 0) {
@@ -4271,6 +4342,7 @@ function draftExecutionBlockers(
   flow: E2eFlow,
   runner: E2eRunnerName,
   validationSummary: ReturnType<typeof summarizeDraftValidation>,
+  selfCheck?: E2eDraftSelfCheck,
 ): string[] {
   const blockers = [...plan.executionProfile.blockers];
   if (runner !== "manual" && flow.entrypoints.length === 0) {
@@ -4285,6 +4357,9 @@ function draftExecutionBlockers(
   if (validationSummary.blockingGapCount > 0) {
     blockers.push(`${validationSummary.blockingGapCount} blocking validation gap${validationSummary.blockingGapCount === 1 ? "" : "s"} remain.`);
   }
+  if (selfCheck?.status === "fail") {
+    blockers.push(...selfCheck.blockers);
+  }
   return uniqueStrings(blockers).slice(0, 8);
 }
 
@@ -4294,15 +4369,20 @@ function draftRunnableStatus(
   runner: E2eRunnerName,
   validationSummary: ReturnType<typeof summarizeDraftValidation>,
   executionBlockers: string[],
+  selfCheck?: E2eDraftSelfCheck,
 ): "runnable-candidate" | "near-runnable" | "review-only" {
   if (runner === "manual") {
+    return "review-only";
+  }
+  if (selfCheck?.status === "fail") {
     return "review-only";
   }
   if (
     executionBlockers.length === 0 &&
     validationSummary.blockingGapCount === 0 &&
     flow.missingTestability.length === 0 &&
-    (flow.fixtureReadiness.status === "ready" || flow.fixtureReadiness.status === "not-needed")
+    (flow.fixtureReadiness.status === "ready" || flow.fixtureReadiness.status === "not-needed") &&
+    selfCheck?.status === "pass"
   ) {
     return "runnable-candidate";
   }
@@ -4310,6 +4390,173 @@ function draftRunnableStatus(
     return "near-runnable";
   }
   return "review-only";
+}
+
+function evaluateDraftSelfCheck(
+  plan: E2ePlanResult,
+  flow: E2eFlow,
+  runner: E2eRunnerName,
+  content: string,
+  todoCount: number,
+): E2eDraftSelfCheck {
+  if (runner === "playwright") {
+    return evaluatePlaywrightDraftSelfCheck(plan, flow, content, todoCount);
+  }
+  if (runner === "maestro") {
+    return evaluateMaestroDraftSelfCheck(plan, content, todoCount);
+  }
+  return buildDraftSelfCheck(
+    "warning",
+    "Manual checklist output cannot be runner-checked automatically.",
+    undefined,
+    [
+      draftSelfCheckItem(
+        "Manual runner",
+        "warning",
+        "Manual E2E drafts are review evidence until the project declares a runnable runner.",
+      ),
+    ],
+  );
+}
+
+function evaluatePlaywrightDraftSelfCheck(
+  plan: E2ePlanResult,
+  flow: E2eFlow,
+  content: string,
+  todoCount: number,
+): E2eDraftSelfCheck {
+  const checks: E2eDraftSelfCheckItem[] = [];
+  checks.push(draftSelfCheckItem(
+    "Playwright import",
+    content.includes('from "@playwright/test"') ? "pass" : "fail",
+    content.includes('from "@playwright/test"')
+      ? "The draft imports Playwright test APIs."
+      : "The draft does not import Playwright test APIs.",
+  ));
+  checks.push(draftSelfCheckItem(
+    "Test case",
+    /\btest\(\s*["'`][^"'`]+["'`]\s*,\s*async\s*\(\s*\{\s*page\s*\}\s*\)/.test(content) ? "pass" : "fail",
+    "The draft should expose one Playwright test that receives a page fixture.",
+  ));
+  const needsEntrypoint = flow.entrypoints.some((entrypoint) => entrypoint.kind === "route");
+  const hasRunnableGoto = /page\.goto\(\s*(?:"(?!TODO)[^"]+"|'(?!TODO)[^']+'|`(?!.*TODO)[^`]+`)\s*\)/.test(content);
+  checks.push(draftSelfCheckItem(
+    "Runnable entrypoint",
+    !needsEntrypoint || hasRunnableGoto ? "pass" : "fail",
+    needsEntrypoint
+      ? "The draft should navigate to an inferred route without placeholder route values."
+      : "No route entrypoint was required for this flow.",
+  ));
+  const unresolvedPlaceholder =
+    /getBy(?:Text|Label|Placeholder|TestId)\(\s*["'`]TODO["'`]\s*\)|getByRole\([^)]*name:\s*["'`]TODO["'`][^)]*\)|TODO-[A-Za-z0-9-]+|Replace routeParams/i.test(content);
+  checks.push(draftSelfCheckItem(
+    "Unresolved placeholders",
+    unresolvedPlaceholder ? "fail" : "pass",
+    unresolvedPlaceholder
+      ? "The draft still contains placeholder locators or route parameters."
+      : "No placeholder locators or route parameters were detected.",
+  ));
+  checks.push(draftSelfCheckItem(
+    "TODO comments",
+    todoCount === 0 ? "pass" : "warning",
+    todoCount === 0
+      ? "No TODO comments remain in the generated draft."
+      : `${todoCount} TODO marker${todoCount === 1 ? "" : "s"} remain for reviewer follow-up.`,
+  ));
+  checks.push(draftSelfCheckItem(
+    "Execution profile",
+    plan.executionProfile.confidence === "low" || plan.executionProfile.blockers.length > 0 ? "warning" : "pass",
+    plan.executionProfile.confidence === "low" || plan.executionProfile.blockers.length > 0
+      ? "Runner setup, base URL, launch command, or config evidence is incomplete."
+      : "Runner setup evidence is strong enough for a local execution attempt.",
+  ));
+  return buildDraftSelfCheck(
+    draftSelfCheckStatus(checks),
+    draftSelfCheckSummary(checks, "Playwright"),
+    plan.executionProfile.testCommand ?? "npx playwright test",
+    checks,
+  );
+}
+
+function evaluateMaestroDraftSelfCheck(
+  plan: E2ePlanResult,
+  content: string,
+  todoCount: number,
+): E2eDraftSelfCheck {
+  const hasAppId = /^appId:\s*(?!\$\{APP_ID\})\S+/m.test(content);
+  const checks = [
+    draftSelfCheckItem(
+      "Maestro app id",
+      hasAppId || plan.executionProfile.appId ? "pass" : "warning",
+      hasAppId || plan.executionProfile.appId
+        ? "The draft has an app id signal."
+        : "The draft still depends on APP_ID being supplied by the runner environment.",
+    ),
+    draftSelfCheckItem(
+      "Launch app",
+      /-\s*launchApp\b/.test(content) ? "pass" : "fail",
+      "The draft should launch the app before interactions.",
+    ),
+    draftSelfCheckItem(
+      "TODO comments",
+      todoCount === 0 ? "pass" : "warning",
+      todoCount === 0
+        ? "No TODO comments remain in the generated draft."
+        : `${todoCount} TODO marker${todoCount === 1 ? "" : "s"} remain for reviewer follow-up.`,
+    ),
+  ];
+  return buildDraftSelfCheck(
+    draftSelfCheckStatus(checks),
+    draftSelfCheckSummary(checks, "Maestro"),
+    plan.executionProfile.testCommand ?? "maestro test .maestro",
+    checks,
+  );
+}
+
+function buildDraftSelfCheck(
+  status: E2eDraftSelfCheckStatus,
+  summary: string,
+  command: string | undefined,
+  checks: E2eDraftSelfCheckItem[],
+): E2eDraftSelfCheck {
+  return {
+    status,
+    summary,
+    command,
+    checks,
+    blockers: checks.filter((check) => check.status === "fail").map((check) => `${check.name}: ${check.detail}`),
+  };
+}
+
+function draftSelfCheckItem(
+  name: string,
+  status: E2eDraftSelfCheckStatus,
+  detail: string,
+): E2eDraftSelfCheckItem {
+  return { name, status, detail };
+}
+
+function draftSelfCheckStatus(checks: E2eDraftSelfCheckItem[]): E2eDraftSelfCheckStatus {
+  if (checks.some((check) => check.status === "fail")) {
+    return "fail";
+  }
+  if (checks.some((check) => check.status === "warning")) {
+    return "warning";
+  }
+  return "pass";
+}
+
+function draftSelfCheckSummary(checks: E2eDraftSelfCheckItem[], runnerName: string): string {
+  const status = draftSelfCheckStatus(checks);
+  const failures = checks.filter((check) => check.status === "fail").length;
+  const warnings = checks.filter((check) => check.status === "warning").length;
+  if (status === "pass") {
+    return `${runnerName} draft passed static runner checks.`;
+  }
+  if (status === "fail") {
+    return `${runnerName} draft failed ${failures} static runner check${failures === 1 ? "" : "s"}.`;
+  }
+  return `${runnerName} draft passed required static checks with ${warnings} warning${warnings === 1 ? "" : "s"}.`;
 }
 
 function buildFallbackFlow(plan: E2ePlanResult): E2eFlow {
@@ -5189,6 +5436,9 @@ function formatDraftFileQuality(file: E2eDraftFile): string | undefined {
   }
   if (file.executionBlockers !== undefined && file.executionBlockers.length > 0) {
     details.push(`${file.executionBlockers.length} execution blocker${file.executionBlockers.length === 1 ? "" : "s"}`);
+  }
+  if (file.selfCheck !== undefined) {
+    details.push(`self-check ${file.selfCheck.status}`);
   }
   if (file.stability !== undefined) {
     details.push(file.stability);

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -1570,7 +1570,7 @@ test("generateE2eDraft uses web selectors in Playwright specs", async () => {
   assert.match(spec, /Inferred selectors/);
 });
 
-test("generateE2ePlan captures Playwright execution profile for runnable drafts", async () => {
+test("generateE2ePlan captures Playwright execution profile and self-check blockers", async () => {
   const root = await makeTempRepo();
   await initGitRepo(root);
   await mkdir(path.join(root, "src/pages/profile"), { recursive: true });
@@ -1625,9 +1625,12 @@ test("generateE2ePlan captures Playwright execution profile for runnable drafts"
   assert.match(markdown, /## Execution Profile/);
   assert.match(markdown, /Start command: `pnpm run dev`/);
   assert.match(markdown, /Base URL: `http:\/\/127\.0\.0\.1:4173`/);
-  assert.equal(draftFile.runnableStatus, "near-runnable");
+  assert.equal(draftFile.runnableStatus, "review-only");
+  assert.equal(draftFile.selfCheck?.status, "fail");
+  assert.ok(draftFile.selfCheck?.blockers.some((blocker) => /Unresolved placeholders/.test(blocker)));
   assert.deepEqual(draftFile.executionBlockers?.filter((blocker) => /Playwright|baseURL|start command/i.test(blocker)), []);
-  assert.match(formatMarkdownE2eDraft(draft), /near-runnable/);
+  assert.match(formatMarkdownE2eDraft(draft), /review-only/);
+  assert.match(formatMarkdownE2eDraft(draft), /## Draft Self Checks/);
   assert.match(spec, /Execution profile:/);
   assert.match(spec, /Start command: pnpm run dev/);
   assert.match(spec, /Test command: pnpm run test:e2e/);
@@ -1702,7 +1705,7 @@ test("generateE2eDraft emits runnable Playwright role and input actions", async 
       "    <input placeholder=\"Profile email\" />",
       "    <button>Save settings</button>",
       "    <a href=\"/settings/history\">View history</a>",
-      "    <p>Saved settings</p>",
+      "    <span title=\"Saved settings\">Saved settings</span>",
       "  </main>;",
       "}",
     ].join("\n"),
@@ -1717,11 +1720,17 @@ test("generateE2eDraft emits runnable Playwright role and input actions", async 
 
   assert.match(spec, /page\.getByPlaceholder\("Profile email"\)\.fill\("codeward@example.com"\)/);
   assert.match(spec, /page\.getByRole\("button", \{ name: "Save settings" \}\)\.click\(\)/);
+  assert.match(spec, /expect\(page\.getByText\("Saved settings"\)\)\.toBeVisible\(\)/);
   assert.match(spec, /role-button: Save settings/);
   assert.match(spec, /role-link: View history/);
+  assert.equal(draftFile.selfCheck?.status, "pass");
+  assert.equal(draftFile.selfCheck?.summary, "Playwright draft passed static runner checks.");
+  assert.match(formatMarkdownE2eDraft(draft), /Draft Self Checks/);
+  assert.doesNotMatch(formatMarkdownE2eDraft(draft), /Turn generated TODOs into runnable assertions/);
   assert.doesNotMatch(spec, /page\.getByLabel\("Profile email"\)/);
   assert.doesNotMatch(spec, /\/\/ TODO: Fill profile email/);
   assert.doesNotMatch(spec, /\/\/ TODO: Save settings/);
+  assert.doesNotMatch(spec, /\bTODO\b/);
 });
 
 test("generateE2eDraft normalizes dynamic routes without creating id domain scenarios", async () => {


### PR DESCRIPTION
## Summary
- Add per-file E2E draft self-check metadata for generated files, including static runner checks, summaries, commands, warnings, and blockers.
- Use self-check results to keep unresolved placeholder drafts in review-only status and to avoid assertion action items when generated Playwright steps are already concrete.
- Document self-check output in README, E2E examples, and release validation criteria.

## Validation
- pnpm test: 60 tests passed
- pnpm scan: 0 findings
- git diff --check
- pnpm pack --dry-run
- Desktop spot check on /Users/khs/Desktop/inpock-frontend/services/offer: generated drafts remain review-only and now self-check fail on unresolved placeholder locators/TODOs alongside missing Playwright config/baseURL.