### PR TITLE
Add opt-in E2E runner setup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ On a changed branch, CodeWard tries to produce reviewable verification artifacts
 
 - a branch-aware verification plan that names the changed domain, actor, trigger, goal, success signal, and edge cases
 - draft Playwright, Maestro, or manual checklist files when the repository shape supports them
+- a runner setup proposal that explains why Playwright or Maestro fits the changed surface and which files/commands would be created if the team accepts it
 - readiness evidence that explains missing runner config, selectors, fixture data, assertions, validation commands, or flow manifests
 - repo-local suggestions for `.codeward/domains.yml`, `.codeward/flows.yml`, and ignored `.codeward/runs/` history so teams can improve the next run without spending LLM tokens
 
@@ -151,6 +152,7 @@ That means CodeWard is most valuable when it becomes the team's verification bas
 | `codeward test-plan . --base origin/main --head HEAD --include-working-tree` | Suggest domain test scenarios for changed files. |
 | `codeward e2e plan . --base origin/main --head HEAD` | Suggest E2E runner, bootstrap steps, user flows, coverage targets, existing test evidence, and missing testability hooks for changed files. |
 | `codeward e2e plan . --base origin/main --head HEAD --record-history` | Save a compact local run snapshot under `.codeward/runs/` while keeping JSON/Markdown output usable. |
+| `codeward e2e setup . --runner playwright` | Explicitly apply the accepted runner setup by creating minimal config/script files for generated E2E drafts. |
 | `codeward e2e draft . --base origin/main --head HEAD` | Generate Maestro or Playwright E2E drafts with flow language, readiness summaries, and action items. |
 | `codeward flows init .` | Create a starter `.codeward/flows.yml` for team-approved core flow definitions. |
 | `codeward flows suggest . --base origin/main --head HEAD` | Generate suggested `.codeward/flows.yml` entries with commit-readiness guidance from changed files and E2E plan context. |
@@ -172,6 +174,10 @@ For monorepos, pass `--workspace-root` when scanning a package. Package-local ch
 `codeward e2e plan` turns changed file paths into a first-pass E2E testing plan. It detects whether a project looks like Expo/React Native, web, or an API/service repo, recommends a runner such as Maestro or Playwright, starts backend services with an API contract checklist, suggests bootstrap steps for repos with little or no test history, suggests domain language for the changed behavior, suggests candidate user flows, adds coverage targets, compares those targets with existing test-suite evidence when tests are present, flags API-dependent flows that need mock or fixture responses, and points out missing stable selectors such as `testID` or `data-testid` before anyone starts writing tests from a blank file.
 
 The plan also includes an execution profile: detected start command, test command, Playwright `baseURL`, mobile app id, runner config files, env fixture files, confidence, and blockers. This keeps generated E2E drafts honest about whether they are runnable candidates or still review-only scaffolds.
+
+When a repository does not already have the selected E2E runner, the plan includes a runner setup proposal instead of silently changing the project. The proposal explains why the runner fits the changed surface, which package command installs the library, which config/script files would be created, and the explicit acceptance command such as `codeward e2e setup . --runner playwright`.
+
+`codeward e2e setup` is the opt-in apply step. For Playwright it can create `playwright.config.ts`, `tests/e2e/`, and a `test:e2e` script. For Maestro it can create `.maestro/`, `.maestro/README.md`, and a `test:e2e` script. It does not run package installation automatically; it prints the install command so teams can keep dependency policy under review.
 
 When run at a monorepo root, the E2E plan also reports changed app/package targets. This helps a maintainer move from a broad workspace diff to scoped commands such as `codeward e2e plan services/offer --workspace-root . --base origin/main --head HEAD`, where package-specific runner detection and flow naming are usually sharper.
 

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -58,6 +58,7 @@ The E2E plan should show:
 
 - runner recommendation with clear evidence
 - execution profile with start command, test command, base URL or app id when discoverable, confidence, and blockers
+- runner setup proposal with install commands, explicit `codeward e2e setup` acceptance command, files to create/update, and next commands when the repo lacks an E2E runner
 - bootstrap steps when the project lacks E2E setup
 - domain language and candidate user scenarios
 - matched `.codeward/domains.yml` or `.codeward/flows.yml` entries when present
@@ -81,13 +82,13 @@ The matrix below is public, fixture-backed evidence from the repository test sui
 
 | Target | Fixture-backed coverage | Expected output |
 | --- | --- | --- |
-| Web app with Playwright routes | `generateE2ePlan matches committed core flow definitions`; `generateE2eDraft uses web selectors in Playwright specs`; `generateE2ePlan captures Playwright execution profile and self-check blockers`; `generateE2ePlan infers Playwright base URLs from dev scripts`; `generateE2eDraft supports Next app router route groups and concrete route hints`; `generateE2ePlan reads React Router object route paths`; `generateE2eDraft fills dynamic route params from concrete route hints`; `generateE2eDraft emits runnable Playwright role and input actions` | `Web` project profile, `playwright` runner, core-flow names such as `Checkout purchase`, route-aware Playwright drafts, stable selector hints, execution profile, dev-script base URL hints, Next App Router route groups, React Router object paths, dynamic route params, draft self-check status, action items, and validation gaps. |
+| Web app with Playwright routes | `generateE2ePlan matches committed core flow definitions`; `generateE2eDraft uses web selectors in Playwright specs`; `generateE2ePlan captures Playwright execution profile and self-check blockers`; `generateE2ePlan infers Playwright base URLs from dev scripts`; `generateE2eDraft supports Next app router route groups and concrete route hints`; `generateE2ePlan reads React Router object route paths`; `generateE2eDraft fills dynamic route params from concrete route hints`; `generateE2eDraft emits runnable Playwright role and input actions` | `Web` project profile, `playwright` runner, core-flow names such as `Checkout purchase`, route-aware Playwright drafts, stable selector hints, execution profile, dev-script base URL hints, opt-in Playwright setup proposal, Next App Router route groups, React Router object paths, dynamic route params, draft self-check status, action items, and validation gaps. |
 | Expo / React Native mobile app | `generateE2ePlan recommends mobile flows for Expo changes`; `generateE2ePlan detects Maestro app ids from app config files`; `generateE2eDraft scopes entrypoint hints to each domain scenario` | `Expo / React Native` project profile, `maestro` runner, app id and launch command hints from `app.json` or `app.config.*`, Maestro YAML drafts, `testID`/`accessibilityLabel` selector hints, and mobile setup actions. |
 | API or backend service | `generateE2ePlan detects API service projects and suggests contract checklists`; `generateE2ePlan detects Django service apps from a workspace root`; `generateE2ePlan names versioned API service paths with domain language`; `generateE2ePlan uses matched core flow names for API service contracts` | `API / service` project profile, manual contract checklist, Django/FastAPI-style service signals when present, domain-aware titles such as `Offer API contract`, API consumer actor, endpoint/handler/service-path trigger, service start/test command hints, and contract failure coverage. |
 | Design tokens and data catalogs | `generateE2ePlan detects design token packages and suggests artifact validation`; `generateE2ePlan detects data catalog repositories and suggests catalog verification` | `Design tokens` and `Data catalog` project profiles, manual artifact/catalog checklist, token or catalog actor language, schema/generated output/consumer fixture coverage, fixture readiness marked not needed for API mocks, and validation matrix rows that do not require browser/device selectors. |
 | Monorepo root and package targeting | `generateE2ePlan surfaces package-scoped targets for monorepo root changes`; `generateE2ePlan matches workspace core flows for package scans`; `generateTestPlan scopes monorepo changes to the requested package` | Root plans list changed app/package targets with package names, project type, runner, and scoped commands; package scans keep package-local changed files, workspace-level `.codeward/flows.yml` matches, package-local generated drafts, and no leaked workspace path prefixes in package drafts. |
 | Release and package metadata | `generateE2ePlan avoids turning release metadata into domain journeys`; `generateE2ePlan keeps package release metadata out of product workflows`; `generateE2ePlan treats agent and repo metadata as configuration, not product journeys` | Changelog, changeset, release manifest, package version, and repo metadata changes produce maintainer/release-operator configuration verification flows instead of product journeys or user-facing E2E drafts. |
-| Test-light project | `generateE2ePlan builds a bootstrap plan for projects without tests`; `generateE2eDraft creates a fallback smoke draft without changed files` | Required bootstrap steps for runner setup, first draft generation, fixture/mock data, testability, and validation evidence before generated drafts are treated as regression coverage. |
+| Test-light project | `generateE2ePlan builds a bootstrap plan for projects without tests`; `generateE2eDraft creates a fallback smoke draft without changed files` | Required bootstrap steps for runner setup, opt-in `codeward e2e setup`, first draft generation, fixture/mock data, testability, and validation evidence before generated drafts are treated as regression coverage. |
 | API-dependent UI flow | `generateE2ePlan flags missing mock fixtures for API-dependent UI flows` | Playwright-compatible UI flow plus fixture/mock readiness actions, inferred endpoint hints, and route-fulfillment scaffold slots for success, empty, unauthorized, timeout, and server-error responses. |
 | Existing test evidence | `generateE2ePlan evaluates existing test suite coverage evidence`; `generateE2ePlan keeps generic test filenames from overmatching unrelated services` | Coverage evidence rows that distinguish covered, partial, and missing targets without matching unrelated generic test filenames. |
 
@@ -95,7 +96,7 @@ See [E2E output examples](e2e-output-examples.md) for the kind of plan and draft
 
 ## Latest Main Validation Snapshot
 
-Last verified on 2026-07-01 after adding the single local release gate, verification-base positioning, and non-app false-positive guards:
+Last verified on 2026-07-01 after adding the single local release gate, verification-base positioning, non-app false-positive guards, and opt-in E2E runner setup proposals:
 
 | Check | Result |
 | --- | --- |
@@ -103,7 +104,7 @@ Last verified on 2026-07-01 after adding the single local release gate, verifica
 | `pnpm scan` | 0 findings. |
 | `git diff --check` | Passed. |
 | `pnpm pack --dry-run` | Passed; tarball includes `dist`, `docs`, `schema`, `README.md`, `CHANGELOG.md`, `LICENSE`, and `package.json`. |
-| Coverage threshold | Passed the 80% line, branch, and function gates; latest runs report about 84.8% lines, 82.2% branches, and 93.31% functions. |
+| Coverage threshold | Passed the 80% line, branch, and function gates; latest runs report about 84.05% lines, 81.96% branches, and 92.90% functions. |
 | `pnpm run release:check` | Passed as the single local release gate for future candidates. |
 
 ## Real Repository Smoke Snapshot

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,14 @@ import { loadConfig, writeDefaultConfig } from "./config.js";
 import { generateAgentContext } from "./context.js";
 import { defaultDomainManifestPath, writeDefaultDomainManifest } from "./domains.js";
 import { buildDoctorResult, formatDoctorReport, formatMarkdownDoctorReport } from "./doctor.js";
-import { formatMarkdownE2eDraft, formatMarkdownE2ePlan, generateE2eDraft, generateE2ePlan } from "./e2e.js";
+import {
+  formatMarkdownE2eDraft,
+  formatMarkdownE2ePlan,
+  formatMarkdownE2eSetup,
+  generateE2eDraft,
+  generateE2ePlan,
+  setupE2eRunner,
+} from "./e2e.js";
 import { evaluateChangeReadiness, formatEvalReport, formatMarkdownEvalReport } from "./eval.js";
 import { defaultFlowManifestPath, writeDefaultCoreFlowManifest } from "./flows.js";
 import { runGitHubAction } from "./github.js";
@@ -198,7 +205,7 @@ async function main(argv: string[]): Promise<number> {
       printE2eHelp();
       return 0;
     }
-    if (subcommand !== "plan" && subcommand !== "draft") {
+    if (subcommand !== "plan" && subcommand !== "draft" && subcommand !== "setup") {
       throw new Error(`Unknown e2e subcommand: ${subcommand}`);
     }
     const options = parseOptions(subcommandRest);
@@ -217,6 +224,15 @@ async function main(argv: string[]): Promise<number> {
         result.localHistory = await recordE2ePlanHistory(options.workspaceRoot ?? options.path, result);
       }
       const output = formatE2ePlanOutput(result, options.format ?? (options.json ? "json" : "markdown"));
+      await printOrWrite(output, options.output);
+      return 0;
+    }
+    if (subcommand === "setup") {
+      const result = await setupE2eRunner(options.path, {
+        ...e2eOptions,
+        force: options.force,
+      });
+      const output = formatE2eSetupOutput(result, options.format ?? (options.json ? "json" : "markdown"));
       await printOrWrite(output, options.output);
       return 0;
     }
@@ -664,6 +680,16 @@ function formatE2eDraftOutput(result: Awaited<ReturnType<typeof generateE2eDraft
   return formatMarkdownE2eDraft(result);
 }
 
+function formatE2eSetupOutput(result: Awaited<ReturnType<typeof setupE2eRunner>>, format: OutputFormat): string {
+  if (format === "json") {
+    return `${JSON.stringify(result, null, 2)}\n`;
+  }
+  if (format !== "markdown" && format !== "text") {
+    throw new Error(`E2E setup supports text, json, or markdown output, not ${format}`);
+  }
+  return formatMarkdownE2eSetup(result);
+}
+
 function manifestSuggestionFormat(format: OutputFormat, command: "domains" | "flows"): "text" | "json" | "markdown" {
   if (format === "sarif") {
     throw new Error(`${command} suggest supports text, json, or markdown output, not sarif`);
@@ -746,6 +772,7 @@ Usage:
   codeward github-action [path] [--mode auto|scan|review] [--base <ref>] [--head <ref>] [--fail-on <severity>]
   codeward test-plan [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--format <format>] [--output <file>]
   codeward e2e plan [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--record-history] [--format <format>]
+  codeward e2e setup [path] [--workspace-root <path>] [--runner maestro|playwright] [--force]
   codeward e2e draft [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--runner maestro|playwright|manual] [--output <dir>] [--force]
   codeward flows init [path] [--write <file>] [--force]
   codeward flows suggest [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--format <format>] [--output <file>] [--write <file>] [--force]
@@ -775,6 +802,7 @@ Examples:
   codeward test-plan . --base origin/main --head HEAD
   codeward e2e plan . --base origin/main --head HEAD
   codeward e2e plan . --base origin/main --head HEAD --record-history
+  codeward e2e setup . --runner playwright
   codeward e2e draft . --base origin/main --head HEAD
   codeward flows init .
   codeward flows suggest . --base origin/main --head HEAD
@@ -794,11 +822,14 @@ E2E planning for AI-assisted changes.
 
 Usage:
   codeward e2e plan [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--record-history] [--format <format>] [--output <file>]
+  codeward e2e setup [path] [--workspace-root <path>] [--runner maestro|playwright] [--force] [--format <format>] [--output <file>]
   codeward e2e draft [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--runner maestro|playwright|manual] [--output <dir>] [--force]
 
 Examples:
   codeward e2e plan . --base origin/main --head HEAD
   codeward e2e plan . --base origin/main --head HEAD --record-history
+  codeward e2e setup . --runner playwright
+  codeward e2e setup apps/mobile --workspace-root . --runner maestro
   codeward e2e draft . --base origin/main --head HEAD
   codeward e2e plan apps/mobile --workspace-root . --include-working-tree
 `);

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -216,6 +216,7 @@ export interface E2ePlanResult {
   project: E2eProjectProfile;
   recommendedRunner: E2eRunnerRecommendation;
   executionProfile: E2eExecutionProfile;
+  runnerSetup: E2eRunnerSetupProposal;
   testSuite: TestSuiteSummary;
   coreFlowManifestPath?: string;
   coreFlows: MatchedCoreFlow[];
@@ -231,6 +232,21 @@ export interface E2ePlanResult {
   bootstrap: E2eBootstrapPlan;
   missingTestability: string[];
   setupNotes: string[];
+}
+
+export type E2eRunnerSetupStatus = "ready" | "proposed" | "not-applicable";
+
+export interface E2eRunnerSetupProposal {
+  runner: E2eRunnerName;
+  status: E2eRunnerSetupStatus;
+  title: string;
+  reason: string;
+  setupCommand?: string;
+  installCommands: string[];
+  filesToCreate: string[];
+  filesToUpdate: string[];
+  nextCommands: string[];
+  notes: string[];
 }
 
 export interface E2eDraftFile {
@@ -339,6 +355,25 @@ export interface E2eDraftResult {
   nextSteps: string[];
 }
 
+export interface E2eSetupOptions extends E2ePlanOptions {
+  force?: boolean;
+}
+
+export interface E2eSetupResult {
+  tool: {
+    name: string;
+    version: string;
+  };
+  root: string;
+  runner: E2eRunnerName;
+  proposal: E2eRunnerSetupProposal;
+  createdFiles: string[];
+  updatedFiles: string[];
+  skippedFiles: string[];
+  installCommands: string[];
+  nextCommands: string[];
+}
+
 interface PackageJson {
   name?: string;
   packageManager?: string;
@@ -394,12 +429,22 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
   ]);
   const validationMatrix = buildE2eValidationMatrix(flows, coreFlows);
   const setupNotes = await buildSetupNotes(root, recommendedRunner.name, project);
+  const runnerSetup = await buildRunnerSetupProposal(
+    root,
+    testPlan.workspaceRoot,
+    project,
+    recommendedRunner.name,
+    executionProfile,
+    testPlan.base,
+    testPlan.head,
+  );
   const bootstrap = buildE2eBootstrapPlan({
     base: testPlan.base,
     head: testPlan.head,
     projectType: project.type,
     recommendedRunner,
     executionProfile,
+    runnerSetup,
     testSuite,
     coreFlowManifestPath: coreFlowManifest.path,
     domainManifestPath: domainManifest.path,
@@ -427,6 +472,7 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
     project,
     recommendedRunner,
     executionProfile,
+    runnerSetup,
     testSuite,
     coreFlowManifestPath: coreFlowManifest.path,
     coreFlows,
@@ -853,6 +899,7 @@ interface E2eBootstrapPlanInput {
   projectType: E2eProjectType;
   recommendedRunner: E2eRunnerRecommendation;
   executionProfile: E2eExecutionProfile;
+  runnerSetup: E2eRunnerSetupProposal;
   testSuite: TestSuiteSummary;
   coreFlowManifestPath?: string;
   domainManifestPath?: string;
@@ -905,6 +952,11 @@ function buildE2eBootstrapPlan(input: E2eBootstrapPlanInput): E2eBootstrapPlan {
       ),
     );
   } else if (runnerGap) {
+    const setupCommands = uniqueStrings([
+      ...input.runnerSetup.installCommands,
+      ...(input.runnerSetup.setupCommand ? [input.runnerSetup.setupCommand] : []),
+      ...input.runnerSetup.nextCommands,
+    ]);
     steps.push(
       bootstrapStep(
         "runner",
@@ -912,9 +964,9 @@ function buildE2eBootstrapPlan(input: E2eBootstrapPlanInput): E2eBootstrapPlan {
         `Configure ${formatRunnerName(input.recommendedRunner.name)} before making drafts required`,
         runnerGap,
         input.recommendedRunner.name === "playwright"
-          ? playwrightConfigGuidance(input.executionProfile)
-          : "Add a .maestro directory or documented Maestro setup, app id, and simulator launch command.",
-        input.recommendedRunner.name === "playwright" ? playwrightSetupCommands(input.executionProfile) : [],
+          ? `${playwrightConfigGuidance(input.executionProfile)} Review the setup proposal, then run \`${input.runnerSetup.setupCommand ?? "codeward e2e setup . --runner playwright"}\` if the team accepts Playwright for this repo.`
+          : `Review the setup proposal, then run \`${input.runnerSetup.setupCommand ?? "codeward e2e setup . --runner maestro"}\` if the team accepts Maestro for this repo.`,
+        setupCommands,
         [],
       ),
     );
@@ -1542,11 +1594,16 @@ function buildDraftActionItems(
   const items: E2eDraftActionItem[] = [];
   const runnerGap = runnerSetupGap(plan, runner);
   if (runnerGap) {
+    const setupCommand = plan.runnerSetup.setupCommand ? ` Run \`${plan.runnerSetup.setupCommand}\` after accepting this runner setup.` : "";
+    const setupDetail =
+      runner === "playwright"
+        ? `${playwrightConfigGuidance(plan.executionProfile)}${setupCommand}`
+        : `${runnerGap}${setupCommand}`;
     items.push(draftActionItem(
       "runner",
       "required",
       `Configure ${formatRunnerName(runner)} execution`,
-      runner === "playwright" ? playwrightConfigGuidance(plan.executionProfile) : runnerGap,
+      setupDetail,
     ));
   }
   const executionBlockers = remainingExecutionProfileBlockers(plan.executionProfile.blockers, runnerGap);
@@ -2127,6 +2184,7 @@ export function formatMarkdownE2ePlan(result: E2ePlanResult): string {
   lines.push("");
 
   appendExecutionProfileMarkdown(lines, result.executionProfile);
+  appendRunnerSetupProposalMarkdown(lines, result.runnerSetup);
 
   if (result.workspaceTargets.length > 0) {
     lines.push("## Changed App/Package Targets");
@@ -2503,6 +2561,48 @@ export function formatMarkdownE2eDraft(result: E2eDraftResult): string {
   return lines.join("\n");
 }
 
+export function formatMarkdownE2eSetup(result: E2eSetupResult): string {
+  const lines: string[] = [];
+  lines.push("# CodeWard E2E Setup");
+  lines.push("");
+  lines.push(`- Root: \`${escapeMarkdownInline(result.root)}\``);
+  lines.push(`- Runner: ${formatRunnerName(result.runner)}`);
+  lines.push(`- Proposal: ${escapeMarkdownInline(result.proposal.title)}`);
+  lines.push(`- Status: ${result.proposal.status}`);
+  lines.push("");
+  lines.push("## Applied Files");
+  lines.push("");
+  lines.push(`- Created: ${result.createdFiles.length > 0 ? result.createdFiles.map((file) => `\`${escapeMarkdownInline(file)}\``).join(", ") : "none"}`);
+  lines.push(`- Updated: ${result.updatedFiles.length > 0 ? result.updatedFiles.map((file) => `\`${escapeMarkdownInline(file)}\``).join(", ") : "none"}`);
+  lines.push(`- Skipped: ${result.skippedFiles.length > 0 ? result.skippedFiles.map((file) => `\`${escapeMarkdownInline(file)}\``).join(", ") : "none"}`);
+  lines.push("");
+  if (result.installCommands.length > 0) {
+    lines.push("## Install Commands");
+    lines.push("");
+    for (const command of result.installCommands) {
+      lines.push(`- \`${escapeMarkdownInline(command)}\``);
+    }
+    lines.push("");
+  }
+  if (result.nextCommands.length > 0) {
+    lines.push("## Next Commands");
+    lines.push("");
+    for (const command of result.nextCommands) {
+      lines.push(`- \`${escapeMarkdownInline(command)}\``);
+    }
+    lines.push("");
+  }
+  if (result.proposal.notes.length > 0) {
+    lines.push("## Notes");
+    lines.push("");
+    for (const note of result.proposal.notes) {
+      lines.push(`- ${escapeMarkdownInline(note)}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
 async function detectProjectProfile(root: string, workspaceRoot?: string): Promise<E2eProjectProfile> {
   const profileRoots = profileSearchRoots(root, workspaceRoot);
   const packageJson = await readPackageJson(root);
@@ -2828,6 +2928,300 @@ async function buildExecutionProfile(
     evidence,
     blockers,
   };
+}
+
+async function buildRunnerSetupProposal(
+  root: string,
+  workspaceRoot: string | undefined,
+  project: E2eProjectProfile,
+  runner: E2eRunnerName,
+  profile: E2eExecutionProfile,
+  base: string,
+  head: string,
+): Promise<E2eRunnerSetupProposal> {
+  const packageJson = await readPackageJson(root);
+  const packageManager = await detectPackageManager(root, packageJson?.packageManager, workspaceRoot);
+  const setupCommand = `codeward e2e setup . --runner ${runner}`;
+  const draftCommand = `codeward e2e draft . --base ${base} --head ${head}`;
+
+  if (runner === "manual") {
+    return {
+      runner,
+      status: "not-applicable",
+      title: manualBootstrapTitle(project.type),
+      reason: manualBootstrapReason(project.type),
+      installCommands: [],
+      filesToCreate: [],
+      filesToUpdate: [],
+      nextCommands: [draftCommand],
+      notes: [manualBootstrapAction(project.type)],
+    };
+  }
+
+  if (runner === "playwright") {
+    const hasConfig = profile.configFiles.some((file) => /playwright\.config\.[cm]?[jt]s$/i.test(file));
+    const hasDependency = packageHasDependency(packageJson, "@playwright/test");
+    const hasScript = Boolean(packageJson?.scripts && chooseScript(packageJson.scripts, testScriptCandidates("playwright")));
+    const status: E2eRunnerSetupStatus = hasConfig && hasDependency && hasScript ? "ready" : "proposed";
+    const filesToCreate = hasConfig ? [] : ["playwright.config.ts", "tests/e2e/"];
+    const filesToUpdate = packageJson && (!hasScript || !hasDependency) ? ["package.json"] : [];
+    return {
+      runner,
+      status,
+      title: status === "ready" ? "Playwright setup is ready for generated specs" : "Propose Playwright setup for generated browser specs",
+      reason:
+        status === "ready"
+          ? "The repository already has Playwright dependency, script, and config evidence, so generated specs can target the existing E2E surface."
+          : "This change targets a web surface, so Playwright is the best default for turning the generated scenario into browser E2E code without introducing a mobile or service runner.",
+      setupCommand: status === "ready" ? undefined : setupCommand,
+      installCommands: hasDependency ? [] : [packageInstallCommand(packageManager, "@playwright/test")],
+      filesToCreate,
+      filesToUpdate,
+      nextCommands: uniqueStrings([
+        profile.startCommand,
+        profile.testCommand ?? "npx playwright test",
+        draftCommand,
+      ].filter(Boolean) as string[]),
+      notes: [
+        playwrightConfigGuidance(profile),
+        "Run the setup command only after reviewing the generated scenario and confirming Playwright fits this repository's QA strategy.",
+      ],
+    };
+  }
+
+  const hasMaestroDirectory = profile.configFiles.some((file) => file === ".maestro" || /maestro\.ya?ml$/i.test(file));
+  const hasScript = Boolean(packageJson?.scripts && chooseScript(packageJson.scripts, testScriptCandidates("maestro")));
+  const status: E2eRunnerSetupStatus = hasMaestroDirectory && hasScript ? "ready" : "proposed";
+  return {
+    runner,
+    status,
+    title: status === "ready" ? "Maestro setup is ready for generated mobile flows" : "Propose Maestro setup for generated mobile flows",
+    reason:
+      status === "ready"
+        ? "The repository already has Maestro flow directory/config and a runnable script signal."
+        : "This change targets a React Native or Expo app surface, so Maestro is the best default for turning the generated scenario into device-level E2E code without assuming a browser runner.",
+    setupCommand: status === "ready" ? undefined : setupCommand,
+    installCommands: [],
+    filesToCreate: hasMaestroDirectory ? [] : [".maestro/", ".maestro/README.md"],
+    filesToUpdate: packageJson && !hasScript ? ["package.json"] : [],
+    nextCommands: uniqueStrings([
+      profile.startCommand,
+      profile.testCommand ?? "maestro test .maestro",
+      draftCommand,
+    ].filter(Boolean) as string[]),
+    notes: [
+      profile.appId
+        ? `Generated flows can use app id ${profile.appId}; keep APP_ID overrideable for local devices.`
+        : "Confirm the app id from app.json or app.config before making generated Maestro flows required.",
+      "Install Maestro with the team's preferred local or CI setup before running generated flows.",
+    ],
+  };
+}
+
+export async function setupE2eRunner(rootInput: string, options: E2eSetupOptions = {}): Promise<E2eSetupResult> {
+  const root = path.resolve(rootInput);
+  const plan = await generateE2ePlan(root, options);
+  const runner = options.runner ?? plan.recommendedRunner.name;
+  const proposal = await buildRunnerSetupProposal(
+    root,
+    plan.workspaceRoot,
+    plan.project,
+    runner,
+    plan.executionProfile,
+    plan.base,
+    plan.head,
+  );
+  const createdFiles: string[] = [];
+  const updatedFiles: string[] = [];
+  const skippedFiles: string[] = [];
+
+  if (runner === "playwright") {
+    await applyPlaywrightSetup(root, plan.executionProfile, options.force ?? false, createdFiles, updatedFiles, skippedFiles);
+  } else if (runner === "maestro") {
+    await applyMaestroSetup(root, plan.executionProfile, options.force ?? false, createdFiles, updatedFiles, skippedFiles);
+  } else {
+    skippedFiles.push("manual runner setup");
+  }
+
+  return {
+    tool: {
+      name: TOOL_NAME,
+      version: VERSION,
+    },
+    root,
+    runner,
+    proposal,
+    createdFiles,
+    updatedFiles,
+    skippedFiles,
+    installCommands: proposal.installCommands,
+    nextCommands: proposal.nextCommands,
+  };
+}
+
+async function applyPlaywrightSetup(
+  root: string,
+  profile: E2eExecutionProfile,
+  force: boolean,
+  createdFiles: string[],
+  updatedFiles: string[],
+  skippedFiles: string[],
+): Promise<void> {
+  const packageJson = await readPackageJson(root);
+  if (packageJson) {
+    const didUpdatePackage = await updatePackageJsonScript(root, "test:e2e", "playwright test", force);
+    if (didUpdatePackage) {
+      updatedFiles.push("package.json");
+    } else {
+      skippedFiles.push("package.json");
+    }
+  } else {
+    skippedFiles.push("package.json");
+  }
+
+  if (await exists(path.join(root, "tests/e2e"))) {
+    skippedFiles.push("tests/e2e/");
+  } else {
+    await fs.mkdir(path.join(root, "tests/e2e"), { recursive: true });
+    createdFiles.push("tests/e2e/");
+  }
+
+  const configPath = path.join(root, "playwright.config.ts");
+  if ((await exists(configPath)) && !force) {
+    skippedFiles.push("playwright.config.ts");
+  } else {
+    await fs.writeFile(configPath, playwrightConfigTemplate(profile), "utf8");
+    createdFiles.push("playwright.config.ts");
+  }
+}
+
+function packageHasDependency(packageJson: PackageJson | undefined, dependencyName: string): boolean {
+  return Boolean(packageJson?.dependencies?.[dependencyName] || packageJson?.devDependencies?.[dependencyName]);
+}
+
+function packageInstallCommand(packageManager: string, dependencyName: string): string {
+  if (packageManager === "pnpm") {
+    return `pnpm add -D ${dependencyName}`;
+  }
+  if (packageManager === "yarn") {
+    return `yarn add -D ${dependencyName}`;
+  }
+  if (packageManager === "bun") {
+    return `bun add -d ${dependencyName}`;
+  }
+  return `npm install -D ${dependencyName}`;
+}
+
+async function updatePackageJsonScript(root: string, scriptName: string, scriptValue: string, force: boolean): Promise<boolean> {
+  const packageJsonPath = path.join(root, "package.json");
+  const packageJson = await readPackageJson(root);
+  if (!packageJson) {
+    return false;
+  }
+  packageJson.scripts ??= {};
+  if (packageJson.scripts[scriptName] && packageJson.scripts[scriptName] !== scriptValue && !force) {
+    return false;
+  }
+  if (packageJson.scripts[scriptName] === scriptValue) {
+    return false;
+  }
+  packageJson.scripts[scriptName] = scriptValue;
+  await fs.writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
+  return true;
+}
+
+function playwrightConfigTemplate(profile: E2eExecutionProfile): string {
+  const baseUrl = profile.baseUrl ?? "http://localhost:3000";
+  const lines = [
+    'import { defineConfig, devices } from "@playwright/test";',
+    "",
+    `const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? ${JSON.stringify(baseUrl)};`,
+    "",
+    "export default defineConfig({",
+    '  testDir: "./tests/e2e",',
+    "  retries: process.env.CI ? 1 : 0,",
+    "  use: {",
+    "    baseURL,",
+    '    trace: "on-first-retry",',
+    "  },",
+  ];
+  if (profile.startCommand) {
+    lines.push(
+      "  webServer: process.env.PLAYWRIGHT_SKIP_WEB_SERVER",
+      "    ? undefined",
+      "    : {",
+      `        command: ${JSON.stringify(profile.startCommand)},`,
+      "        url: baseURL,",
+      "        reuseExistingServer: !process.env.CI,",
+      "        timeout: 120_000,",
+      "      },",
+    );
+  }
+  lines.push(
+    "  projects: [",
+    "    {",
+    '      name: "chromium",',
+    '      use: { ...devices["Desktop Chrome"] },',
+    "    },",
+    "  ],",
+    "});",
+    "",
+  );
+  return lines.join("\n");
+}
+
+function maestroReadmeTemplate(profile: E2eExecutionProfile): string {
+  const lines = [
+    "# Maestro E2E Setup",
+    "",
+    "This directory is prepared for CodeWard-generated Maestro flows.",
+    "",
+    "## Run",
+    "",
+    "```sh",
+    profile.testCommand ?? "maestro test .maestro",
+    "```",
+    "",
+  ];
+  if (profile.appId) {
+    lines.push("## App Id", "", `Use \`${profile.appId}\` or export \`APP_ID\` for generated flows.`, "");
+  } else {
+    lines.push("## App Id", "", "Confirm the app id from app.json or app.config before making generated flows required.", "");
+  }
+  if (profile.startCommand) {
+    lines.push("## Launch", "", `Start or launch the app with \`${profile.startCommand}\` before running device flows.`, "");
+  }
+  return lines.join("\n");
+}
+
+async function applyMaestroSetup(
+  root: string,
+  profile: E2eExecutionProfile,
+  force: boolean,
+  createdFiles: string[],
+  updatedFiles: string[],
+  skippedFiles: string[],
+): Promise<void> {
+  await fs.mkdir(path.join(root, ".maestro"), { recursive: true });
+  createdFiles.push(".maestro/");
+
+  const packageJson = await readPackageJson(root);
+  if (packageJson) {
+    const didUpdatePackage = await updatePackageJsonScript(root, "test:e2e", "maestro test .maestro", force);
+    if (didUpdatePackage) {
+      updatedFiles.push("package.json");
+    } else {
+      skippedFiles.push("package.json");
+    }
+  }
+
+  const readmePath = path.join(root, ".maestro/README.md");
+  if ((await exists(readmePath)) && !force) {
+    skippedFiles.push(".maestro/README.md");
+  } else {
+    await fs.writeFile(readmePath, maestroReadmeTemplate(profile), "utf8");
+    createdFiles.push(".maestro/README.md");
+  }
 }
 
 function executionConfigCandidates(runner: E2eRunnerName): string[] {
@@ -5482,6 +5876,7 @@ function buildMaestroDraft(plan: E2ePlanResult, flow: E2eFlow): string {
   lines.push(`# Head: ${plan.head}`);
   appendDraftBriefComments(lines, flow, "maestro", "#");
   appendExecutionProfileComments(lines, plan.executionProfile, "#");
+  appendRunnerSetupProposalComments(lines, plan.runnerSetup, "#");
   lines.push("# Replace ${APP_ID} with the app id or export APP_ID before running Maestro.");
   lines.push("");
   lines.push("appId: ${APP_ID}");
@@ -5562,6 +5957,7 @@ function buildPlaywrightDraft(plan: E2ePlanResult, flow: E2eFlow): string {
   }
   appendDraftBriefComments(lines, flow, "playwright", "//");
   appendExecutionProfileComments(lines, plan.executionProfile, "//");
+  appendRunnerSetupProposalComments(lines, plan.runnerSetup, "//");
   lines.push("");
   lines.push('import { expect, test } from "@playwright/test";');
   lines.push("");
@@ -5645,6 +6041,7 @@ function buildManualDraft(plan: E2ePlanResult, flow: E2eFlow): string {
   lines.push("");
   appendManualDraftBrief(lines, flow, "manual");
   appendManualExecutionProfile(lines, plan.executionProfile);
+  appendManualRunnerSetupProposal(lines, plan.runnerSetup);
   lines.push("");
   lines.push("## Steps");
   lines.push("");
@@ -5777,6 +6174,40 @@ function appendExecutionProfileMarkdown(lines: string[], profile: E2eExecutionPr
     for (const blocker of profile.blockers) {
       lines.push(`- ${escapeMarkdownInline(blocker)}`);
     }
+  }
+  lines.push("");
+}
+
+function appendRunnerSetupProposalMarkdown(lines: string[], setup: E2eRunnerSetupProposal): void {
+  lines.push("## Runner Setup Proposal");
+  lines.push("");
+  lines.push(`- Status: ${setup.status}`);
+  lines.push(`- Runner: ${formatRunnerName(setup.runner)}`);
+  lines.push(`- Proposal: ${escapeMarkdownInline(setup.title)}`);
+  lines.push(`- Why this runner: ${escapeMarkdownInline(setup.reason)}`);
+  if (setup.setupCommand) {
+    lines.push(`- Accept setup with: \`${escapeMarkdownInline(setup.setupCommand)}\``);
+  }
+  if (setup.installCommands.length > 0) {
+    lines.push("- Install commands:");
+    for (const command of setup.installCommands) {
+      lines.push(`  - \`${escapeMarkdownInline(command)}\``);
+    }
+  }
+  if (setup.filesToCreate.length > 0) {
+    lines.push(`- Files to create: ${setup.filesToCreate.map((file) => `\`${escapeMarkdownInline(file)}\``).join(", ")}`);
+  }
+  if (setup.filesToUpdate.length > 0) {
+    lines.push(`- Files to update: ${setup.filesToUpdate.map((file) => `\`${escapeMarkdownInline(file)}\``).join(", ")}`);
+  }
+  if (setup.nextCommands.length > 0) {
+    lines.push("- Next commands after setup:");
+    for (const command of setup.nextCommands.slice(0, 4)) {
+      lines.push(`  - \`${escapeMarkdownInline(command)}\``);
+    }
+  }
+  for (const note of setup.notes.slice(0, 3)) {
+    lines.push(`- Note: ${escapeMarkdownInline(note)}`);
   }
   lines.push("");
 }
@@ -5937,6 +6368,32 @@ function appendExecutionProfileComments(
   }
 }
 
+function appendRunnerSetupProposalComments(
+  lines: string[],
+  setup: E2eRunnerSetupProposal,
+  commentPrefix: string,
+): void {
+  if (setup.status === "ready" || setup.status === "not-applicable") {
+    return;
+  }
+  lines.push("");
+  lines.push(`${commentPrefix} Runner setup proposal:`);
+  lines.push(`${commentPrefix} - ${setup.title}`);
+  lines.push(`${commentPrefix} - Why: ${setup.reason}`);
+  if (setup.setupCommand) {
+    lines.push(`${commentPrefix} - Accept with: ${setup.setupCommand}`);
+  }
+  for (const command of setup.installCommands) {
+    lines.push(`${commentPrefix} - Install: ${command}`);
+  }
+  if (setup.filesToCreate.length > 0) {
+    lines.push(`${commentPrefix} - Creates: ${setup.filesToCreate.join(", ")}`);
+  }
+  if (setup.filesToUpdate.length > 0) {
+    lines.push(`${commentPrefix} - Updates: ${setup.filesToUpdate.join(", ")}`);
+  }
+}
+
 function appendManualDraftBrief(lines: string[], flow: E2eFlow, runner: E2eRunnerName): void {
   const brief = buildDraftBrief(flow, runner);
   lines.push("## Draft Brief");
@@ -5972,6 +6429,29 @@ function appendManualExecutionProfile(lines: string[], profile: E2eExecutionProf
     for (const blocker of profile.blockers.slice(0, 4)) {
       lines.push(`  - ${blocker}`);
     }
+  }
+}
+
+function appendManualRunnerSetupProposal(lines: string[], setup: E2eRunnerSetupProposal): void {
+  if (setup.status === "ready" || setup.status === "not-applicable") {
+    return;
+  }
+  lines.push("");
+  lines.push("## Runner Setup Proposal");
+  lines.push("");
+  lines.push(`- ${setup.title}`);
+  lines.push(`- Why: ${setup.reason}`);
+  if (setup.setupCommand) {
+    lines.push(`- Accept with: \`${setup.setupCommand}\``);
+  }
+  for (const command of setup.installCommands) {
+    lines.push(`- Install: \`${command}\``);
+  }
+  if (setup.filesToCreate.length > 0) {
+    lines.push(`- Creates: ${setup.filesToCreate.map((file) => `\`${file}\``).join(", ")}`);
+  }
+  if (setup.filesToUpdate.length > 0) {
+    lines.push(`- Updates: ${setup.filesToUpdate.map((file) => `\`${file}\``).join(", ")}`);
   }
 }
 
@@ -6376,10 +6856,6 @@ function playwrightConfigGuidance(profile: E2eExecutionProfile): string {
     return `Create playwright.config.ts with a confirmed baseURL and webServer.command "${profile.startCommand}", then run the generated spec locally.`;
   }
   return "Create playwright.config.ts with testDir \"./tests/e2e\", a confirmed baseURL, and a webServer command before treating generated specs as required.";
-}
-
-function playwrightSetupCommands(profile: E2eExecutionProfile): string[] {
-  return uniqueStrings([profile.startCommand, profile.testCommand].filter(Boolean) as string[]);
 }
 
 function formatDraftFileQuality(file: E2eDraftFile): string | undefined {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,14 @@ export {
   writeDefaultDomainManifest,
 } from "./domains.js";
 export { buildDoctorResult, formatDoctorReport, formatMarkdownDoctorReport } from "./doctor.js";
-export { formatMarkdownE2eDraft, formatMarkdownE2ePlan, generateE2eDraft, generateE2ePlan } from "./e2e.js";
+export {
+  formatMarkdownE2eDraft,
+  formatMarkdownE2ePlan,
+  formatMarkdownE2eSetup,
+  generateE2eDraft,
+  generateE2ePlan,
+  setupE2eRunner,
+} from "./e2e.js";
 export { evaluateChangeReadiness, formatEvalReport, formatMarkdownEvalReport } from "./eval.js";
 export {
   defaultFlowManifestPath,
@@ -96,6 +103,10 @@ export type {
   E2eProjectType,
   E2eRunnerName,
   E2eRunnerRecommendation,
+  E2eRunnerSetupProposal,
+  E2eRunnerSetupStatus,
+  E2eSetupOptions,
+  E2eSetupResult,
 } from "./e2e.js";
 export type { EvalCheck, EvalCheckStatus, EvalOptions, EvalRating, EvalResult } from "./eval.js";
 export type {

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -31,6 +31,7 @@ import {
   localHistoryGitignorePatterns,
   reviewProject,
   scanProject,
+  setupE2eRunner,
   verifyChange,
   writeDefaultConfig,
 } from "../dist/index.js";
@@ -1859,6 +1860,9 @@ test("generateE2ePlan builds a bootstrap plan for projects without tests", async
 
   assert.equal(plan.testSuite.hasTestSuite, false);
   assert.equal(plan.recommendedRunner.name, "playwright");
+  assert.equal(plan.runnerSetup.status, "proposed");
+  assert.equal(plan.runnerSetup.setupCommand, "codeward e2e setup . --runner playwright");
+  assert.ok(plan.runnerSetup.installCommands.some((command) => /@playwright\/test/.test(command)));
   assert.ok(plan.bootstrap.counts.required >= 4);
   assert.ok(plan.bootstrap.steps.some((step) => step.category === "runner" && step.status === "required"));
   assert.ok(plan.bootstrap.steps.some((step) => step.category === "draft" && step.status === "required"));
@@ -1870,10 +1874,18 @@ test("generateE2ePlan builds a bootstrap plan for projects without tests", async
   assert.ok(plan.bootstrap.steps.some((step) => step.commands.includes("codeward flows suggest . --base main --head HEAD")));
   assert.match(plan.bootstrap.summary, /required bootstrap step/);
   assert.match(markdown, /## Bootstrap Plan/);
+  assert.match(markdown, /## Runner Setup Proposal/);
+  assert.match(markdown, /Accept setup with: `codeward e2e setup \. --runner playwright`/);
   assert.match(markdown, /Create the first changed-flow E2E draft/);
   assert.match(markdown, /Add deterministic fixture or mock responses/);
   assert.match(markdown, /codeward e2e draft \. --base main --head HEAD/);
-  assert.match(formatMarkdownE2eDraft(draft), /Resolve required bootstrap steps/);
+  const draftMarkdown = formatMarkdownE2eDraft(draft);
+  assert.match(draftMarkdown, /Resolve required bootstrap steps/);
+  const draftFile = draft.files[0];
+  assert.ok(draftFile);
+  const generatedSpec = await readFile(path.join(root, draftFile.path), "utf8");
+  assert.match(generatedSpec, /Runner setup proposal:/);
+  assert.match(generatedSpec, /Accept with: codeward e2e setup \. --runner playwright/);
 });
 
 test("generateE2eDraft uses web selectors in Playwright specs", async () => {
@@ -2076,16 +2088,38 @@ test("generateE2ePlan infers Playwright base URLs from dev scripts", async () =>
   assert.equal(plan.executionProfile.startCommand, "pnpm run dev");
   assert.equal(plan.executionProfile.testCommand, "npx playwright test");
   assert.equal(plan.executionProfile.baseUrl, "http://localhost:3004");
+  assert.equal(plan.runnerSetup.status, "proposed");
+  assert.equal(plan.runnerSetup.setupCommand, "codeward e2e setup . --runner playwright");
+  assert.deepEqual(plan.runnerSetup.installCommands, ["pnpm add -D @playwright/test"]);
+  assert.ok(plan.runnerSetup.filesToCreate.includes("playwright.config.ts"));
   assert.ok(plan.executionProfile.blockers.some((blocker) => /Playwright config/.test(blocker)));
   assert.equal(plan.executionProfile.blockers.some((blocker) => /baseURL|base URL/.test(blocker)), false);
   assert.ok(runnerStep);
   assert.match(runnerStep.action, /playwright\.config\.ts/);
   assert.match(runnerStep.action, /webServer\.command "pnpm run dev"/);
   assert.match(runnerStep.action, /use\.baseURL "http:\/\/localhost:3004"/);
-  assert.deepEqual(runnerStep.commands, ["pnpm run dev", "npx playwright test"]);
+  assert.ok(runnerStep.commands.includes("pnpm add -D @playwright/test"));
+  assert.ok(runnerStep.commands.includes("codeward e2e setup . --runner playwright"));
+  assert.ok(runnerStep.commands.includes("pnpm run dev"));
+  assert.ok(runnerStep.commands.includes("npx playwright test"));
   assert.ok(runnerAction);
   assert.match(runnerAction.detail, /playwright\.config\.ts/);
   assert.match(runnerAction.detail, /http:\/\/localhost:3004/);
+  assert.match(runnerAction.detail, /codeward e2e setup \. --runner playwright/);
+
+  const setup = await setupE2eRunner(root, { base: "main", head: "HEAD", runner: "playwright" });
+  const packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
+  const configText = await readFile(path.join(root, "playwright.config.ts"), "utf8");
+
+  assert.equal(setup.runner, "playwright");
+  assert.ok(setup.createdFiles.includes("playwright.config.ts"));
+  assert.ok(setup.createdFiles.includes("tests/e2e/"));
+  assert.ok(setup.updatedFiles.includes("package.json"));
+  assert.deepEqual(setup.installCommands, ["pnpm add -D @playwright/test"]);
+  assert.equal(packageJson.scripts["test:e2e"], "playwright test");
+  assert.match(configText, /testDir: "\.\/tests\/e2e"/);
+  assert.match(configText, /http:\/\/localhost:3004/);
+  assert.match(configText, /command: "pnpm run dev"/);
 });
 
 test("generateE2eDraft supports Next app router route groups and concrete route hints", async () => {


### PR DESCRIPTION
## Summary
- add runner setup proposals to E2E plans so missing Playwright/Maestro setup is presented as an opt-in path, not a hard demand
- add `codeward e2e setup` to create minimal Playwright or Maestro config/script files after a user accepts the proposal
- include setup proposal context inside generated draft files and document the plan -> setup -> draft workflow

## Validation
- pnpm test
- pnpm run release:check
- local preview on inpock-app-client with target repo status unchanged