### PR TITLE
feat: add e2e readiness summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ The draft result is meant to be useful as a PR artifact, not only as generated f
 - `selfCheck`: static runner checks for generated draft structure, unresolved placeholders, TODO markers, and the execution profile
 - `actionItems`: required and recommended follow-up work, grouped by assertion, fixture, selector, runner, validation, and manifest
 - `actionSummary`: total required/recommended action counts, ready file count, and the most common action categories
+- `readinessSummary`: an overall 0-100 score, readiness level, self-check counts, TODO counts, execution blocker counts, and top blockers
 
 See [docs/e2e-output-examples.md](docs/e2e-output-examples.md) for compact examples of web, mobile, API/service, test-light, and monorepo output.
 

--- a/docs/e2e-output-examples.md
+++ b/docs/e2e-output-examples.md
@@ -143,8 +143,10 @@ Draft action items should make the next developer action explicit:
 
 ```txt
 Action summary:
+- readiness score: 64/100 (needs-work)
 - runnable status: near-runnable
 - self-check: warning or fail when placeholder locators remain
+- top blocker: No Playwright baseURL or E2E base URL was detected.
 - required assertion: Turn generated TODOs into runnable assertions
 - required fixture: Add deterministic fixture or mock data
 - required validation: Resolve missing validation evidence

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -73,6 +73,7 @@ The E2E draft should show:
 - `selfCheck` status, summary, command, warnings, and blockers for each generated draft file
 - `actionItems` grouped by assertion, fixture, selector, runner, validation, or manifest
 - `actionSummary` with required and recommended action counts
+- `readinessSummary` with score, level, self-check counts, TODO counts, execution blocker counts, and top blockers
 - Playwright `test.step()` names that read like the product journey
 
 ## Current Fixture Evidence Matrix

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -296,6 +296,24 @@ export interface E2eDraftActionSummary {
 }
 
 export type E2eDraftPromotionStatus = "commit-candidate" | "needs-review" | "low-signal";
+export type E2eDraftReadinessLevel = "ready" | "near-runnable" | "needs-work" | "blocked";
+
+export interface E2eDraftReadinessSummary {
+  score: number;
+  level: E2eDraftReadinessLevel;
+  recommendation: string;
+  runnableCandidates: number;
+  nearRunnable: number;
+  reviewOnly: number;
+  selfCheckPass: number;
+  selfCheckWarning: number;
+  selfCheckFail: number;
+  filesWithTodos: number;
+  totalTodos: number;
+  filesWithExecutionBlockers: number;
+  totalExecutionBlockers: number;
+  topBlockers: string[];
+}
 
 export interface E2eDraftResult {
   tool: {
@@ -309,6 +327,7 @@ export interface E2eDraftResult {
   plan: E2ePlanResult;
   files: E2eDraftFile[];
   actionSummary: E2eDraftActionSummary;
+  readinessSummary: E2eDraftReadinessSummary;
   nextSteps: string[];
 }
 
@@ -497,6 +516,7 @@ export async function generateE2eDraft(rootInput: string, options: E2eDraftOptio
     });
   }
 
+  const actionSummary = summarizeDraftActionItems(files);
   return {
     tool: {
       name: TOOL_NAME,
@@ -508,7 +528,8 @@ export async function generateE2eDraft(rootInput: string, options: E2eDraftOptio
     outputDirectory: toDisplayPath(root, outputDirectory),
     plan,
     files,
-    actionSummary: summarizeDraftActionItems(files),
+    actionSummary,
+    readinessSummary: summarizeDraftReadiness(files, actionSummary),
     nextSteps: buildDraftNextSteps(plan, runner),
   };
 }
@@ -1627,6 +1648,106 @@ function compareDraftActionKindSummary(left: E2eDraftActionKindSummary, right: E
   return right.total - left.total || right.required - left.required || left.kind.localeCompare(right.kind);
 }
 
+function summarizeDraftReadiness(
+  files: E2eDraftFile[],
+  actionSummary: E2eDraftActionSummary,
+): E2eDraftReadinessSummary {
+  const totalFiles = Math.max(files.length, 1);
+  const runnableCandidates = files.filter((file) => file.runnableStatus === "runnable-candidate").length;
+  const nearRunnable = files.filter((file) => file.runnableStatus === "near-runnable").length;
+  const reviewOnly = files.filter((file) => file.runnableStatus === "review-only").length;
+  const selfCheckPass = files.filter((file) => file.selfCheck?.status === "pass").length;
+  const selfCheckWarning = files.filter((file) => file.selfCheck?.status === "warning").length;
+  const selfCheckFail = files.filter((file) => file.selfCheck?.status === "fail").length;
+  const filesWithTodos = files.filter((file) => (file.todoCount ?? 0) > 0).length;
+  const totalTodos = files.reduce((sum, file) => sum + (file.todoCount ?? 0), 0);
+  const filesWithExecutionBlockers = files.filter((file) => (file.executionBlockers?.length ?? 0) > 0).length;
+  const totalExecutionBlockers = files.reduce((sum, file) => sum + (file.executionBlockers?.length ?? 0), 0);
+  const topBlockers = topDraftReadinessBlockers(files);
+
+  const statusScore =
+    (runnableCandidates * 100 + nearRunnable * 75 + reviewOnly * 35) / totalFiles;
+  const selfCheckPenalty = (selfCheckWarning * 10 + selfCheckFail * 25) / totalFiles;
+  const requiredActionPenalty = Math.min(25, actionSummary.required * 3);
+  const todoPenalty = Math.min(15, totalTodos);
+  const blockerPenalty = Math.min(20, filesWithExecutionBlockers * 5);
+  const score = clampReadinessScore(
+    Math.round(statusScore - selfCheckPenalty - requiredActionPenalty - todoPenalty - blockerPenalty),
+  );
+  const level = draftReadinessLevel(score, actionSummary.required, selfCheckFail, reviewOnly);
+
+  return {
+    score,
+    level,
+    recommendation: draftReadinessRecommendation(level, topBlockers),
+    runnableCandidates,
+    nearRunnable,
+    reviewOnly,
+    selfCheckPass,
+    selfCheckWarning,
+    selfCheckFail,
+    filesWithTodos,
+    totalTodos,
+    filesWithExecutionBlockers,
+    totalExecutionBlockers,
+    topBlockers,
+  };
+}
+
+function topDraftReadinessBlockers(files: E2eDraftFile[]): string[] {
+  const counts = new Map<string, number>();
+  for (const file of files) {
+    const blockers = [...(file.executionBlockers ?? []), ...(file.selfCheck?.blockers ?? [])];
+    for (const blocker of uniqueStrings(blockers)) {
+      counts.set(blocker, (counts.get(blocker) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .slice(0, 5)
+    .map(([blocker, count]) => count > 1 ? `${blocker} (${count} files)` : blocker);
+}
+
+function clampReadinessScore(score: number): number {
+  return Math.max(0, Math.min(100, score));
+}
+
+function draftReadinessLevel(
+  score: number,
+  requiredActions: number,
+  selfCheckFail: number,
+  reviewOnly: number,
+): E2eDraftReadinessLevel {
+  if (score >= 85 && requiredActions === 0 && selfCheckFail === 0 && reviewOnly === 0) {
+    return "ready";
+  }
+  if (score >= 70 && selfCheckFail === 0) {
+    return "near-runnable";
+  }
+  if (score >= 45) {
+    return "needs-work";
+  }
+  return "blocked";
+}
+
+function draftReadinessRecommendation(level: E2eDraftReadinessLevel, blockers: string[]): string {
+  if (level === "ready") {
+    return "Generated drafts are ready to try as local regression evidence.";
+  }
+  if (level === "near-runnable") {
+    return "Run the suggested command locally, then close the remaining recommended review items.";
+  }
+  const blocker = blockers[0];
+  if (level === "needs-work") {
+    return blocker
+      ? `Resolve the highest-impact blocker first: ${blocker}.`
+      : "Close required action items before treating the drafts as regression evidence.";
+  }
+  return blocker
+    ? `Do not treat these drafts as runnable yet. Start with: ${blocker}.`
+    : "Do not treat these drafts as runnable until required setup and validation gaps are closed.";
+}
+
 function buildFlowLanguageBrief(flow: Omit<E2eFlow, "languageBrief">): E2eFlowLanguageBrief {
   const actor = inferFlowActor(flow);
   const trigger = inferFlowTrigger(flow);
@@ -2106,8 +2227,25 @@ export function formatMarkdownE2eDraft(result: E2eDraftResult): string {
   lines.push("## Draft Readiness Summary");
   lines.push("");
   lines.push(
+    `Score: ${result.readinessSummary.score}/100 (${result.readinessSummary.level}) - ${escapeMarkdownInline(result.readinessSummary.recommendation)}`,
+  );
+  lines.push(
     `Summary: ${result.actionSummary.required} required action${result.actionSummary.required === 1 ? "" : "s"}, ${result.actionSummary.recommended} recommended action${result.actionSummary.recommended === 1 ? "" : "s"}.`,
   );
+  lines.push(`- Runnable candidates: ${result.readinessSummary.runnableCandidates}`);
+  lines.push(`- Near-runnable files: ${result.readinessSummary.nearRunnable}`);
+  lines.push(`- Review-only files: ${result.readinessSummary.reviewOnly}`);
+  lines.push(
+    `- Self-checks: ${result.readinessSummary.selfCheckPass} pass, ${result.readinessSummary.selfCheckWarning} warning, ${result.readinessSummary.selfCheckFail} fail`,
+  );
+  lines.push(`- TODO markers: ${result.readinessSummary.totalTodos} across ${result.readinessSummary.filesWithTodos} file${result.readinessSummary.filesWithTodos === 1 ? "" : "s"}`);
+  lines.push(`- Execution blockers: ${result.readinessSummary.totalExecutionBlockers} across ${result.readinessSummary.filesWithExecutionBlockers} file${result.readinessSummary.filesWithExecutionBlockers === 1 ? "" : "s"}`);
+  if (result.readinessSummary.topBlockers.length > 0) {
+    lines.push("- Top blockers:");
+    for (const blocker of result.readinessSummary.topBlockers.slice(0, 3)) {
+      lines.push(`  - ${escapeMarkdownInline(blocker)}`);
+    }
+  }
   lines.push(`- Ready files: ${result.actionSummary.readyFiles}`);
   lines.push(`- Files with required actions: ${result.actionSummary.filesWithRequiredActions}`);
   lines.push(`- Files with recommended actions: ${result.actionSummary.filesWithRecommendedActions}`);

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -1412,8 +1412,11 @@ test("generateE2ePlan flags missing mock fixtures for API-dependent UI flows", a
   assert.ok(draftFile.actionItems.some((item) => item.kind === "validation" && item.priority === "required"));
   assert.equal(draft.actionSummary.filesWithRequiredActions > 0, true);
   assert.equal(draft.actionSummary.required > 0, true);
+  assert.equal(draft.readinessSummary.filesWithExecutionBlockers > 0, true);
+  assert.equal(draft.readinessSummary.totalExecutionBlockers > 0, true);
   assert.ok(draft.actionSummary.byKind.some((item) => item.kind === "fixture" && item.required > 0));
   assert.match(formatMarkdownE2eDraft(draft), /## Draft Readiness Summary/);
+  assert.match(formatMarkdownE2eDraft(draft), /Top blockers:/);
   assert.match(formatMarkdownE2eDraft(draft), /Files with required actions:/);
   assert.match(formatMarkdownE2eDraft(draft), /## Draft Action Items/);
   assert.match(formatMarkdownE2eDraft(draft), /\[required\] fixture: Add deterministic fixture or mock data/);
@@ -1628,9 +1631,13 @@ test("generateE2ePlan captures Playwright execution profile and self-check block
   assert.equal(draftFile.runnableStatus, "review-only");
   assert.equal(draftFile.selfCheck?.status, "fail");
   assert.ok(draftFile.selfCheck?.blockers.some((blocker) => /Unresolved placeholders/.test(blocker)));
+  assert.equal(draft.readinessSummary.reviewOnly > 0, true);
+  assert.equal(draft.readinessSummary.selfCheckFail > 0, true);
+  assert.ok(draft.readinessSummary.topBlockers.some((blocker) => /Unresolved placeholders/.test(blocker)));
   assert.deepEqual(draftFile.executionBlockers?.filter((blocker) => /Playwright|baseURL|start command/i.test(blocker)), []);
   assert.match(formatMarkdownE2eDraft(draft), /review-only/);
   assert.match(formatMarkdownE2eDraft(draft), /## Draft Self Checks/);
+  assert.match(formatMarkdownE2eDraft(draft), /Score: \d+\/100/);
   assert.match(spec, /Execution profile:/);
   assert.match(spec, /Start command: pnpm run dev/);
   assert.match(spec, /Test command: pnpm run test:e2e/);
@@ -1725,7 +1732,11 @@ test("generateE2eDraft emits runnable Playwright role and input actions", async 
   assert.match(spec, /role-link: View history/);
   assert.equal(draftFile.selfCheck?.status, "pass");
   assert.equal(draftFile.selfCheck?.summary, "Playwright draft passed static runner checks.");
+  assert.equal(draft.readinessSummary.nearRunnable, 1);
+  assert.equal(draft.readinessSummary.selfCheckPass, 1);
+  assert.equal(draft.readinessSummary.totalTodos, 0);
   assert.match(formatMarkdownE2eDraft(draft), /Draft Self Checks/);
+  assert.match(formatMarkdownE2eDraft(draft), /Self-checks: 1 pass, 0 warning, 0 fail/);
   assert.doesNotMatch(formatMarkdownE2eDraft(draft), /Turn generated TODOs into runnable assertions/);
   assert.doesNotMatch(spec, /page\.getByLabel\("Profile email"\)/);
   assert.doesNotMatch(spec, /\/\/ TODO: Fill profile email/);


### PR DESCRIPTION
## Summary
- Add an aggregate readiness summary to E2E draft output with a 0-100 score, readiness level, recommendation, runnable status counts, self-check counts, TODO counts, execution blocker counts, and top blockers.
- Surface the readiness summary in Markdown so users can quickly see whether generated drafts are runnable, near-runnable, needs-work, or blocked.
- Document the new summary in README, E2E output examples, and release validation criteria.

## Validation
- pnpm test: 60 tests passed
- pnpm scan: 0 findings
- git diff --check
- pnpm pack --dry-run
- Desktop spot check on /Users/khs/Desktop/inpock-frontend/services/offer: readiness summary reports 0/100 blocked with top blockers for missing Playwright baseURL/config, unresolved placeholders, validation gaps, and selector gaps.