### PR TITLE
Feat: reach consuming surfaces through a reverse import graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Added a reverse import graph: when only shared components, hooks, or library files change, QAMap now follows imports (2 hops, tsconfig paths and workspace package names included) to the pages and screens that consume them, generates the consuming surface's UI flow with the import chain as evidence, and matches verification/flow/domain manifests through the same expansion.
 
+### Fixed
+
+- Draft steps no longer emit blank actions for non-Latin UI labels: Korean (and any Unicode) placeholder, aria-label, and button text now survives step naming, with a selector-kind fallback when a label is symbol-only.
+- Domain scenario names no longer duplicate the "primary journey" suffix (for example "Notification Primary Journey primary journey").
+
 ## 0.3.1 - 2026-07-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added a reverse import graph: when only shared components, hooks, or library files change, QAMap now follows imports (2 hops, tsconfig paths and workspace package names included) to the pages and screens that consume them, generates the consuming surface's UI flow with the import chain as evidence, and matches verification/flow/domain manifests through the same expansion.
+
 ## 0.3.1 - 2026-07-03
 
 ### Fixed

--- a/src/domain-language.ts
+++ b/src/domain-language.ts
@@ -171,7 +171,7 @@ function buildScenarioSuggestions(
       continue;
     }
     scenarios.push({
-      title: `${domain.name} primary journey`,
+      title: primaryJourneyTitle(domain.name),
       intent: `Use "${domain.name}" as the shared name for this changed behavior until the team chooses a more specific scenario.`,
       checks: [
         `Start from the normal entry point for ${domain.name}.`,
@@ -192,7 +192,7 @@ function buildScenarioSuggestions(
     .filter((item) => !hasBehaviorScenarioForTerm(item, behaviorScenarios))
     .slice(0, 5)) {
     scenarios.push({
-      title: `${term.term} primary journey`,
+      title: primaryJourneyTitle(term.term),
       intent: `Use "${term.term}" as the shared name for this changed behavior until the team chooses a better domain term.`,
       checks: [
         `Start from the normal entry point for ${term.term}.`,
@@ -206,6 +206,10 @@ function buildScenarioSuggestions(
   }
 
   return dedupeScenarios(scenarios).slice(0, 6);
+}
+
+function primaryJourneyTitle(name: string): string {
+  return `${name.replace(/\s+primary\s+journey\s*$/i, "").trim()} primary journey`;
 }
 
 function hasBehaviorScenarioForTerm(term: DomainLanguageTerm, scenarios: DomainScenarioSuggestion[]): boolean {

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -4715,7 +4715,12 @@ function exerciseStepSubject(step: string): string | undefined {
 }
 
 function selectorStepLabel(selector: E2eSelector): string {
-  return titleCase(selector.value.replace(/[-_]+/g, " "));
+  const label = titleCase(selector.value.replace(/[-_]+/g, " "));
+  if (label) {
+    return label;
+  }
+  const raw = selector.value.trim();
+  return raw.length > 0 ? `"${raw}"` : `the ${selector.kind} control`;
 }
 
 function actionVerbForSelector(selector: E2eSelector): string {
@@ -6006,7 +6011,7 @@ function titleCase(value: string): string {
   return value
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
     .replace(/[-_]+/g, " ")
-    .replace(/[^a-zA-Z0-9 ]+/g, " ")
+    .replace(/[^\p{L}\p{N} ]+/gu, " ")
     .trim()
     .split(/\s+/)
     .filter(Boolean)

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import { buildDomainLanguageSummary } from "./domain-language.js";
 import { defaultDomainManifestPath, loadDomainManifest, matchDomains } from "./domains.js";
 import { collectProjectFiles } from "./fs.js";
+import { buildReverseImportIndex, expandChangedFilesWithImporters, findImportingSurfaces } from "./import-graph.js";
+import type { ImportImpact } from "./import-graph.js";
 import { loadCoreFlowManifest, matchCoreFlows } from "./flows.js";
 import { loadVerificationManifest, matchVerificationManifest } from "./manifest.js";
 import {
@@ -433,11 +435,12 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
   const coreFlowRoot = testPlan.workspaceRoot ?? root;
   const coreFlowManifest = await loadCoreFlowManifest(coreFlowRoot);
   const coreFlowChangedFiles = toCoreFlowChangedFiles(testPlan.changedFiles, root, coreFlowRoot);
-  const coreFlows = matchCoreFlows(coreFlowManifest, coreFlowChangedFiles);
+  const matchableChangedFiles = await expandChangedFilesForMatching(coreFlowRoot, coreFlowChangedFiles);
+  const coreFlows = matchCoreFlows(coreFlowManifest, matchableChangedFiles);
   const domainManifest = await loadDomainManifest(coreFlowRoot);
-  const domains = matchDomains(domainManifest, coreFlowChangedFiles);
+  const domains = matchDomains(domainManifest, matchableChangedFiles);
   const verificationManifest = await loadVerificationManifest(coreFlowRoot, { manifestPath: options.manifestPath });
-  const verificationManifestMatches = matchVerificationManifest(verificationManifest, coreFlowChangedFiles);
+  const verificationManifestMatches = matchVerificationManifest(verificationManifest, matchableChangedFiles);
   const domainLanguage = await buildDomainLanguageSummary(root, testPlan.changedFiles, coreFlows, domains);
   const workspaceTargets = await buildWorkspaceTargets(root, testPlan);
   const flows = await buildFlows(
@@ -4259,9 +4262,10 @@ async function buildFlows(
   domainLanguage: DomainLanguageSummary,
 ): Promise<E2eFlow[]> {
   const files = changedFiles.map((file) => file.path);
+  const importImpacts = await collectImportImpacts(root, files);
   const fixtureContext = await collectFixtureReadinessContext(root, files);
   const flowResults = await Promise.all(
-    buildFlowCandidates(files, runner, projectType, domainLanguage).map((candidate) =>
+    buildFlowCandidates(files, runner, projectType, domainLanguage, importImpacts).map((candidate) =>
       buildFlow(root, runner, candidate, testSuiteInventory, fixtureContext),
     ),
   );
@@ -4270,20 +4274,73 @@ async function buildFlows(
   return dedupeFlows(flows).slice(0, 4);
 }
 
+async function expandChangedFilesForMatching(
+  root: string,
+  changedFiles: TestPlanChangedFile[],
+): Promise<TestPlanChangedFile[]> {
+  if (changedFiles.length === 0 || changedFiles.length > 60) {
+    return changedFiles;
+  }
+  try {
+    const expansion = await expandChangedFilesWithImporters(root, changedFiles.map((file) => file.path));
+    const knownPaths = new Set(changedFiles.map((file) => file.path));
+    const importerEntries = expansion.files
+      .filter((file) => !knownPaths.has(file))
+      .map((file) => ({ status: "M", path: file }));
+    return [...changedFiles, ...importerEntries];
+  } catch {
+    return changedFiles;
+  }
+}
+
+function isRoutableSurfaceFile(file: string): boolean {
+  if (isApiRouteFile(file) || isTestLikeFile(file)) {
+    return false;
+  }
+  return (
+    /(?:^|\/)app\/.*(?:^|\/)?page\.[cm]?[jt]sx?$/i.test(file) ||
+    /(?:^|\/)pages\/(?!api\/).+\.(?:[cm]?[jt]sx?|vue|svelte)$/i.test(file) ||
+    /(?:^|\/)(?:screens|views)\/.+\.(?:[cm]?[jt]sx?|vue|svelte)$/i.test(file) ||
+    /(?:^|\/)routes\/(?!api\/).+\.(?:[cm]?[jt]sx?|vue|svelte)$/i.test(file)
+  );
+}
+
+async function collectImportImpacts(root: string, changedFiles: string[]): Promise<ImportImpact[]> {
+  const propagatableFiles = changedFiles.filter(
+    (file) =>
+      !isRoutableSurfaceFile(file) && !isTestLikeFile(file) && !isConfigLikeFile(file) && !isContentOrStyleFile(file),
+  );
+  if (propagatableFiles.length === 0) {
+    return [];
+  }
+  try {
+    const index = await buildReverseImportIndex(root);
+    return findImportingSurfaces(index, propagatableFiles, isRoutableSurfaceFile);
+  } catch {
+    return [];
+  }
+}
+
+function describeImportChain(impact: ImportImpact): string {
+  return impact.chain.join(" -> ");
+}
+
 function buildFlowCandidates(
   files: string[],
   runner: E2eRunnerName,
   projectType: E2eProjectType,
   domainLanguage: DomainLanguageSummary,
+  importImpacts: ImportImpact[] = [],
 ): FlowCandidate[] {
-  const lowSignalCandidate = buildLowSignalChangeCandidate(files);
+  const lowSignalCandidate = importImpacts.length === 0 ? buildLowSignalChangeCandidate(files) : undefined;
   if (lowSignalCandidate) {
     return [lowSignalCandidate];
   }
 
   const behaviorFiles = files.filter((file) => !isTestLikeFile(file));
   const candidateFiles = behaviorFiles.length > 0 ? behaviorFiles : files;
-  const uiFiles = candidateFiles.filter(isUserFacingFile);
+  const impactSurfaceFiles = importImpacts.map((impact) => impact.surface).filter((surface) => !candidateFiles.includes(surface));
+  const uiFiles = uniqueStrings([...candidateFiles.filter(isUserFacingFile), ...impactSurfaceFiles]);
   const apiFiles = candidateFiles.filter(isApiLikeFile);
   const apiServiceSourceFiles =
     projectType === "api-service"
@@ -4309,11 +4366,14 @@ function buildFlowCandidates(
 
   if (uiFiles.length > 0) {
     const subject = summarizeFlowSubject(uiFiles, "Changed", domainLanguage);
+    const impactReason = importImpacts.length > 0
+      ? ` Changed shared files reach these surfaces through imports: ${importImpacts.slice(0, 3).map(describeImportChain).join("; ")}.`
+      : "";
     candidates.push({
       kind: "ui",
       title: `${subject} UI smoke flow`,
-      reason: "User-facing route, screen, navigation, or component files changed, so the draft should open the touched surface and cover the primary visible action.",
-      files: uiFiles,
+      reason: `User-facing route, screen, navigation, or component files changed, so the draft should open the touched surface and cover the primary visible action.${impactReason}`,
+      files: uniqueStrings([...uiFiles, ...importImpacts.map((impact) => impact.changedFile)]),
       steps: [
         "Launch the app.",
         "Navigate to the changed screen or component surface.",

--- a/src/import-graph.ts
+++ b/src/import-graph.ts
@@ -1,0 +1,376 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const maxGraphFiles = 12000;
+const maxSourceBytes = 300_000;
+const defaultMaxHops = 2;
+const maxImpactSurfaces = 6;
+const maxExpandedImporters = 40;
+
+const sourceExtensions = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts", ".vue", ".svelte"]);
+const resolvableExtensions = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts", ".vue", ".svelte"];
+
+const ignoredDirectories = new Set([
+  ".git",
+  ".hg",
+  ".svn",
+  "node_modules",
+  "dist",
+  "build",
+  "out",
+  "coverage",
+  ".next",
+  ".nuxt",
+  ".turbo",
+  ".cache",
+  ".expo",
+  "vendor",
+]);
+
+export interface ImportImpact {
+  surface: string;
+  changedFile: string;
+  hops: number;
+  chain: string[];
+}
+
+export interface ChangedFileExpansion {
+  files: string[];
+  via: Record<string, string[]>;
+}
+
+interface ReverseImportIndex {
+  importersOf: Map<string, Set<string>>;
+}
+
+interface WorkspacePackages {
+  byName: Map<string, string>;
+}
+
+interface TsconfigPaths {
+  baseUrl: string;
+  patterns: Array<{ prefix: string; suffix: string; targets: string[] }>;
+}
+
+const importSpecifierMatcher =
+  /(?:import|export)\s+(?:[\s\S]*?from\s+)?["']([^"'\n]+)["']|require\(\s*["']([^"'\n]+)["']\s*\)|import\(\s*["']([^"'\n]+)["']\s*\)/g;
+
+// Per-process cache: safe because the CLI is one-shot per invocation. Callers that
+// mutate source files and re-plan within one process will see a stale graph.
+const indexCache = new Map<string, Promise<ReverseImportIndex>>();
+const maxCachedIndexes = 8;
+
+export async function buildReverseImportIndex(rootInput: string): Promise<ReverseImportIndex> {
+  const root = path.resolve(rootInput);
+  const cached = indexCache.get(root);
+  if (cached) {
+    return cached;
+  }
+  const pending = buildReverseImportIndexUncached(root);
+  if (indexCache.size >= maxCachedIndexes) {
+    indexCache.clear();
+  }
+  indexCache.set(root, pending);
+  return pending;
+}
+
+async function buildReverseImportIndexUncached(root: string): Promise<ReverseImportIndex> {
+  const { sourceFiles, packageJsonFiles } = await collectSourceFiles(root);
+  const fileSet = new Set(sourceFiles);
+  const tsconfigPaths = await readTsconfigPaths(root);
+  const workspacePackages = await readWorkspacePackages(root, packageJsonFiles);
+  const importersOf = new Map<string, Set<string>>();
+
+  for (const file of sourceFiles) {
+    let text: string;
+    try {
+      const stats = await fs.stat(path.join(root, file));
+      if (stats.size > maxSourceBytes) {
+        continue;
+      }
+      text = await fs.readFile(path.join(root, file), "utf8");
+    } catch {
+      continue;
+    }
+    for (const match of text.matchAll(importSpecifierMatcher)) {
+      const specifier = match[1] ?? match[2] ?? match[3];
+      const resolved = resolveImportSpecifier(specifier, file, fileSet, tsconfigPaths, workspacePackages);
+      if (!resolved || resolved === file) {
+        continue;
+      }
+      let importers = importersOf.get(resolved);
+      if (!importers) {
+        importers = new Set<string>();
+        importersOf.set(resolved, importers);
+      }
+      importers.add(file);
+    }
+  }
+
+  return { importersOf };
+}
+
+export function findImportingSurfaces(
+  index: ReverseImportIndex,
+  changedFiles: string[],
+  isSurface: (file: string) => boolean,
+  maxHops: number = defaultMaxHops,
+): ImportImpact[] {
+  const impacts: ImportImpact[] = [];
+  const seenSurfaces = new Set<string>();
+
+  for (const changedFile of changedFiles) {
+    if (isSurface(changedFile)) {
+      continue;
+    }
+    for (const reached of walkImporters(index, changedFile, maxHops)) {
+      if (!isSurface(reached.file) || seenSurfaces.has(reached.file)) {
+        continue;
+      }
+      seenSurfaces.add(reached.file);
+      impacts.push({
+        surface: reached.file,
+        changedFile,
+        hops: reached.hops,
+        chain: reached.chain,
+      });
+      if (impacts.length >= maxImpactSurfaces) {
+        return impacts;
+      }
+    }
+  }
+  return impacts;
+}
+
+export async function expandChangedFilesWithImporters(
+  rootInput: string,
+  changedFiles: string[],
+  maxHops: number = defaultMaxHops,
+): Promise<ChangedFileExpansion> {
+  if (changedFiles.length === 0) {
+    return { files: [], via: {} };
+  }
+  const index = await buildReverseImportIndex(rootInput);
+  const via: Record<string, string[]> = {};
+  const expanded: string[] = [...changedFiles];
+  const known = new Set(changedFiles);
+
+  for (const changedFile of changedFiles) {
+    for (const reached of walkImporters(index, changedFile, maxHops)) {
+      if (known.has(reached.file)) {
+        continue;
+      }
+      known.add(reached.file);
+      expanded.push(reached.file);
+      via[reached.file] = reached.chain;
+      if (expanded.length - changedFiles.length >= maxExpandedImporters) {
+        return { files: expanded, via };
+      }
+    }
+  }
+  return { files: expanded, via };
+}
+
+function* walkImporters(
+  index: ReverseImportIndex,
+  startFile: string,
+  maxHops: number,
+): Generator<{ file: string; hops: number; chain: string[] }> {
+  const visited = new Set<string>([startFile]);
+  let frontier: Array<{ file: string; chain: string[] }> = [{ file: startFile, chain: [startFile] }];
+
+  for (let hop = 1; hop <= maxHops; hop += 1) {
+    const nextFrontier: Array<{ file: string; chain: string[] }> = [];
+    for (const entry of frontier) {
+      for (const importer of index.importersOf.get(entry.file) ?? []) {
+        if (visited.has(importer)) {
+          continue;
+        }
+        visited.add(importer);
+        const chain = [...entry.chain, importer];
+        yield { file: importer, hops: hop, chain };
+        nextFrontier.push({ file: importer, chain });
+      }
+    }
+    frontier = nextFrontier;
+    if (frontier.length === 0) {
+      return;
+    }
+  }
+}
+
+async function collectSourceFiles(root: string): Promise<{ sourceFiles: string[]; packageJsonFiles: string[] }> {
+  const sourceFiles: string[] = [];
+  const packageJsonFiles: string[] = [];
+  const queue: string[] = [""];
+  while (queue.length > 0 && sourceFiles.length < maxGraphFiles) {
+    const relativeDir = queue.shift() as string;
+    let entries;
+    try {
+      entries = await fs.readdir(path.join(root, relativeDir), { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (sourceFiles.length >= maxGraphFiles) {
+        break;
+      }
+      const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        if (!ignoredDirectories.has(entry.name) && !entry.name.startsWith(".")) {
+          queue.push(relativePath);
+        }
+        continue;
+      }
+      if (!entry.isFile()) {
+        continue;
+      }
+      if (entry.name === "package.json") {
+        packageJsonFiles.push(relativePath);
+        continue;
+      }
+      if (sourceExtensions.has(path.extname(entry.name))) {
+        sourceFiles.push(relativePath);
+      }
+    }
+  }
+  return { sourceFiles, packageJsonFiles };
+}
+
+async function readWorkspacePackages(root: string, packageJsonFiles: string[]): Promise<WorkspacePackages> {
+  const byName = new Map<string, string>();
+  for (const file of packageJsonFiles.slice(0, 200)) {
+    try {
+      const parsed = JSON.parse(await fs.readFile(path.join(root, file), "utf8")) as { name?: string };
+      const directory = path.posix.dirname(toPosix(file));
+      if (parsed.name && directory !== ".") {
+        byName.set(parsed.name, directory);
+      }
+    } catch {
+      continue;
+    }
+  }
+  return { byName };
+}
+
+async function readTsconfigPaths(root: string): Promise<TsconfigPaths> {
+  const empty: TsconfigPaths = { baseUrl: "", patterns: [] };
+  for (const candidate of ["tsconfig.json", "jsconfig.json"]) {
+    let raw: string;
+    try {
+      raw = await fs.readFile(path.join(root, candidate), "utf8");
+    } catch {
+      continue;
+    }
+    try {
+      const withoutComments = raw.replace(/\/\/[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "").replace(/,\s*([}\]])/g, "$1");
+      const parsed = JSON.parse(withoutComments) as {
+        compilerOptions?: { baseUrl?: string; paths?: Record<string, string[]> };
+      };
+      const baseUrl = normalizeRelativePath(parsed.compilerOptions?.baseUrl ?? "");
+      const patterns: TsconfigPaths["patterns"] = [];
+      for (const [pattern, targets] of Object.entries(parsed.compilerOptions?.paths ?? {})) {
+        const starIndex = pattern.indexOf("*");
+        patterns.push({
+          prefix: starIndex === -1 ? pattern : pattern.slice(0, starIndex),
+          suffix: starIndex === -1 ? "" : pattern.slice(starIndex + 1),
+          targets: targets.map((target) => normalizeRelativePath(path.posix.join(baseUrl, target))),
+        });
+      }
+      return { baseUrl, patterns };
+    } catch {
+      return empty;
+    }
+  }
+  return empty;
+}
+
+function resolveImportSpecifier(
+  specifier: string | undefined,
+  importerFile: string,
+  fileSet: Set<string>,
+  tsconfigPaths: TsconfigPaths,
+  workspacePackages: WorkspacePackages,
+): string | undefined {
+  if (!specifier || specifier.startsWith("http:") || specifier.startsWith("https:")) {
+    return undefined;
+  }
+  if (specifier.startsWith(".")) {
+    const base = path.posix.normalize(path.posix.join(path.posix.dirname(toPosix(importerFile)), specifier));
+    return probeFile(base, fileSet);
+  }
+  for (const pattern of tsconfigPaths.patterns) {
+    if (!specifier.startsWith(pattern.prefix)) {
+      continue;
+    }
+    if (pattern.suffix && !specifier.endsWith(pattern.suffix)) {
+      continue;
+    }
+    const middle = specifier.slice(pattern.prefix.length, pattern.suffix ? -pattern.suffix.length : undefined);
+    for (const target of pattern.targets) {
+      const candidate = normalizeRelativePath(target.replace("*", middle));
+      const resolved = probeFile(candidate, fileSet);
+      if (resolved) {
+        return resolved;
+      }
+    }
+  }
+  return resolveWorkspaceSpecifier(specifier, fileSet, workspacePackages);
+}
+
+function resolveWorkspaceSpecifier(
+  specifier: string,
+  fileSet: Set<string>,
+  workspacePackages: WorkspacePackages,
+): string | undefined {
+  const slashIndex = specifier.startsWith("@") ? specifier.indexOf("/", specifier.indexOf("/") + 1) : specifier.indexOf("/");
+  const packageName = slashIndex === -1 ? specifier : specifier.slice(0, slashIndex);
+  const packageDir = workspacePackages.byName.get(packageName);
+  if (!packageDir) {
+    return undefined;
+  }
+  const remainder = slashIndex === -1 ? "" : specifier.slice(slashIndex + 1);
+  const candidates = remainder
+    ? [`${packageDir}/${remainder}`, `${packageDir}/src/${remainder}`]
+    : [`${packageDir}/index`, `${packageDir}/src/index`];
+  for (const candidate of candidates) {
+    const resolved = probeFile(candidate, fileSet);
+    if (resolved) {
+      return resolved;
+    }
+  }
+  return undefined;
+}
+
+function probeFile(baseCandidate: string, fileSet: Set<string>): string | undefined {
+  const candidate = normalizeRelativePath(baseCandidate);
+  if (!candidate) {
+    return undefined;
+  }
+  if (fileSet.has(candidate)) {
+    return candidate;
+  }
+  const withoutJsExtension = candidate.replace(/\.(?:js|mjs|cjs|jsx)$/, "");
+  for (const base of withoutJsExtension === candidate ? [candidate] : [candidate, withoutJsExtension]) {
+    for (const extension of resolvableExtensions) {
+      if (fileSet.has(`${base}${extension}`)) {
+        return `${base}${extension}`;
+      }
+    }
+    for (const extension of resolvableExtensions) {
+      if (fileSet.has(`${base}/index${extension}`)) {
+        return `${base}/index${extension}`;
+      }
+    }
+  }
+  return undefined;
+}
+
+function normalizeRelativePath(value: string): string {
+  const normalized = path.posix.normalize(toPosix(value)).replace(/^\.\/?/, "");
+  return normalized === "." ? "" : normalized;
+}
+
+function toPosix(value: string): string {
+  return value.replace(/\\/g, "/");
+}

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -5,6 +5,7 @@ import {
   matchVerificationManifest,
 } from "./manifest.js";
 import type { EvalOptions, EvalResult } from "./eval.js";
+import { expandChangedFilesWithImporters } from "./import-graph.js";
 import type { VerificationManifestMatch } from "./manifest.js";
 import { reviewProject } from "./review.js";
 import type { ReviewResult } from "./review.js";
@@ -33,6 +34,25 @@ export interface VerifyResult {
   recommendations: string[];
 }
 
+async function expandForManifestMatching(
+  root: string,
+  changedFiles: ReturnType<typeof changedFilesRelativeToManifestRoot>,
+): Promise<ReturnType<typeof changedFilesRelativeToManifestRoot>> {
+  if (changedFiles.length === 0 || changedFiles.length > 60) {
+    return changedFiles;
+  }
+  try {
+    const expansion = await expandChangedFilesWithImporters(root, changedFiles.map((file) => file.path));
+    const knownPaths = new Set(changedFiles.map((file) => file.path));
+    const importerEntries = expansion.files
+      .filter((file) => !knownPaths.has(file))
+      .map((file) => ({ status: "M", path: file }));
+    return [...changedFiles, ...importerEntries];
+  } catch {
+    return changedFiles;
+  }
+}
+
 export async function verifyChange(rootInput: string, options: VerifyOptions = {}): Promise<VerifyResult> {
   const scanOptions = options.workspaceRoot
     ? { ...options.scanOptions, workspaceRoot: options.workspaceRoot }
@@ -54,7 +74,8 @@ export async function verifyChange(rootInput: string, options: VerifyOptions = {
   const manifestRoot = evaluation.workspaceRoot ?? evaluation.root;
   const verificationManifest = await loadVerificationManifest(manifestRoot, { manifestPath: options.manifestPath });
   const manifestChangedFiles = changedFilesRelativeToManifestRoot(evaluation.changedFiles, evaluation.root, manifestRoot);
-  const verificationManifestMatches = matchVerificationManifest(verificationManifest, manifestChangedFiles);
+  const matchableChangedFiles = await expandForManifestMatching(manifestRoot, manifestChangedFiles);
+  const verificationManifestMatches = matchVerificationManifest(verificationManifest, matchableChangedFiles);
 
   return {
     tool: {

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -4567,6 +4567,54 @@ test("qa command emits a PR comment draft without requiring a manifest", async (
   assert.equal(agentCliSummary.schema.name, "qamap.qa");
 });
 
+test("draft steps keep non-Latin selector labels instead of emitting blank actions", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "app/memo"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({ scripts: { test: "playwright test" }, dependencies: { next: "^15.0.0", "@playwright/test": "^1.56.0" } }),
+  );
+  await writeFile(
+    path.join(root, "app/memo/page.tsx"),
+    [
+      "export default function MemoPage() {",
+      "  return <main>",
+      "    <input placeholder=\"메모를 입력하세요\" />",
+      "    <button aria-label=\"저장하기\">저장</button>",
+      "  </main>;",
+      "}",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/memo-tags"]);
+  await writeFile(
+    path.join(root, "app/memo/page.tsx"),
+    [
+      "export default function MemoPage() {",
+      "  return <main>",
+      "    <input placeholder=\"메모를 입력하세요\" />",
+      "    <input placeholder=\"태그를 입력하세요\" />",
+      "    <button aria-label=\"저장하기\">저장</button>",
+      "  </main>;",
+      "}",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "add tag input"]);
+
+  const draft = await generateE2eDraft(root, { base: "main", head: "HEAD", runner: "playwright", dryRun: true });
+  const stepText = draft.files.flatMap((file) => file.draftSteps ?? []).join("\n");
+  assert.match(stepText, /Fill 메모를 입력하세요 with realistic data/);
+  assert.match(stepText, /using 저장하기/);
+  assert.doesNotMatch(stepText, /Fill\s{2,}with/);
+  assert.doesNotMatch(stepText, /using \.\s*$/m);
+  assert.doesNotMatch(formatMarkdownE2eDraft(draft), /Fill\s{2,}with/);
+});
+
 test("generateE2ePlan reaches consuming surfaces when only a shared component changes", async () => {
   const root = await makeTempRepo();
   await initGitRepo(root);

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -4567,6 +4567,114 @@ test("qa command emits a PR comment draft without requiring a manifest", async (
   assert.equal(agentCliSummary.schema.name, "qamap.qa");
 });
 
+test("generateE2ePlan reaches consuming surfaces when only a shared component changes", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "components"), { recursive: true });
+  await mkdir(path.join(root, "app/cart"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      scripts: { test: "playwright test" },
+      dependencies: { next: "^15.0.0", "@playwright/test": "^1.56.0" },
+    }),
+  );
+  await writeFile(
+    path.join(root, "tsconfig.json"),
+    JSON.stringify({ compilerOptions: { baseUrl: ".", paths: { "@/*": ["./*"] } } }),
+  );
+  await writeFile(
+    path.join(root, "components/Button.tsx"),
+    "export function Button({ label }: { label: string }) { return <button data-testid=\"shared-button\">{label}</button>; }\n",
+  );
+  await writeFile(
+    path.join(root, "app/cart/page.tsx"),
+    [
+      "import { Button } from \"@/components/Button\";",
+      "export default function CartPage() {",
+      "  return <main><h1>Cart</h1><Button label=\"Checkout\" /></main>;",
+      "}",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/button-variant"]);
+  await writeFile(
+    path.join(root, "components/Button.tsx"),
+    "export function Button({ label }: { label: string }) { return <button data-testid=\"shared-button\" className=\"primary\">{label}</button>; }\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "button variant"]);
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD", runner: "playwright" });
+  const uiFlow = plan.flows.find((flow) => flow.files.includes("app/cart/page.tsx"));
+  assert.ok(uiFlow, "expected a flow that reaches the consuming cart page via imports");
+  assert.ok(uiFlow.files.includes("components/Button.tsx"));
+  assert.match(uiFlow.reason, /through imports: components\/Button\.tsx -> app\/cart\/page\.tsx/);
+  assert.ok(uiFlow.entrypoints.some((entrypoint) => entrypoint.value === "/cart"));
+});
+
+test("verification manifest flows match when changed files are imported by anchored files", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "components"), { recursive: true });
+  await mkdir(path.join(root, "app/cart"), { recursive: true });
+  await mkdir(path.join(root, ".qamap"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({ scripts: { test: "playwright test" }, dependencies: { next: "^15.0.0" } }),
+  );
+  await writeFile(
+    path.join(root, "components/Button.tsx"),
+    "export function Button() { return <button data-testid=\"shared-button\">Buy</button>; }\n",
+  );
+  await writeFile(
+    path.join(root, "app/cart/page.tsx"),
+    "import { Button } from \"../../components/Button\";\nexport default function CartPage() { return <main><Button /></main>; }\n",
+  );
+  await writeFile(
+    path.join(root, ".qamap/manifest.yaml"),
+    [
+      "version: 1",
+      "domains:",
+      "  - id: cart",
+      "    name: Cart",
+      "    paths:",
+      "      - app/cart/**",
+      "flows:",
+      "  - id: cart-checkout",
+      "    name: Cart checkout",
+      "    domain: cart",
+      "    anchors:",
+      "      - kind: file",
+      "        path: app/cart/page.tsx",
+      "    checks:",
+      "      - id: cart-checkout-success",
+      "        title: Complete checkout from the cart",
+      "        type: success",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/button-only"]);
+  await writeFile(
+    path.join(root, "components/Button.tsx"),
+    "export function Button() { return <button data-testid=\"shared-button\">Buy now</button>; }\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "button copy"]);
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD", runner: "playwright" });
+  assert.ok(
+    plan.verificationManifestMatches.some((match) => match.kind === "flow" && match.id === "cart-checkout"),
+    "expected the cart-checkout manifest flow to match via the import chain",
+  );
+});
+
 test("generated drafts are not counted as test-suite evidence", async () => {
   const root = await makeTempRepo();
   await initGitRepo(root);


### PR DESCRIPTION
## Intent

Fix the single most reproduced failure from real-repo testing: when a PR changes only shared components, hooks, or library files, QAMap produced no user-flow output (or a content-free "X primary journey"), because flow detection only looked at the literally changed files. This was confirmed on six external repositories — the headline change of every tested diff (cal.com's shared markdown fix, excalidraw's viewport feature, fastify's reply fix, and more) never became a named flow.

- Add `src/import-graph.ts`: a static reverse import graph built per run — regex import/require/dynamic-import extraction, relative-path resolution, `tsconfig.json`/`jsconfig.json` `paths` aliases, and workspace package names (e.g. a `@scope/lib/util` specifier resolves into `packages/lib/util.ts` via package.json names). Reverse BFS is capped at 2 hops, 12k source files, and 6 surfaces, with a per-process index cache.
- Flow candidates now include the routable surfaces (app/pages/screens/views/routes entries) that transitively import the changed files. The consuming page joins the UI flow's files, so the existing route/selector/endpoint extraction works on it, and the flow reason carries the evidence chain (`components/Button.tsx -> app/cart/page.tsx`).
- Verification-manifest, core-flow, and domain matching run against the import-expanded changed-file set, so a flow anchored to `app/cart/**` now matches a PR that only touched `components/Button.tsx`.
- Fix two output-trust bugs found in external testing: draft steps no longer emit blank actions for non-Latin UI labels (Korean placeholder/aria-label text was stripped to an empty string by ASCII-only title casing, producing "Fill  with realistic data."), and domain scenario names no longer duplicate the "primary journey" suffix.

## Agent / Review Risk

- The import graph runs on every `e2e plan/draft`, `qa`, and `verify` invocation. Measured on a 5,000-source-file production monorepo (cal.com): full `qa` run completes in ~3.0s including the graph. Caps bound the worst case; failures fall back silently to the previous behavior.
- Import resolution is regex-based (no TypeScript compiler): dynamic/computed specifiers and re-export barrels beyond 2 hops are not followed. Vue/Svelte files are indexed as importers but SFC script blocks are matched by the same regex.
- The per-process index cache assumes the CLI is one-shot; callers that mutate sources and re-plan in one process see a stale graph (documented in the module).

## Validation Evidence

- [x] `pnpm test` (98/98 passing; 3 new regression tests)
- [x] `pnpm scan` (0 findings)
- [x] `git diff --check` clean

## E2E / Manual Coverage

- New tests: shared-component change reaches the consuming page via a `@/*` alias (flow includes the page, entrypoint `/cart`, chain in reason); manifest flow anchored to the page matches a component-only diff; Korean placeholder/aria-label survive into draft steps with no blank actions.
- Manual on cal.com (real repo, HEAD~5 window containing the shared `markdownToSafeHTML` fix that previously matched nothing): the plan now emits a UI smoke flow containing `apps/web/pages/router/index.tsx` reached at hop 1, with "Changed shared files reach these surfaces through imports: …" as evidence.

## Maintainer Notes

- Known follow-up (intentionally out of scope): in the `qa`/draft path, domain-language flows can still occupy the 4-flow cap ahead of the import-impact UI flow; plan-level output always shows it. Draft-ranking priority for import-impact flows is the next increment.
- Next per the agreed backlog: diff-derived assertions (replace body-visible smoke checks), then repo-config reading (ports, existing suites, testDir).
