### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 No changes yet.
 
+## 0.1.1 - 2026-07-01
+
+Documentation and launch polish release.
+
+### Changed
+
+- Refreshed the README first screen with `Install & Quick Start`, npm install commands, and clearer local-first/no-LLM-token positioning.
+- Added a 30-second demo GIF and quick start walkthrough showing how a checkout-form PR becomes a domain-aware Playwright draft.
+- Updated npm package metadata keywords and description to match the PR verification and E2E draft generation positioning.
+
 ## 0.1.0 - 2026-07-01
 
 Initial public release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivorycanvas/codeward",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Local-first PR verification and E2E draft generation from git diffs, with no cloud or LLM token.",
   "type": "module",
   "packageManager": "pnpm@10.32.1",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const TOOL_NAME = "CodeWard";
-export const VERSION = "0.1.0";
+export const VERSION = "0.1.1";


### PR DESCRIPTION
## Summary
- bump package and CLI version to 0.1.1
- document the launch README/demo polish release in CHANGELOG
- prepare npm patch release after README and demo updates were merged

## Validation
- pnpm run release:check
  - 80/80 node tests passed
  - CodeWard scan: 0 findings
  - coverage: lines 85.35%, branches 83.32%, functions 93.48%
  - pnpm pack --dry-run generated @ivorycanvas/codeward@0.1.1
- verified `node dist/cli.js --version` prints 0.1.1
- previewed the package against Desktop/inpock-frontend services/offer and confirmed it produces a concrete Campaign Application Complete Playwright draft without modifying that repo

## Release note
This is a documentation and launch polish patch release for the public npm package.