### PR TITLE
Add Playwright bootstrap guidance

### DIFF
--- a/docs/e2e-output-examples.md
+++ b/docs/e2e-output-examples.md
@@ -146,7 +146,8 @@ Action summary:
 - readiness score: 64/100 (needs-work)
 - runnable status: near-runnable
 - self-check: warning or fail when placeholder locators remain
-- top blocker: No Playwright baseURL or E2E base URL was detected.
+- top blocker: No Playwright config file was detected.
+- required runner: Create `playwright.config.ts` with `testDir`, `use.baseURL`, and `webServer.command` when CodeWard inferred the dev URL from scripts.
 - required assertion: Turn generated TODOs into runnable assertions
 - required fixture: Add deterministic fixture or mock data
 - required validation: Resolve missing validation evidence

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -861,9 +861,9 @@ function buildE2eBootstrapPlan(input: E2eBootstrapPlanInput): E2eBootstrapPlan {
         `Configure ${formatRunnerName(input.recommendedRunner.name)} before making drafts required`,
         runnerGap,
         input.recommendedRunner.name === "playwright"
-          ? "Add a Playwright config, baseURL, and app serve command, then run the generated spec locally."
+          ? playwrightConfigGuidance(input.executionProfile)
           : "Add a .maestro directory or documented Maestro setup, app id, and simulator launch command.",
-        [],
+        input.recommendedRunner.name === "playwright" ? playwrightSetupCommands(input.executionProfile) : [],
         [],
       ),
     );
@@ -1415,7 +1415,7 @@ function buildDraftActionItems(
       "runner",
       "required",
       `Configure ${formatRunnerName(runner)} execution`,
-      runnerGap,
+      runner === "playwright" ? playwrightConfigGuidance(plan.executionProfile) : runnerGap,
     ));
   }
   const executionBlockers = remainingExecutionProfileBlockers(plan.executionProfile.blockers, runnerGap);
@@ -5778,6 +5778,9 @@ function buildDraftNextSteps(plan: E2ePlanResult, runner: E2eRunnerName): string
       : `Run the app with the launch command that matches your simulator or device, then run \`${plan.executionProfile.testCommand ?? "maestro test .maestro"}\`.`);
   } else if (runner === "playwright") {
     steps.push("Replace TODO locators with role, text, or data-testid locators from the app.");
+    if (plan.executionProfile.blockers.some((blocker) => /No Playwright config/i.test(blocker))) {
+      steps.push(playwrightConfigGuidance(plan.executionProfile));
+    }
     if (plan.executionProfile.baseUrl) {
       steps.push(`Confirm Playwright baseURL \`${plan.executionProfile.baseUrl}\` points at the target environment.`);
     } else {
@@ -5803,6 +5806,23 @@ function buildDraftNextSteps(plan: E2ePlanResult, runner: E2eRunnerName): string
     steps.push("Resolve missing validation matrix rows before promoting generated drafts to required PR evidence.");
   }
   return steps;
+}
+
+function playwrightConfigGuidance(profile: E2eExecutionProfile): string {
+  if (profile.baseUrl && profile.startCommand) {
+    return `Create playwright.config.ts with testDir "./tests/e2e", use.baseURL "${profile.baseUrl}", and webServer.command "${profile.startCommand}" before treating generated specs as required.`;
+  }
+  if (profile.baseUrl) {
+    return `Create playwright.config.ts with testDir "./tests/e2e" and use.baseURL "${profile.baseUrl}", then document the app serve command before treating generated specs as required.`;
+  }
+  if (profile.startCommand) {
+    return `Create playwright.config.ts with a confirmed baseURL and webServer.command "${profile.startCommand}", then run the generated spec locally.`;
+  }
+  return "Create playwright.config.ts with testDir \"./tests/e2e\", a confirmed baseURL, and a webServer command before treating generated specs as required.";
+}
+
+function playwrightSetupCommands(profile: E2eExecutionProfile): string[] {
+  return uniqueStrings([profile.startCommand, profile.testCommand].filter(Boolean) as string[]);
 }
 
 function formatDraftFileQuality(file: E2eDraftFile): string | undefined {

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -1812,6 +1812,11 @@ test("generateE2ePlan infers Playwright base URLs from dev scripts", async () =>
   await git(root, ["commit", "-m", "update settings page"]);
 
   const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const draft = await generateE2eDraft(root, { base: "main", head: "HEAD", output: ".generated-e2e" });
+  const runnerStep = plan.bootstrap.steps.find((step) => step.title === "Configure Playwright before making drafts required");
+  const runnerAction = draft.files
+    .flatMap((file) => file.actionItems ?? [])
+    .find((item) => item.kind === "runner" && item.title === "Configure Playwright execution");
 
   assert.equal(plan.executionProfile.runner, "playwright");
   assert.equal(plan.executionProfile.startCommand, "pnpm run dev");
@@ -1819,6 +1824,14 @@ test("generateE2ePlan infers Playwright base URLs from dev scripts", async () =>
   assert.equal(plan.executionProfile.baseUrl, "http://localhost:3004");
   assert.ok(plan.executionProfile.blockers.some((blocker) => /Playwright config/.test(blocker)));
   assert.equal(plan.executionProfile.blockers.some((blocker) => /baseURL|base URL/.test(blocker)), false);
+  assert.ok(runnerStep);
+  assert.match(runnerStep.action, /playwright\.config\.ts/);
+  assert.match(runnerStep.action, /webServer\.command "pnpm run dev"/);
+  assert.match(runnerStep.action, /use\.baseURL "http:\/\/localhost:3004"/);
+  assert.deepEqual(runnerStep.commands, ["pnpm run dev", "npx playwright test"]);
+  assert.ok(runnerAction);
+  assert.match(runnerAction.detail, /playwright\.config\.ts/);
+  assert.match(runnerAction.detail, /http:\/\/localhost:3004/);
 });
 
 test("generateE2eDraft emits runnable Playwright role and input actions", async () => {


### PR DESCRIPTION
## Summary
- Make missing Playwright config guidance concrete when CodeWard can infer a base URL and start command.
- Surface the minimum playwright.config.ts shape in bootstrap steps, draft action items, and next steps.
- Update E2E output examples to show the new runner action.

## Validation
- pnpm check
- pnpm test
- pnpm scan
- git diff --check
- pnpm pack --dry-run
- Local representative repo spot check for inferred Playwright base URL and missing config guidance.