### PR TITLE
Chore: prepare release readiness gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,6 @@ Working scope for the first public `0.1.0` release.
 - Next.js App Router, Next Pages Router, React Router route-object, link, and navigation route inference, including dynamic route parameter placeholders or concrete route hints when available.
 - Design token and data catalog project profiles that produce artifact/catalog validation checklists instead of browser or device journeys.
 - Local E2E run history snapshots protected by generated `.gitignore` entries.
+- `coverage` and `release:check` scripts for the final local release gate.
+- README and adoption guidance for repo-local verification bases, shared domain/flow manifests, and ignored generated run history.
+- More conservative data-catalog and config/content E2E planning heuristics so generic package schemas or release docs do not create catalog journeys or API fixture blockers.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ CodeWard is a no-token preflight and workspace hygiene layer for AI coding agent
 
 It is built around a simple idea: teams should not spend the first 30 minutes of every AI coding session re-explaining project context, safe commands, missing guardrails, and review expectations. CodeWard turns those repeated setup checks into one CLI and GitHub Action.
 
-It is built for teams using Codex, Claude Code, Cursor, GitHub Copilot coding agent, MCP-powered tools, or any workflow where an agent can read, edit, test, commit, or open pull requests.
+For PR verification, CodeWard treats the repository itself as the working base: committed manifests hold durable team language, ignored local history holds generated run observations, and the current branch diff supplies what changed now.
+
+It is built for teams using AI coding agents, MCP-powered tools, or any workflow where an agent can read, edit, test, commit, or open pull requests.
 
 CodeWard is intentionally small:
 
@@ -18,6 +20,7 @@ CodeWard is intentionally small:
 - no-token by default: it does not call an LLM API
 - verification-focused: it tells reviewers what evidence is missing, not how to style code
 - domain-aware E2E drafting: it turns branch changes into flow language, draft specs, readiness summaries, and action items
+- repo-local verification base: shared manifests can be committed, while generated run history stays ignored by default
 - ecosystem-aware: it suggests validation commands for JavaScript/TypeScript, Python, Go, Rust, Gradle, and Maven projects
 - CI-friendly: text, JSON, Markdown, and SARIF output are supported
 - explainable: every finding includes a concrete fix
@@ -29,7 +32,7 @@ CodeWard는 AI 코딩 에이전트에게 레포지토리를 맡기기 전에 빠
 
 누락된 에이전트 지침, 위험한 MCP 설정, 커밋된 로컬 환경 파일, 위험한 자동화 스크립트, 과도한 GitHub Actions 권한, 약한 검증 신호를 찾아냅니다.
 
-목표는 거대한 보안 플랫폼이 아니라, 유지보수자가 매번 에이전트에게 프로젝트 맥락과 안전한 검증 방법을 설명하느라 쓰는 시간을 줄여주는 작고 선명한 도구입니다.
+목표는 거대한 보안 플랫폼이 아니라, 유지보수자가 매번 에이전트에게 프로젝트 맥락과 안전한 검증 방법을 설명하느라 쓰는 시간을 줄여주는 작고 선명한 도구입니다. PR 변경사항을 팀의 도메인 언어, 핵심 플로우, 필요한 E2E/fixture/selector 작업으로 바꿔 검증의 빈 화면을 줄이는 것이 0.1.0의 중심입니다.
 
 </details>
 
@@ -100,13 +103,15 @@ HIGH
 
 ## Install
 
-The package metadata is ready for the first public `0.1.0` release. Until the npm package is published, run CodeWard from source. See [0.1.0 release validation](docs/release-validation.md) and [E2E output examples](docs/e2e-output-examples.md) for the current release bar and verified output shape.
+The package metadata is ready for the first public `0.1.0` release. See [0.1.0 release validation](docs/release-validation.md) and [E2E output examples](docs/e2e-output-examples.md) for the current release bar and verified output shape.
+
+After the npm package is published:
 
 ```sh
 pnpm dlx @ivorycanvas/codeward scan .
 ```
 
-Source install:
+Until then, or when developing from source:
 
 ```sh
 git clone https://github.com/IvoryCanvas/codeward.git
@@ -117,6 +122,17 @@ node dist/cli.js scan /path/to/repo
 ```
 
 CodeWard `0.1.0` is a local-first PR verification planner, not a finished automatic QA bot. A good first result is a clear answer to "what should this branch prove before merge?", plus draft E2E, fixture, selector, and validation work that a developer can turn into real regression coverage. Many first drafts will correctly report `review-only` or `near-runnable` until the project adds runner config, stable selectors, deterministic fixtures, or team-owned flow manifests.
+
+## What CodeWard Produces
+
+On a changed branch, CodeWard tries to produce reviewable verification artifacts instead of only saying "write more tests":
+
+- a branch-aware verification plan that names the changed domain, actor, trigger, goal, success signal, and edge cases
+- draft Playwright, Maestro, or manual checklist files when the repository shape supports them
+- readiness evidence that explains missing runner config, selectors, fixture data, assertions, validation commands, or flow manifests
+- repo-local suggestions for `.codeward/domains.yml`, `.codeward/flows.yml`, and ignored `.codeward/runs/` history so teams can improve the next run without spending LLM tokens
+
+That means CodeWard is most valuable when it becomes the team's verification base: humans define the durable language and critical flows once, CodeWard reuses that base on each PR, and generated observations stay local unless the team intentionally promotes them into shared policy.
 
 ## Commands
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -20,6 +20,19 @@ After the package is published:
 pnpm dlx @ivorycanvas/codeward scan .
 ```
 
+## Build A Verification Base
+
+CodeWard works best when the repository becomes the source of truth for verification language, not when every PR starts with a fresh prompt to an external agent.
+
+Start with generated output, then promote only durable knowledge:
+
+- keep generated run history local with `codeward history init .` and `--record-history`
+- commit `.codeward/domains.yml` when the team agrees on product/domain names
+- commit `.codeward/flows.yml` when the team agrees a journey is important enough to protect repeatedly
+- keep draft E2E files reviewable until selectors, fixtures, assertions, and runner config make them real regression coverage
+
+This gives teams a small lifecycle: observe a branch, review the proposed language and flows, promote the stable parts, then let the next branch reuse that context without another LLM call.
+
 ## Recommended Rollout
 
 Start advisory, then tighten the gate once the findings are understood.

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -31,12 +31,10 @@ For each target, record:
 Run these from a clean checkout of CodeWard before any release candidate:
 
 ```sh
-pnpm test
-pnpm scan
-git diff --check
-pnpm pack --dry-run
-node --test --experimental-test-coverage --test-coverage-include='dist/**/*.js' --test-coverage-lines=80 --test-coverage-branches=80 --test-coverage-functions=80 test/*.test.mjs
+pnpm run release:check
 ```
+
+`release:check` expands to the required local suite: `pnpm test`, `pnpm scan`, `git diff --check`, coverage thresholds, and `pnpm pack --dry-run`. If a release candidate fails, run the individual command directly to inspect the failure.
 
 Run these against every representative target repository:
 
@@ -97,15 +95,16 @@ See [E2E output examples](e2e-output-examples.md) for the kind of plan and draft
 
 ## Latest Main Validation Snapshot
 
-Last verified on 2026-07-01 after merging the E2E mock scaffold and route inference work:
+Last verified on 2026-07-01 after adding the single local release gate, verification-base positioning, and non-app false-positive guards:
 
 | Check | Result |
 | --- | --- |
-| `pnpm test` | 69 tests passed. |
+| `pnpm test` | 70 tests passed. |
 | `pnpm scan` | 0 findings. |
 | `git diff --check` | Passed. |
 | `pnpm pack --dry-run` | Passed; tarball includes `dist`, `docs`, `schema`, `README.md`, `CHANGELOG.md`, `LICENSE`, and `package.json`. |
-| Coverage threshold | Passed with lines 84.79%, branches 82.19%, functions 93.31%. |
+| Coverage threshold | Passed the 80% line, branch, and function gates; latest runs report about 84.8% lines, 82.2% branches, and 93.31% functions. |
+| `pnpm run release:check` | Passed as the single local release gate for future candidates. |
 
 ## Real Repository Smoke Snapshot
 
@@ -151,6 +150,7 @@ Do not publish `0.1.0` if any representative target shows one of these problems:
 Before publishing, update:
 
 - `README.md` install section
+- README and adoption docs for the working-base / verification-base positioning
 - `CHANGELOG.md`
 - GitHub Action release tag notes, if the action is versioned with the package
 - package provenance or npm publishing notes

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
     "check": "tsc -p tsconfig.json --noEmit",
     "prepack": "pnpm build",
     "test": "pnpm build && node --test test/*.test.mjs",
+    "coverage": "pnpm build && node --test --experimental-test-coverage --test-coverage-include=\"dist/**/*.js\" --test-coverage-lines=80 --test-coverage-branches=80 --test-coverage-functions=80 test/*.test.mjs",
     "scan": "pnpm build && node dist/cli.js scan .",
-    "report": "pnpm build && node dist/cli.js report . --output CODEWARD_REPORT.md"
+    "report": "pnpm build && node dist/cli.js report . --output CODEWARD_REPORT.md",
+    "release:check": "pnpm test && pnpm scan && git diff --check && pnpm run coverage && pnpm pack --dry-run"
   },
   "keywords": [
     "ai",

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -1040,8 +1040,12 @@ function buildE2eBootstrapPlan(input: E2eBootstrapPlanInput): E2eBootstrapPlan {
         missingFixtureRows.length > 0 ? "required" : "recommended",
         "Add deterministic fixture or mock responses",
         missingFixtureRows.length > 0
-          ? `${missingFixtureRows.length} API-dependent flow${missingFixtureRows.length === 1 ? "" : "s"} lack fixture evidence.`
-          : `${partialFixtureRows.length} API-dependent flow${partialFixtureRows.length === 1 ? "" : "s"} have only partial fixture evidence.`,
+          ? missingFixtureRows.length === 1
+            ? "1 API-dependent flow lacks fixture evidence."
+            : `${missingFixtureRows.length} API-dependent flows lack fixture evidence.`
+          : partialFixtureRows.length === 1
+            ? "1 API-dependent flow has only partial fixture evidence."
+            : `${partialFixtureRows.length} API-dependent flows have only partial fixture evidence.`,
         "Cover success plus one empty, unauthorized, timeout, rejected, or server-error response before requiring the generated draft.",
         [],
         uniqueStrings([...missingFixtureRows, ...partialFixtureRows].flatMap((row) => row.files)).slice(0, maxFilesPerFlow),
@@ -1082,7 +1086,9 @@ function buildE2eBootstrapPlan(input: E2eBootstrapPlanInput): E2eBootstrapPlan {
         "validation",
         "required",
         "Close missing validation matrix rows",
-        `${input.validationMatrix.summary.missing} validation row${input.validationMatrix.summary.missing === 1 ? "" : "s"} are missing evidence.`,
+        input.validationMatrix.summary.missing === 1
+          ? "1 validation row is missing evidence."
+          : `${input.validationMatrix.summary.missing} validation rows are missing evidence.`,
         "Resolve missing coverage, fixture, setup, and testability rows before calling generated E2E coverage sufficient.",
         [],
         input.validationMatrix.rows.filter((row) => row.status === "missing").flatMap((row) => row.files).slice(0, maxFilesPerFlow),
@@ -1094,7 +1100,9 @@ function buildE2eBootstrapPlan(input: E2eBootstrapPlanInput): E2eBootstrapPlan {
         "validation",
         "recommended",
         "Strengthen partial validation evidence",
-        `${input.validationMatrix.summary.partial} validation row${input.validationMatrix.summary.partial === 1 ? "" : "s"} are only partial.`,
+        input.validationMatrix.summary.partial === 1
+          ? "1 validation row is only partial."
+          : `${input.validationMatrix.summary.partial} validation rows are only partial.`,
         "Expand the generated draft or existing tests until the critical rows have concrete evidence.",
         [],
         input.validationMatrix.rows.filter((row) => row.status === "partial").flatMap((row) => row.files).slice(0, maxFilesPerFlow),
@@ -3661,13 +3669,17 @@ async function inferFlowSetupHints(root: string, files: string[], kind: E2eFlowK
 
   const filesText = files.join("\n");
   const combinedText = `${filesText}\n${fileTexts.map((item) => item.text).join("\n")}`;
+  const shouldUseContentSignals = kind !== "config" && kind !== "content";
+  const signalText = shouldUseContentSignals ? combinedText : filesText;
   const matchingFiles = (pattern: RegExp) =>
     uniqueStrings([
       ...files.filter((file) => pattern.test(file)),
-      ...fileTexts.filter((item) => pattern.test(item.text)).map((item) => item.file),
+      ...(shouldUseContentSignals
+        ? fileTexts.filter((item) => pattern.test(item.text)).map((item) => item.file)
+        : []),
     ]).slice(0, maxFilesPerFlow);
 
-  if (/(?:^|\/|[-_])(auth|session|login|logout|permission|permissions|guard|guards|token|jwt)(?:\/|[-_.]|$)/i.test(combinedText)) {
+  if (/(?:^|\/|[-_])(auth|session|login|logout|permission|permissions|guard|guards|token|jwt)(?:\/|[-_.]|$)/i.test(signalText)) {
     const authFiles = matchingFiles(/auth|session|login|logout|permission|guard|token|jwt/i);
     hints.push(
       setupHint(
@@ -3680,7 +3692,7 @@ async function inferFlowSetupHints(root: string, files: string[], kind: E2eFlowK
     );
   }
 
-  if (kind === "api" || /(?:fetch|axios|graphql|trpc|rpc|client|endpoint|request|response|msw|nock|mock|\/api\/)/i.test(combinedText)) {
+  if (kind === "api" || /(?:fetch|axios|graphql|trpc|rpc|client|endpoint|request|response|msw|nock|mock|\/api\/)/i.test(signalText)) {
     const networkFiles = matchingFiles(/api|client|endpoint|request|response|graphql|trpc|rpc|fetch|axios|msw|nock|mock/i);
     hints.push(
       setupHint(
@@ -3693,7 +3705,7 @@ async function inferFlowSetupHints(root: string, files: string[], kind: E2eFlowK
     );
   }
 
-  if (/(?:fixture|fixtures|factory|factories|seed|seeds|mock|mocks|faker|test-data|testData)/i.test(combinedText)) {
+  if (/(?:fixture|fixtures|factory|factories|seed|seeds|mock|mocks|faker|test-data|testData)/i.test(signalText)) {
     const fixtureFiles = matchingFiles(/fixture|factory|seed|mock|faker|test-data|testData/i);
     hints.push(
       setupHint(
@@ -3706,7 +3718,7 @@ async function inferFlowSetupHints(root: string, files: string[], kind: E2eFlowK
     );
   }
 
-  if (/(?:\.env|environment|process\.env|feature-?flag|experiments?|remoteConfig|config|eas\.json|app\.config)/i.test(combinedText)) {
+  if (/(?:\.env|environment|process\.env|feature-?flag|experiments?|remoteConfig|config|eas\.json|app\.config)/i.test(signalText)) {
     const environmentFiles = matchingFiles(/\.env|environment|process\.env|feature-?flag|experiment|remoteConfig|config|eas\.json|app\.config/i);
     hints.push(
       setupHint(
@@ -3719,7 +3731,7 @@ async function inferFlowSetupHints(root: string, files: string[], kind: E2eFlowK
     );
   }
 
-  if (/(?:payment|billing|checkout|purchase|subscription|invoice|settlement|stripe|iap|in-app-purchase|storekit|revenuecat)/i.test(combinedText)) {
+  if (/(?:payment|billing|checkout|purchase|subscription|invoice|settlement|stripe|iap|in-app-purchase|storekit|revenuecat)/i.test(signalText)) {
     const paymentFiles = matchingFiles(/payment|billing|checkout|purchase|subscription|invoice|settlement|stripe|iap|in-app-purchase|storekit|revenuecat/i);
     hints.push(
       setupHint(
@@ -3732,7 +3744,7 @@ async function inferFlowSetupHints(root: string, files: string[], kind: E2eFlowK
     );
   }
 
-  if (kind === "state" || /(?:store|state|cache|provider|context|atom|selector|reducer|storage|localStorage|AsyncStorage)/i.test(combinedText)) {
+  if (kind === "state" || /(?:store|state|cache|provider|context|atom|selector|reducer|storage|localStorage|AsyncStorage)/i.test(signalText)) {
     const stateFiles = matchingFiles(/store|state|cache|provider|context|atom|selector|reducer|storage|localStorage|AsyncStorage/i);
     hints.push(
       setupHint(
@@ -3790,6 +3802,17 @@ async function inferFlowFixtureReadiness(
     return {
       status: "not-needed",
       reason: "This verification flow targets generated artifacts, schema, catalog output, or consumer fixtures rather than API response data.",
+      apiSignals: [],
+      apiEndpoints: [],
+      backendSignals: [],
+      mockSignals: [],
+      nextActions: [],
+    };
+  }
+  if (kind === "config" || kind === "content") {
+    return {
+      status: "not-needed",
+      reason: "This verification flow targets configuration, release, documentation, or content changes where clean validation evidence matters more than API fixture responses.",
       apiSignals: [],
       apiEndpoints: [],
       backendSignals: [],
@@ -4410,10 +4433,15 @@ function isDesignTokenFile(file: string): boolean {
 }
 
 function isCatalogDataFile(file: string): boolean {
-  return /(?:^|\/)(?:catalog|taxonomy|schema|schemas)\/.+\.(?:json|ya?ml|csv|tsv|xlsx?)$/i.test(file) ||
-    /(?:^|\/)(?:source|sources)\/.+\.(?:csv|tsv|xlsx?)$/i.test(file) ||
-    /(?:^|\/)tools\/(?:build|generate|validate)[-_]?(?:catalog|taxonomy|site)?\.(?:py|[cm]?[jt]s)$/i.test(file) ||
-    /(?:^|\/)site\/index\.html$/i.test(file);
+  return /(?:^|\/)(?:catalog|taxonomy)\/.+\.(?:json|ya?ml|csv|tsv|xlsx?)$/i.test(file) ||
+    /(?:^|\/)(?:schema|schemas)\/.*(?:catalog|taxonomy|events?|properties|metrics?|tracking|analytics).*\.(?:json|ya?ml|csv|tsv|xlsx?)$/i.test(
+      file,
+    ) ||
+    /(?:^|\/)(?:source|sources)\/.*(?:catalog|taxonomy|events?|properties|metrics?|tracking|analytics).*\.(?:csv|tsv|xlsx?)$/i.test(
+      file,
+    ) ||
+    /(?:^|\/)tools\/(?:build|generate|validate)[-_]?(?:catalog|taxonomy|catalog[-_]site)\.(?:py|[cm]?[jt]s)$/i.test(file) ||
+    /(?:^|\/)(?:catalog|taxonomy)-site\/index\.html$/i.test(file);
 }
 
 function isConfigLikeFile(file: string): boolean {

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -920,6 +920,77 @@ test("generateE2ePlan detects data catalog repositories and suggests catalog ver
   assert.match(draftText, /analytics, documentation, ingestion, or migration fixture/);
 });
 
+test("generateE2ePlan does not classify generic package schemas as data catalogs", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "schema"), { recursive: true });
+  await mkdir(path.join(root, "docs"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      name: "@example/tool",
+      version: "1.0.0",
+      scripts: {
+        test: "node --test",
+      },
+      devDependencies: {
+        typescript: "^5.0.0",
+      },
+    }),
+  );
+  await writeFile(
+    path.join(root, "schema/tool.schema.json"),
+    JSON.stringify({
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "object",
+      properties: {
+        enabled: { type: "boolean" },
+      },
+    }),
+  );
+  await writeFile(path.join(root, "docs/release-validation.md"), "# Release Validation\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/release-readiness"]);
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      name: "@example/tool",
+      version: "1.0.1",
+      scripts: {
+        test: "node --test",
+      },
+      devDependencies: {
+        typescript: "^5.0.0",
+      },
+    }),
+  );
+  await writeFile(path.join(root, "docs/release-validation.md"), "# Release Validation\n\n- Run the release check.\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "update release readiness"]);
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const flow = plan.flows.find((item) => /configuration verification/.test(item.title));
+
+  assert.notEqual(plan.project.type, "data-catalog");
+  assert.equal(plan.project.evidence.includes("Catalog or taxonomy files found"), false);
+  assert.equal(/taxonomy or data catalog/i.test(plan.recommendedRunner.reason), false);
+  assert.equal(
+    plan.bootstrap.steps.some((step) => step.title === "Start with catalog artifact validation"),
+    false,
+  );
+  assert.ok(flow);
+  assert.equal(flow.fixtureReadiness.status, "not-needed");
+  assert.deepEqual(flow.setupHints.map((hint) => hint.kind), []);
+  assert.ok(plan.flows.every((flow) => flow.languageBrief.actor === "Maintainer or release operator"));
+  assert.equal(
+    plan.bootstrap.steps.some((step) => step.title === "Add deterministic fixture or mock responses"),
+    false,
+  );
+});
+
 test("generateE2ePlan detects Nuxt and Vue projects as web before API service dependencies", async () => {
   const root = await makeTempRepo();
   await initGitRepo(root);


### PR DESCRIPTION
## Summary

- Add `coverage` and `release:check` scripts so the 0.1.0 local release gate is one reproducible command.
- Clarify the 0.1.0 positioning around repo-local verification bases, shared domain/flow manifests, and ignored generated run history.
- Tighten E2E planning heuristics so generic package schemas and release/docs changes do not get misclassified as data-catalog work or API fixture blockers.
- Add a regression fixture that proves generic schema plus release-doc changes stay as maintainer/release verification work.

## Validation

- `pnpm run release:check`
  - `pnpm test`: 70 tests passed
  - `pnpm scan`: 0 findings
  - `git diff --check`: passed
  - coverage gate: passed 80% line/branch/function thresholds
  - `pnpm pack --dry-run`: passed and includes runtime, docs, schema, README, changelog, license, package metadata
- `node dist/cli.js e2e plan . --base origin/main --head HEAD --format markdown`
  - Project stays `Unknown` with manual runner for this release/docs branch
  - Output keeps the flow as `Maintainer or release operator`
  - No data-catalog project classification
  - No API fixture blocker for release/docs text

## Release Note

This does not publish 0.1.0. It prepares the local release gate and improves first-run output quality before npm credentials are used.
