### PR TITLE
Fix catalog draft preview noise

### DIFF
--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -3658,6 +3658,10 @@ async function inferFlowEntrypoints(root: string, files: string[], runner: E2eRu
 }
 
 async function inferFlowSetupHints(root: string, files: string[], kind: E2eFlowKind): Promise<E2eSetupHint[]> {
+  if (kind === "artifact" || kind === "catalog") {
+    return [];
+  }
+
   const hints: E2eSetupHint[] = [];
   const fileTexts: Array<{ file: string; text: string }> = [];
   for (const file of files.slice(0, 12)) {
@@ -4847,11 +4851,60 @@ async function buildDraftFlows(plan: E2ePlanResult): Promise<DraftE2eFlow[]> {
     }));
   }
 
-  const combined = dedupeFlows([...scenarioFlows, ...baseFlows]).slice(0, 4);
+  const combined = dedupeDraftFlowsByOutputPath(
+    dedupeFlows([...scenarioFlows, ...baseFlows]),
+    plan.recommendedRunner.name,
+  ).slice(0, 4);
   return combined.map((flow) => ({
     ...flow,
     draftSource: draftFlowSource(flow),
   }));
+}
+
+function dedupeDraftFlowsByOutputPath(flows: DraftE2eFlow[], runner: E2eRunnerName): DraftE2eFlow[] {
+  const flowsByOutput = new Map<string, DraftE2eFlow>();
+  for (const flow of flows) {
+    const outputKey = `${slugify(flow.title)}${draftExtension(runner)}`;
+    const existing = flowsByOutput.get(outputKey);
+    flowsByOutput.set(outputKey, existing ? mergeDraftFlows(existing, flow) : flow);
+  }
+  return [...flowsByOutput.values()];
+}
+
+function mergeDraftFlows(left: DraftE2eFlow, right: DraftE2eFlow): DraftE2eFlow {
+  const mergedFlow: Omit<DraftE2eFlow, "languageBrief"> = {
+    ...left,
+    files: uniqueStrings([...left.files, ...right.files]).slice(0, 20),
+    steps: uniqueStrings([...left.steps, ...right.steps]).slice(0, 8),
+    coverage: uniqueCoverageTargets([...left.coverage, ...right.coverage]).slice(0, 7),
+    coverageEvidence: left.coverageEvidence.length > 0 ? left.coverageEvidence : right.coverageEvidence,
+    entrypoints: uniqueEntrypoints([...left.entrypoints, ...right.entrypoints]).slice(0, 6),
+    setupHints: uniqueSetupHints([...left.setupHints, ...right.setupHints]).slice(0, 6),
+    selectors: uniqueSelectors([...left.selectors, ...right.selectors]).slice(0, 12),
+    missingTestability: uniqueStrings([...left.missingTestability, ...right.missingTestability]),
+    draftSource: preferredDraftSource(left.draftSource, right.draftSource),
+    domainScenario: left.domainScenario ?? right.domainScenario,
+    coreFlow: left.coreFlow ?? right.coreFlow,
+  };
+  return {
+    ...mergedFlow,
+    languageBrief: buildFlowLanguageBrief(mergedFlow),
+  };
+}
+
+function preferredDraftSource(left: DraftFlowSource | undefined, right: DraftFlowSource | undefined): DraftFlowSource | undefined {
+  const ranks: Record<DraftFlowSource, number> = {
+    "core-flow": 0,
+    "domain-language": 1,
+    heuristic: 2,
+  };
+  if (!left) {
+    return right;
+  }
+  if (!right) {
+    return left;
+  }
+  return ranks[right] < ranks[left] ? right : left;
 }
 
 async function buildDomainScenarioDraftFlow(
@@ -4889,7 +4942,7 @@ async function buildDomainScenarioDraftFlow(
   ]);
   const setupHints = uniqueSetupHints([
     ...filterSetupHintsForFiles(baseFlows.flatMap((flow) => flow.setupHints), files),
-    ...(await inferFlowSetupHints(plan.root, files, "domain")),
+    ...(shouldInferDomainScenarioSetupHints(baseFlow) ? await inferFlowSetupHints(plan.root, files, "domain") : []),
   ]);
   const flow: Omit<DraftE2eFlow, "languageBrief"> = {
     title,
@@ -4911,6 +4964,10 @@ async function buildDomainScenarioDraftFlow(
     ...flow,
     languageBrief: buildFlowLanguageBrief(flow),
   };
+}
+
+function shouldInferDomainScenarioSetupHints(baseFlow: E2eFlow | undefined): boolean {
+  return !baseFlow || (!isDesignTokenFocusedFlow(baseFlow) && !isCatalogFocusedFlow(baseFlow));
 }
 
 interface SpecializedDomainScenarioDraft {

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -833,8 +833,10 @@ test("generateE2ePlan detects design token packages and suggests artifact valida
   assert.equal(flow.fixtureReadiness.status, "not-needed");
   assert.equal(flow.languageBrief.actor, "Design system consumer or maintainer");
   assert.match(flow.languageBrief.successSignal, /token schema, generated artifacts, semantic aliases/);
+  assert.deepEqual(flow.setupHints.map((hint) => hint.kind), []);
   assert.ok(flow.coverage.some((target) => target.title === "Token schema and generated artifact compatibility"));
   assert.ok(flow.coverage.some((target) => target.title === "Downstream consumer visual fixture"));
+  assert.equal(draftFile.setupHintCount, 0);
   assert.equal(testabilityRow.status, "ready");
   assert.doesNotMatch(testabilityRow.requiredEvidence, /selector|entrypoint/i);
   assert.match(testabilityRow.currentEvidence, /token validation commands/);
@@ -861,6 +863,15 @@ test("generateE2ePlan detects data catalog repositories and suggests catalog ver
       "    description: Tracks creator registration completion.",
     ].join("\n"),
   );
+  await writeFile(
+    path.join(root, "catalog/user_properties.yaml"),
+    [
+      "properties:",
+      "  - name: creator_id",
+      "    owner: growth",
+      "    description: Identifies the creator for analytics consumers.",
+    ].join("\n"),
+  );
   await writeFile(path.join(root, "tools/build_catalog.py"), "print('build catalog')\n");
   await writeFile(path.join(root, "site/index.html"), "<main>Catalog</main>\n");
   await git(root, ["add", "."]);
@@ -878,6 +889,16 @@ test("generateE2ePlan detects data catalog repositories and suggests catalog ver
       "    properties:",
       "      - name: source",
       "        type: string",
+    ].join("\n"),
+  );
+  await writeFile(
+    path.join(root, "catalog/user_properties.yaml"),
+    [
+      "properties:",
+      "  - name: creator_id",
+      "    owner: growth",
+      "    description: Identifies the creator for analytics consumers.",
+      "    type: string",
     ].join("\n"),
   );
   await git(root, ["add", "."]);
@@ -907,8 +928,15 @@ test("generateE2ePlan detects data catalog repositories and suggests catalog ver
   assert.equal(flow.fixtureReadiness.status, "not-needed");
   assert.equal(flow.languageBrief.actor, "Data catalog consumer or maintainer");
   assert.match(flow.languageBrief.successSignal, /catalog schema, generated output/);
+  assert.deepEqual(flow.setupHints.map((hint) => hint.kind), []);
   assert.ok(flow.coverage.some((target) => target.title === "Catalog schema and generated output compatibility"));
   assert.ok(flow.coverage.some((target) => target.title === "Consumer fixture and migration coverage"));
+  assert.equal(draftFile.setupHintCount, 0);
+  assert.equal(new Set(draft.files.map((item) => item.path)).size, draft.files.length);
+  assert.equal(
+    draft.files.filter((item) => /taxonomy catalog verification checklist/.test(item.flowTitle)).length,
+    1,
+  );
   assert.equal(testabilityRow.status, "ready");
   assert.doesNotMatch(testabilityRow.requiredEvidence, /selector|entrypoint/i);
   assert.match(testabilityRow.currentEvidence, /catalog validation commands/);
@@ -918,6 +946,7 @@ test("generateE2ePlan detects data catalog repositories and suggests catalog ver
   assert.match(draftMarkdown, /catalog validation command, generation command/);
   assert.match(draftText, /catalog validation command and the generation command/);
   assert.match(draftText, /analytics, documentation, ingestion, or migration fixture/);
+  assert.doesNotMatch(draftText, /Payment sandbox|Network response|Fixture data|State reset/);
 });
 
 test("generateE2ePlan does not classify generic package schemas as data catalogs", async () => {


### PR DESCRIPTION
## Summary
- avoid API/payment setup hints for catalog and design-token artifact draft flows
- merge duplicate draft flows that would write to the same output path
- add regression coverage for catalog draft uniqueness and artifact setup hint noise

## Validation
- pnpm test
- pnpm run release:check
- local preview across Desktop repositories with status unchanged