### PR TITLE
Fix: classify prefixed and module-directory python service files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Django-style Python service files with prefixed names (`views_campaigns.py`) or module directories (`views/seeding_creator.py`, `internal_ops/`) are now classified as service sources, so backend changes join API contract flows instead of disappearing from the plan.
+
 - Monorepo roots without framework dependencies of their own (turbo/pnpm/yarn workspaces where apps live under `apps/`, `services/`, or `packages/`) are no longer classified as unknown/manual: project detection now aggregates workspace member dependencies, with per-member evidence, so a frontend monorepo gets a web/Playwright recommendation at the root.
 
 ### Added

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -5173,7 +5173,8 @@ function routeSegmentsFromFileParts(parts: string[]): string[] {
 function isBackendImplementationFile(file: string): boolean {
   return /(?:^|\/)(?:server|servers|backend|api|apis|routes|controllers?|handlers?|resolvers?|endpoints?)\//i.test(file) ||
     /(?:openapi|swagger|schema|controller|handler|resolver|route)\.(?:json|ya?ml|[cm]?[jt]sx?|py|go|rs|kt|java|rb|php)$/i.test(file) ||
-    /(?:^|\/)(?:urls|views|serializers|routers|controllers?|handlers?|admin|models|services|tasks|permissions|filters)\.py$/i.test(file);
+    /(?:^|\/)(?:urls|views|viewsets|serializers|routers|controllers?|handlers?|admin|models|services|tasks|permissions|filters|consumers|signals)\w*\.py$/i.test(file) ||
+    /(?:^|\/)(?:views|viewsets|serializers|services|routers|handlers|tasks|consumers|internal_ops)\/[^/]+\.py$/i.test(file);
 }
 
 function isMockOrFixtureFile(file: string): boolean {
@@ -5758,7 +5759,8 @@ function isUiImplementationFile(file: string): boolean {
 
 function isServiceSourceFile(file: string): boolean {
   return /(?:^|\/)src\/.+\.(?:[cm]?[jt]s|py|go|rs|java|kt|cs)$/i.test(file) ||
-    /(?:^|\/)(?:urls|views|serializers|routers|controllers?|handlers?|admin|models|services|tasks|permissions|filters)\.py$/i.test(file);
+    /(?:^|\/)(?:urls|views|viewsets|serializers|routers|controllers?|handlers?|admin|models|services|tasks|permissions|filters|consumers|signals)\w*\.py$/i.test(file) ||
+    /(?:^|\/)(?:views|viewsets|serializers|services|api|apis|routers|handlers|tasks|consumers|internal_ops)\/[^/]+\.py$/i.test(file);
 }
 
 function summarizeFlowSubject(files: string[], fallback: string, domainLanguage?: DomainLanguageSummary): string {

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -4724,6 +4724,32 @@ test("verification manifest flows match when changed files are imported by ancho
   );
 });
 
+test("django service files with prefixed or module-directory names join api flows", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "offers/views"), { recursive: true });
+  await mkdir(path.join(root, "offers/internal_ops"), { recursive: true });
+  await writeFile(path.join(root, "manage.py"), "#!/usr/bin/env python\n");
+  await writeFile(path.join(root, "requirements.txt"), "django==5.0\n");
+  await writeFile(path.join(root, "offers/views/seeding_creator.py"), "def seeding_creator(request):\n    return None\n");
+  await writeFile(path.join(root, "offers/internal_ops/views_campaigns.py"), "def campaigns(request):\n    return None\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/campaign-sort"]);
+  await writeFile(path.join(root, "offers/views/seeding_creator.py"), "def seeding_creator(request):\n    return {\"sorted\": True}\n");
+  await writeFile(path.join(root, "offers/internal_ops/views_campaigns.py"), "def campaigns(request):\n    return {\"sorted\": True}\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "sort campaigns"]);
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const flowFiles = plan.flows.flatMap((flow) => flow.files);
+  assert.ok(flowFiles.includes("offers/views/seeding_creator.py"));
+  assert.ok(flowFiles.includes("offers/internal_ops/views_campaigns.py"));
+  assert.ok(plan.flows.some((flow) => /API contract/i.test(flow.title)));
+});
+
 test("generated drafts are not counted as test-suite evidence", async () => {
   const root = await makeTempRepo();
   await initGitRepo(root);


### PR DESCRIPTION
## Intent

Fix the second failure surfaced by the fixed-repo benchmark: on a Django API server, the changed view files a human QA would name first never appeared in any flow (`mustReachFiles` recall 0/2), because Python service classification only matched exact basenames like `views.py`.

- `isServiceSourceFile` and `isBackendImplementationFile` now also match prefixed service filenames (for example `views_summary.py`) and files inside service module directories (`views/`, `serializers/`, `services/`, `tasks/`, ...).
- With the real changed files in the flow, domain language names the flow concretely instead of "Changed API contract smoke checklist".

## Agent / Review Risk

- Pattern widening only; Django `settings/*.py` and test files remain excluded by the existing config/test filters.
- `isBackendImplementationFile` also feeds fixture readiness and changed-endpoint observation, so backend Python changes now register there too.

## Validation Evidence

- [x] `pnpm test` (99/99; new Django-shaped regression test)
- [x] `pnpm bench --baseline`: the Django target's must-reach recall moved 0/2 → 2/2; the other three pinned targets are unchanged. All four targets now sit at full recall (9/9 labeled files reached).

## E2E / Manual Coverage

- Verified read-only against the pinned team benchmark; flow output for the Django window now anchors on the changed view files.

*(Edited: fixture examples replaced with neutral names; see #78.)*
