### PR TITLE
Fix: detect project type through workspace member dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Monorepo roots without framework dependencies of their own (turbo/pnpm/yarn workspaces where apps live under `apps/`, `services/`, or `packages/`) are no longer classified as unknown/manual: project detection now aggregates workspace member dependencies, with per-member evidence, so a frontend monorepo gets a web/Playwright recommendation at the root.
+
 ### Added
 
 - Added a reverse import graph: when only shared components, hooks, or library files change, QAMap now follows imports (2 hops, tsconfig paths and workspace package names included) to the pages and screens that consume them, generates the consuming surface's UI flow with the import chain as evidence, and matches verification/flow/domain manifests through the same expansion.

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -1,5 +1,6 @@
 import { promises as fs, type Dirent } from "node:fs";
 import path from "node:path";
+import YAML from "yaml";
 import { buildDomainLanguageSummary } from "./domain-language.js";
 import { defaultDomainManifestPath, loadDomainManifest, matchDomains } from "./domains.js";
 import { collectProjectFiles } from "./fs.js";
@@ -406,6 +407,7 @@ interface PackageJson {
   devDependencies?: Record<string, string>;
   scripts?: Record<string, string>;
   bin?: string | Record<string, string>;
+  workspaces?: string[] | { packages?: string[] };
 }
 
 const maxFilesPerFlow = 8;
@@ -3016,6 +3018,28 @@ export function formatMarkdownE2eSetup(result: E2eSetupResult): string {
   return lines.join("\n");
 }
 
+const frameworkSignalDependencies = [
+  "expo",
+  "react-native",
+  "@playwright/test",
+  "playwright",
+  "@angular/core",
+  "@remix-run/react",
+  "astro",
+  "next",
+  "nuxt",
+  "react-dom",
+  "react-router-dom",
+  "svelte",
+  "vue",
+  "vite",
+  "@nestjs/core",
+  "express",
+  "fastify",
+  "koa",
+  "hono",
+];
+
 async function detectProjectProfile(root: string, workspaceRoot?: string): Promise<E2eProjectProfile> {
   const profileRoots = profileSearchRoots(root, workspaceRoot);
   const packageJson = await readPackageJson(root);
@@ -3027,6 +3051,21 @@ async function detectProjectProfile(root: string, workspaceRoot?: string): Promi
     ...(packageJson?.devDependencies ?? {}),
   };
   const evidence: string[] = [];
+
+  const rootHasFrameworkSignal = frameworkSignalDependencies.some((dependency) => dependency in dependencies);
+  if (!rootHasFrameworkSignal) {
+    const memberDependencies = await collectWorkspaceMemberDependencies(root, packageJson);
+    for (const member of memberDependencies) {
+      for (const [dependency, version] of Object.entries(member.dependencies)) {
+        if (!(dependency in dependencies)) {
+          dependencies[dependency] = version;
+        }
+      }
+      if (member.frameworkSignals.length > 0) {
+        evidence.push(`workspace member ${member.directory}: ${member.frameworkSignals.join(", ")}`);
+      }
+    }
+  }
 
   const hasExpoDependency = "expo" in dependencies;
   const hasReactNativeDependency = "react-native" in dependencies;
@@ -8768,6 +8807,87 @@ async function readPackageJson(root: string): Promise<PackageJson | undefined> {
   } catch {
     return undefined;
   }
+}
+
+interface WorkspaceMemberDependencies {
+  directory: string;
+  dependencies: Record<string, string>;
+  frameworkSignals: string[];
+}
+
+const maxWorkspaceMembers = 30;
+
+async function collectWorkspaceMemberDependencies(
+  root: string,
+  packageJson: PackageJson | undefined,
+): Promise<WorkspaceMemberDependencies[]> {
+  const patterns = await readWorkspaceMemberPatterns(root, packageJson);
+  if (patterns.length === 0) {
+    return [];
+  }
+  const memberDirectories = await expandWorkspaceMemberPatterns(root, patterns);
+  const members: WorkspaceMemberDependencies[] = [];
+  for (const directory of memberDirectories.slice(0, maxWorkspaceMembers)) {
+    const memberPackageJson = await readPackageJson(path.join(root, directory));
+    if (!memberPackageJson) {
+      continue;
+    }
+    const dependencies = {
+      ...(memberPackageJson.dependencies ?? {}),
+      ...(memberPackageJson.devDependencies ?? {}),
+    };
+    members.push({
+      directory,
+      dependencies,
+      frameworkSignals: frameworkSignalDependencies.filter((dependency) => dependency in dependencies),
+    });
+  }
+  return members;
+}
+
+async function readWorkspaceMemberPatterns(root: string, packageJson: PackageJson | undefined): Promise<string[]> {
+  const patterns: string[] = [];
+  const workspaces = packageJson?.workspaces;
+  if (Array.isArray(workspaces)) {
+    patterns.push(...workspaces);
+  } else if (workspaces?.packages) {
+    patterns.push(...workspaces.packages);
+  }
+  const workspaceYaml = await readTextIfExists(path.join(root, "pnpm-workspace.yaml"));
+  if (workspaceYaml) {
+    try {
+      const parsed = YAML.parse(workspaceYaml) as { packages?: string[] };
+      patterns.push(...(parsed?.packages ?? []));
+    } catch {
+      // ignore unparseable workspace config
+    }
+  }
+  return uniqueStrings(patterns.filter((pattern) => typeof pattern === "string" && !pattern.startsWith("!")));
+}
+
+async function expandWorkspaceMemberPatterns(root: string, patterns: string[]): Promise<string[]> {
+  const directories: string[] = [];
+  for (const pattern of patterns) {
+    const normalized = pattern.replace(/\/\*{1,2}$/, "");
+    if (normalized.includes("*")) {
+      continue;
+    }
+    if (normalized === pattern) {
+      directories.push(normalized);
+      continue;
+    }
+    try {
+      const entries = await fs.readdir(path.join(root, normalized), { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory() && !entry.name.startsWith(".")) {
+          directories.push(`${normalized}/${entry.name}`);
+        }
+      }
+    } catch {
+      continue;
+    }
+  }
+  return uniqueStrings(directories);
 }
 
 async function readTextIfExists(filePath: string): Promise<string | undefined> {

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -500,7 +500,8 @@ test("generateE2ePlan surfaces package-scoped targets for monorepo root changes"
   const mobileTarget = plan.workspaceTargets.find((target) => target.path === "apps/mobile");
   const offerTarget = plan.workspaceTargets.find((target) => target.path === "services/offer");
 
-  assert.equal(plan.project.type, "unknown");
+  assert.equal(plan.project.type, "expo-react-native");
+  assert.ok(plan.project.evidence.some((item) => item.startsWith("workspace member apps/mobile:")));
   assert.equal(plan.workspaceTargets.length, 2);
   assert.ok(mobileTarget);
   assert.equal(mobileTarget.packageName, "@fixture/mobile");


### PR DESCRIPTION
## Intent

Fix the top failure surfaced by the new fixed-repo benchmark: a frontend monorepo whose root `package.json` contains only tooling (turbo/eslint/prettier) was classified as unknown and recommended `manual`, because project detection only read root-level dependencies. This is the same failure shape previously observed on a public Vue/pnpm-workspace repository.

- Project detection now aggregates workspace member dependencies when the root has no framework signals of its own: members are resolved from `package.json` `workspaces` globs and `pnpm-workspace.yaml` (up to 30 members), and each contributing member is named in the evidence (`workspace member services/manager: react-dom`).
- Monorepo roots therefore inherit an app profile (web/Expo/API) instead of unknown, so the root-level runner recommendation is usable; per-package workspace targets are unchanged.

## Agent / Review Risk

- Detection changes only fire when the root has zero framework dependencies AND workspace member patterns exist, so single-package repos and CLI packages (including this one) are unaffected.
- Mixed monorepos (mobile + web members) resolve by the existing priority order (Expo before web) — the previously pinned root type `unknown` for that fixture was updated to reflect the intended new behavior.

## Validation Evidence

- [x] `pnpm test` (98/98; monorepo fixture expectation updated to the new behavior)
- [x] `pnpm bench --baseline`: the misdetected frontend monorepo now reports `playwright` (was `manual`); the other three pinned targets are byte-for-byte unchanged except agent payload growing with the corrected profile.

## E2E / Manual Coverage

- Verified read-only against the pinned team benchmark targets; no files are written into benchmark repositories.

## Maintainer Notes

- Follow-up candidate: when all changed files fall inside a single workspace member, the root recommendation could adopt that member's profile outright (today the aggregate profile plus scoped-target commands cover it).
