### PR TITLE
Chore: release 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,29 +2,27 @@
 
 ## Unreleased
 
-### Changed
-
-- Running `qamap` with no arguments now prints a short "start here" guide (the three core commands and when to use them) instead of the full 25-command usage wall; the full reference moved to `qamap help` and stays on `--help`.
-
-### Added
-
-- Draft steps and assertions now prefer selectors and labels that the diff itself introduced: added `aria-label`/`data-testid`/`testID`/placeholder values rank first when binding actions, so generated specs exercise what the change added instead of pre-existing UI. Selectors carry an `addedInDiff` marker in JSON output, and the benchmark runner reports a `diffAnchor` metric.
-- Domain scenarios are named after the action the diff introduced when an added element label makes one clear (for example "Checkout Submit" instead of "Checkout primary journey"), reducing content-free flow names.
-
-### Fixed
-
-- Django-style Python service files with prefixed names (`views_summary.py`) or inside service module directories (`views/report_export.py`) are now classified as service sources, so backend changes join API contract flows instead of disappearing from the plan.
-
-- Monorepo roots without framework dependencies of their own (turbo/pnpm/yarn workspaces where apps live under `apps/`, `services/`, or `packages/`) are no longer classified as unknown/manual: project detection now aggregates workspace member dependencies, with per-member evidence, so a frontend monorepo gets a web/Playwright recommendation at the root.
+## 0.3.2 - 2026-07-04
 
 ### Added
 
 - Added a reverse import graph: when only shared components, hooks, or library files change, QAMap now follows imports (2 hops, tsconfig paths and workspace package names included) to the pages and screens that consume them, generates the consuming surface's UI flow with the import chain as evidence, and matches verification/flow/domain manifests through the same expansion.
+- Draft steps and assertions now prefer selectors and labels that the diff itself introduced: added `aria-label`/`data-testid`/`testID`/placeholder values rank first when binding actions, gated by step intent so added status copy becomes an assertion target rather than a click target. Selectors carry an `addedInDiff` marker in JSON output.
+- Domain scenarios are named after the action the diff introduced when an added element label makes one clear (for example "Checkout Submit" instead of "Checkout primary journey"), and labels carrying an action word win over plain field labels.
+- Added `scripts/bench.mjs` (`pnpm bench`): a read-only benchmark runner that scores plan/qa output against pinned repositories, with runner-accuracy, must-reach recall, import-propagation, diff-anchoring, blank-action, and generic-title metrics; documented in `docs/benchmarking.md`.
+
+### Changed
+
+- Running `qamap` with no arguments now prints a short "start here" guide (the three core commands and when to use them) instead of the full usage wall; the full reference moved to `qamap help` and stays on `--help`.
+- The README demo is a real, unedited terminal recording of the zero-tests-to-passing-E2E loop against the published package, replacing the earlier staged walkthrough.
+- Fixtures, documentation examples, and CLI usage samples were standardized on a clearly invented demo vocabulary so examples cannot be mistaken for any real product.
 
 ### Fixed
 
+- Monorepo roots without framework dependencies of their own (turbo/pnpm/yarn workspaces where apps live under `apps/`, `services/`, or `packages/`) are no longer classified as unknown/manual: project detection aggregates workspace member dependencies, with per-member evidence, so a frontend monorepo gets a web/Playwright recommendation at the root.
+- Django-style Python service files with prefixed names (`views_summary.py`) or inside service module directories (`views/report_export.py`) are now classified as service sources, so backend changes join API contract flows instead of disappearing from the plan.
 - Draft steps no longer emit blank actions for non-Latin UI labels: Korean (and any Unicode) placeholder, aria-label, and button text now survives step naming, with a selector-kind fallback when a label is symbol-only.
-- Domain scenario names no longer duplicate the "primary journey" suffix (for example "Notification Primary Journey primary journey").
+- Domain scenario names no longer duplicate the "primary journey" suffix.
 
 ## 0.3.1 - 2026-07-03
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ Optional team memory
 
 Requires Node.js 20 or newer.
 
-Run QAMap once without adding a dependency:
+Run QAMap once without adding a dependency. Inside a repository whose default branch is `origin/main` (or `main`), the base is inferred automatically:
 
 ```sh
-pnpm dlx @ivorycanvas/qamap qa . --base origin/main --head HEAD
+pnpm dlx @ivorycanvas/qamap qa
 ```
+
+Pass `--base <ref> --head <ref>` for anything non-standard, and run bare `qamap` any time to see the start-here guide (`qamap help` prints the full reference).
 
 That first command is intentionally manifest-free. It previews a PR comment/checklist that names the affected flow, recommended runner, draft file, missing fixture/selector/assertion evidence, and validation command.
 
@@ -303,7 +305,7 @@ pnpm build
 node dist/cli.js scan /path/to/repo
 ```
 
-QAMap `0.2.x` is a local-first PR verification planner with a repository-level verification manifest loop, not a finished automatic QA bot. A good result is a clear answer to "what should this branch prove before merge?", plus manifest-backed E2E, fixture, selector, and validation work that a developer can turn into real regression coverage. Many first drafts will correctly report `review-only` or `near-runnable` until the project adds runner config, stable selectors, deterministic fixtures, or team-owned manifest entries.
+QAMap is a local-first PR verification planner with a repository-level verification manifest loop, not a finished automatic QA bot. A good result is a clear answer to "what should this branch prove before merge?", plus manifest-backed E2E, fixture, selector, and validation work that a developer can turn into real regression coverage. Many first drafts will correctly report `review-only` or `near-runnable` until the project adds runner config, stable selectors, deterministic fixtures, or team-owned manifest entries.
 
 ## What QAMap Produces
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -40,7 +40,7 @@ jobs:
 ```
 
 Use `fetch-depth: 0` so QAMap can compare the pull request branch with the base ref.
-For production workflows, pin to a version tag such as `IvoryCanvas/qamap@v0.3.1` after that tag is published. Use `@main` only when intentionally testing unreleased behavior.
+For production workflows, pin to a version tag such as `IvoryCanvas/qamap@v0.3.2` after that tag is published. Use `@main` only when intentionally testing unreleased behavior.
 
 ## Monorepo Package
 

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -1,4 +1,20 @@
-# 0.2.1 Patch Release Validation
+# Release Validation
+
+## 0.3.2 - 2026-07-04
+
+Validated before publishing `0.3.2` (reverse import graph, diff-anchored steps and names, workspace-member project detection, Python service classification, start-here CLI guide):
+
+| Gate | Result |
+| --- | --- |
+| `pnpm test` | 100/100 passing |
+| `pnpm scan` (self-scan) | 0 findings |
+| Coverage thresholds (lines/branches/functions >= 80) | Passing |
+| `pnpm bench` against four pinned local benchmark targets (web monorepo, Python API server, Expo app, legacy Vue app) | Runner choice 4/4, labeled must-reach recall 9/9, blank actions 0, no metric regressions vs the previous baseline |
+| README demo | Real recorded run; the generated starter spec passes against the demo app |
+
+Historical validation notes for earlier releases follow below.
+
+# 0.2.1 Patch Release Validation (historical)
 
 QAMap should not publish a patch or minor version only because the CLI commands work in fixtures. The `0.2.1` release should prove that the manifest-backed QA skill flow is useful across representative repositories without requiring an LLM call.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -45,7 +45,6 @@ Before treating the next public release as ready, the golden demo must satisfy t
 - Improve `doctor` output with clearer scoring and remediation grouping.
 - Improve `review` output for changed-line locations.
 - Expand manifest support with richer anchors, symbol-level matching, and configurable taste rubrics.
-- Match changed files to flows through a reverse import graph, not only declared anchor paths, so shared component and hook changes map to the flows that depend on them.
 - Map changed symbols to manifest anchors after the path/route baseline is stable.
 - Keep the `--format agent` output a stable, versioned contract that skills and MCP wrappers can rely on.
 - Add language-specific domain patterns for backend services, CLIs, libraries, mobile apps, and infrastructure repositories.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Local-first QA skill that turns PR diffs into affected flows, missing evidence, and E2E drafts with no cloud or LLM token.",
   "type": "module",
   "packageManager": "pnpm@10.32.1",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const TOOL_NAME = "QAMap";
-export const VERSION = "0.3.1";
+export const VERSION = "0.3.2";


### PR DESCRIPTION
## Intent

Prepare the `0.3.2` release: version bump, dated changelog, and documentation refresh.

- CHANGELOG consolidates everything shipped since `0.3.1` under `0.3.2 - 2026-07-04` (reverse import graph, diff-anchored steps and names, workspace-member project detection, Python service classification, start-here CLI guide, benchmark runner, real demo recording, invented demo vocabulary).
- README: version-free positioning line, and the quick start now leads with the zero-flag `qamap qa` form since the base branch is inferred automatically.
- docs/github-action.md pins the example to `@v0.3.2`; docs/roadmap.md drops the now-shipped import-graph item; docs/release-validation.md gains a dated 0.3.2 gate table and marks earlier notes as historical.

## Agent / Review Risk

- Docs and version metadata only; no engine changes.

## Validation Evidence

- [x] `pnpm run release:check` (build, 100/100 tests, self-scan 0 findings, whitespace check, coverage thresholds, `pnpm pack --dry-run` for `ivorycanvas-qamap-0.3.2.tgz`)

## Maintainer Notes

- After merge: publish from a clean `main` checkout, then tag `v0.3.2` and publish the GitHub release.
