### PR TITLE
Feat: greet bare qamap runs with a start-here guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Running `qamap` with no arguments now prints a short "start here" guide (the three core commands and when to use them) instead of the full 25-command usage wall; the full reference moved to `qamap help` and stays on `--help`.
+
 ### Added
 
 - Draft steps and assertions now prefer selectors and labels that the diff itself introduced: added `aria-label`/`data-testid`/`testID`/placeholder values rank first when binding actions, so generated specs exercise what the change added instead of pre-existing UI. Selectors carry an `addedInDiff` marker in JSON output, and the benchmark runner reports a `diffAnchor` metric.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -85,7 +85,12 @@ interface ParsedOptions {
 async function main(argv: string[]): Promise<number> {
   const [command, ...rest] = argv;
 
-  if (!command || command === "--help" || command === "-h") {
+  if (!command) {
+    printStartHere();
+    return 0;
+  }
+
+  if (command === "help" || command === "--help" || command === "-h") {
     printHelp();
     return 0;
   }
@@ -875,6 +880,30 @@ function readValue(args: string[], index: number, flag: string): string {
     throw new Error(`Missing value for ${flag}`);
   }
   return value;
+}
+
+function printStartHere(): void {
+  console.log(`QAMap ${VERSION} — local-first PR QA for AI-assisted changes.
+
+Start here, from inside your repository, on the branch you want to check:
+
+  qamap qa
+      What should this branch prove before merge? Prints the affected user
+      flow, recommended E2E runner, missing evidence, and a PR checklist.
+      The base branch defaults to origin/main (then main); override with
+      --base <ref> --head <ref>.
+
+  qamap e2e setup . --runner playwright
+      No tests yet? Create the runner config plus a first runnable starter
+      spec for the changed flow, then run it with: npm run test:e2e
+
+  qamap manifest init
+      Save reviewed team QA language to .qamap/manifest.yaml so future
+      branches get sharper recommendations. Optional — qa works without it.
+
+Handing the result to a coding agent? Add: --format agent
+
+Full command reference: qamap help`);
 }
 
 function printHelp(): void {


### PR DESCRIPTION
## Intent

Make the first contact with the CLI intuitive. Running bare `qamap` used to print a 25-command usage wall; a first-time user could not tell where to start.

- Bare `qamap` now prints a short start-here guide: the three core commands (`qa`, `e2e setup`, `manifest init`), what each answers, that the base branch is inferred from origin/main automatically, and the `--format agent` hint for coding agents.
- The full command reference moved to `qamap help` and remains available via `--help`/`-h`, so scripts and documentation links keep working.

## Agent / Review Risk

- Exit codes and every existing invocation are unchanged; only the zero-argument output differs.

## Validation Evidence

- [x] `pnpm test` (100/100)
- [x] Manually verified: bare `qamap` prints the guide; `qamap help` and `qamap --help` print the full reference.
