### PR TITLE
Feat: add fixed-repo benchmark runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ qamap.sarif
 .env
 .env.*
 !.env.example
+bench.config.local.json
+bench-results/

--- a/bench.config.example.json
+++ b/bench.config.example.json
@@ -1,0 +1,25 @@
+{
+  "$comment": "Copy to bench.config.local.json (gitignored) and point targets at real repositories with pinned commits. The runner is read-only against every target.",
+  "targets": [
+    {
+      "name": "example-web-app",
+      "path": "~/Desktop/example-web-app",
+      "base": "<base-sha>",
+      "head": "<head-sha>",
+      "expect": {
+        "runner": "playwright",
+        "mustReachFiles": ["app/checkout/page.tsx"],
+        "mustNameFlows": ["checkout"]
+      }
+    },
+    {
+      "name": "example-mobile-app",
+      "path": "~/Desktop/example-mobile-app",
+      "base": "<base-sha>",
+      "head": "<head-sha>",
+      "expect": {
+        "runner": "maestro"
+      }
+    }
+  ]
+}

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,30 @@
+# Benchmarking QAMap
+
+`scripts/bench.mjs` scores QAMap's plan/qa output against a fixed set of repositories with pinned commits, so heuristic changes can be judged by numbers instead of feel. The runner is read-only against every target.
+
+## Setup
+
+1. Copy `bench.config.example.json` to `bench.config.local.json` (gitignored).
+2. Point each target at a local repository checkout, pin `base`/`head` commit SHAs, and optionally declare expectations:
+   - `expect.runner` — the runner a human would pick for this repo (`playwright`, `maestro`, `manual`).
+   - `expect.mustReachFiles` — files a human QA would name for this diff window; recall against generated flows is reported.
+   - `expect.mustNameFlows` — substrings that should appear in at least one flow title.
+
+## Run
+
+```sh
+pnpm bench                      # table only
+node scripts/bench.mjs --save   # also writes bench-results/<timestamp>.json
+node scripts/bench.mjs --baseline bench-results/<file>.json   # delta vs a saved run
+```
+
+## Metrics
+
+- `runner` mismatch lines — wrong tool recommendation for a known repo shape.
+- `viaImport` — flows produced through the reverse import graph (shared-file changes reaching surfaces).
+- `blank` — steps with blank action slots (must stay 0).
+- `generic` — flows with content-free names (`... primary journey`, `... smoke flow`); lower is better.
+- `reach` — recall of `mustReachFiles`; missing files are listed per target.
+- `agentBytes` — size of the `--format agent` payload.
+
+Re-run with `--baseline` before merging heuristic changes; a PR that moves these numbers should say so in its body.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "coverage": "pnpm build && node --test --experimental-test-coverage --test-coverage-include=\"dist/**/*.js\" --test-coverage-lines=80 --test-coverage-branches=80 --test-coverage-functions=80 test/*.test.mjs",
     "scan": "pnpm build && node dist/cli.js scan .",
     "report": "pnpm build && node dist/cli.js report . --output QAMAP_REPORT.md",
-    "release:check": "pnpm test && pnpm scan && git diff --check && pnpm run coverage && pnpm pack --dry-run"
+    "release:check": "pnpm test && pnpm scan && git diff --check && pnpm run coverage && pnpm pack --dry-run",
+    "bench": "pnpm build && node scripts/bench.mjs"
   },
   "keywords": [
     "ai",

--- a/scripts/bench.mjs
+++ b/scripts/bench.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+// QAMap benchmark runner: scores plan/qa output quality against a fixed set of
+// repositories with pinned base/head commits. Read-only against every target.
+//
+// Usage:
+//   node scripts/bench.mjs [--config bench.config.local.json] [--save] [--baseline bench-results/<file>.json]
+//
+// Config format (see bench.config.example.json):
+//   { "targets": [ { "name", "path", "base", "head",
+//       "expect": { "runner", "mustReachFiles": [], "mustNameFlows": [] } } ] }
+
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { formatAgentQaDraft, generateE2ePlan, generateQaDraft } from "../dist/index.js";
+
+const args = process.argv.slice(2);
+const configPath = readArg("--config") ?? "bench.config.local.json";
+const baselinePath = readArg("--baseline");
+const save = args.includes("--save");
+
+const config = JSON.parse(await fs.readFile(configPath, "utf8"));
+const results = [];
+
+for (const target of config.targets) {
+  const root = expandHome(target.path);
+  const options = { base: target.base, head: target.head };
+  const startedAt = Date.now();
+  let plan;
+  let qa;
+  try {
+    plan = await generateE2ePlan(root, options);
+    qa = await generateQaDraft(root, { ...options, runner: undefined });
+  } catch (error) {
+    results.push({ name: target.name, error: String(error && error.message ? error.message : error) });
+    continue;
+  }
+  const durationMs = Date.now() - startedAt;
+
+  const flowSteps = plan.flows.flatMap((flow) => flow.steps);
+  const draftSteps = qa.flows.flatMap((flow) => flow.draftSteps ?? []);
+  const allSteps = [...flowSteps, ...draftSteps];
+  const blankActionPattern = /Fill\s{2,}|using \.\s*$|\s{2,}with realistic data/;
+  const genericTitlePattern = /(?:primary journey|smoke flow|smoke checklist)$/i;
+
+  const expect = target.expect ?? {};
+  const flowFiles = new Set(plan.flows.flatMap((flow) => flow.files));
+  const mustReach = expect.mustReachFiles ?? [];
+  const reached = mustReach.filter((file) => flowFiles.has(file));
+  const flowTitles = plan.flows.map((flow) => flow.title.toLowerCase());
+  const mustName = expect.mustNameFlows ?? [];
+  const named = mustName.filter((name) => flowTitles.some((title) => title.includes(name.toLowerCase())));
+
+  results.push({
+    name: target.name,
+    runner: plan.recommendedRunner.name,
+    runnerExpected: expect.runner ?? null,
+    runnerCorrect: expect.runner ? plan.recommendedRunner.name === expect.runner : null,
+    flows: plan.flows.length,
+    genericTitles: plan.flows.filter((flow) => genericTitlePattern.test(flow.title)).length,
+    importPropagatedFlows: plan.flows.filter((flow) => flow.reason.includes("through imports")).length,
+    blankActions: allSteps.filter((step) => blankActionPattern.test(step)).length,
+    mustReachRecall: mustReach.length > 0 ? `${reached.length}/${mustReach.length}` : null,
+    mustReachMissing: mustReach.filter((file) => !flowFiles.has(file)),
+    mustNameRecall: mustName.length > 0 ? `${named.length}/${mustName.length}` : null,
+    readiness: `${qa.readiness.level} (${qa.readiness.score})`,
+    agentBytes: formatAgentQaDraft(qa).length,
+    durationMs,
+  });
+}
+
+printTable(results);
+
+if (baselinePath) {
+  const baseline = JSON.parse(await fs.readFile(baselinePath, "utf8"));
+  printDeltas(baseline.results ?? baseline, results);
+}
+
+if (save) {
+  await fs.mkdir("bench-results", { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const outputPath = path.join("bench-results", `bench-${stamp}.json`);
+  await fs.writeFile(outputPath, `${JSON.stringify({ config: configPath, results }, null, 2)}\n`);
+  console.log(`\nSaved: ${outputPath}`);
+}
+
+function printTable(rows) {
+  const columns = [
+    ["name", 22],
+    ["runner", 11],
+    ["flows", 5],
+    ["importPropagatedFlows", 10],
+    ["blankActions", 6],
+    ["genericTitles", 8],
+    ["mustReachRecall", 10],
+    ["readiness", 18],
+    ["agentBytes", 10],
+    ["durationMs", 10],
+  ];
+  const header = columns.map(([key, width]) => shortLabel(key).padEnd(width)).join(" ");
+  console.log(header);
+  console.log("-".repeat(header.length));
+  for (const row of rows) {
+    if (row.error) {
+      console.log(`${row.name.padEnd(22)} ERROR: ${row.error}`);
+      continue;
+    }
+    console.log(
+      columns
+        .map(([key, width]) => String(row[key] ?? "-").padEnd(width))
+        .join(" "),
+    );
+    if (row.runnerCorrect === false) {
+      console.log(`  ! runner mismatch: expected ${row.runnerExpected}, got ${row.runner}`);
+    }
+    if (row.mustReachMissing && row.mustReachMissing.length > 0) {
+      console.log(`  ! not reached: ${row.mustReachMissing.join(", ")}`);
+    }
+  }
+}
+
+function printDeltas(baselineRows, currentRows) {
+  console.log("\nDelta vs baseline (numeric metrics; negative blankActions/genericTitles is better):");
+  for (const current of currentRows) {
+    const before = baselineRows.find((row) => row.name === current.name);
+    if (!before || current.error || before.error) {
+      continue;
+    }
+    const deltas = [];
+    for (const key of ["flows", "importPropagatedFlows", "blankActions", "genericTitles", "agentBytes"]) {
+      const diff = (current[key] ?? 0) - (before[key] ?? 0);
+      if (diff !== 0) {
+        deltas.push(`${key} ${diff > 0 ? "+" : ""}${diff}`);
+      }
+    }
+    console.log(`- ${current.name}: ${deltas.length > 0 ? deltas.join(", ") : "no change"}`);
+  }
+}
+
+function shortLabel(key) {
+  const labels = {
+    importPropagatedFlows: "viaImport",
+    blankActions: "blank",
+    genericTitles: "generic",
+    mustReachRecall: "reach",
+    durationMs: "ms",
+  };
+  return labels[key] ?? key;
+}
+
+function readArg(flag) {
+  const index = args.indexOf(flag);
+  return index === -1 ? undefined : args[index + 1];
+}
+
+function expandHome(value) {
+  return value.startsWith("~/") ? path.join(os.homedir(), value.slice(2)) : value;
+}


### PR DESCRIPTION
## Intent

Make "test while improving" repeatable: add a read-only benchmark runner that scores QAMap's plan/qa output against a fixed set of repositories with pinned base/head commits. Heuristic PRs can now report a before/after metric table instead of subjective judgment.

- `scripts/bench.mjs` + `pnpm bench`: per target reports runner-choice correctness, flows produced through the reverse import graph, blank-action steps, content-free flow names, `mustReachFiles` recall, readiness, `--format agent` payload size, and duration; `--save` writes JSON, `--baseline` prints deltas against a saved run.
- `bench.config.example.json` is committed; the real target list lives in gitignored `bench.config.local.json`, so private repositories never enter the public repo.
- `docs/benchmarking.md` documents setup, metrics, and the pre-merge delta workflow.

## Agent / Review Risk

- No product-code changes; the runner only imports the published API from `dist/` and never writes into target repositories.
- Results files and the local config are gitignored.

## Validation Evidence

- [x] `pnpm test` (98/98)
- [x] `pnpm bench` run against four pinned local repositories (web, API server, Expo app, Vue legacy): table renders, mismatches and metrics report correctly, baseline JSON saved.

## E2E / Manual Coverage

- First baseline recorded: blank actions 0 on all four targets (the non-Latin label fix holds on real Korean-language repos), one import-propagated flow appears, and one runner mismatch is surfaced (a frontend repo detected as `manual`) — exactly the class of regression this harness exists to catch.

## Maintainer Notes

- Enrich `bench.config.local.json` over time with `mustReachFiles` per pinned window (the files a human QA would name); recall against those labels is the single most meaningful number here.
- Follow-up candidates: wire `pnpm bench --baseline` into the release checklist, and add public fixture repos so contributors without the private targets can run the same harness.
