### PR TITLE
Feat: open qa reports with an at-a-glance verdict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- `qamap qa` now opens with an At a Glance section — the affected flows in one line, the single next command to run, and the one or two blocking evidence items — before the detailed report. Execution blockers already covered by a required action are no longer repeated, required items sort before recommended ones, and the missing-evidence list is capped with a summary line.
+
 ## 0.3.2 - 2026-07-04
 
 ### Added

--- a/skills/qamap-pr-qa/SKILL.md
+++ b/skills/qamap-pr-qa/SKILL.md
@@ -45,7 +45,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
    - `requiredBootstrap[]` — setup steps that block trusting generated drafts.
    - `firstDraftCommand` — present only when the repo has no test suite; run it to create the first starter draft.
    - `prChecklist[]` and `commands[]` — checklist lines and validation commands for the handoff.
-   In markdown format, read the `PR Comment Draft`, `Missing Evidence Before Trusting This PR`, and `PR Checklist` sections.
+   In markdown format, start from `At a Glance` (affected flows, the single next command, blocking items), then read the `PR Comment Draft`, `Missing Evidence Before Trusting This PR`, and `PR Checklist` sections.
 6. Include the useful parts in the PR body, review note, or handoff summary.
 
 ## Output Rules

--- a/src/qa.ts
+++ b/src/qa.ts
@@ -148,6 +148,25 @@ export function formatMarkdownQaDraft(result: QaDraftResult): string {
   lines.push("");
   lines.push("> Local-first PR QA skill output. No cloud. No LLM token. Manifest is optional, not required for first use.");
   lines.push("");
+  lines.push("## At a Glance");
+  lines.push("");
+  if (result.flows.length === 0) {
+    lines.push("- Affected: no changed flow candidate was generated from this diff.");
+  } else {
+    const flowTitles = result.flows.slice(0, 3).map((flow) => escapeMarkdownInline(flow.title)).join(", ");
+    const moreFlows = result.flows.length > 3 ? ` and ${result.flows.length - 3} more` : "";
+    lines.push(`- Affected: ${flowTitles}${moreFlows}`);
+  }
+  lines.push(`- Do next: \`${escapeMarkdownInline(nextStepCommand(result))}\``);
+  const blocking = result.missingEvidence.filter((item) => item.priority === "required").slice(0, 2);
+  if (blocking.length === 0) {
+    lines.push("- Blocking: nothing blocking detected; review the draft and run the validation command.");
+  } else {
+    for (const [index, item] of blocking.entries()) {
+      lines.push(`- Blocking${blocking.length > 1 ? ` ${index + 1}` : ""}: ${escapeMarkdownInline(item.title)} — ${escapeMarkdownInline(item.detail)}`);
+    }
+  }
+  lines.push("");
   lines.push("## Summary");
   lines.push("");
   lines.push(`- Root: \`${escapeMarkdownInline(result.root)}\``);
@@ -238,8 +257,11 @@ export function formatMarkdownQaDraft(result: QaDraftResult): string {
   if (result.missingEvidence.length === 0) {
     lines.push("- No required evidence gap was detected in the generated QA draft. Still run the project validation command before merge.");
   } else {
-    for (const item of result.missingEvidence.slice(0, 8)) {
+    for (const item of result.missingEvidence.slice(0, 6)) {
       lines.push(`- [${item.priority}] ${item.kind}: ${escapeMarkdownInline(item.title)} - ${escapeMarkdownInline(item.detail)} (${escapeMarkdownInline(item.flowTitle)})`);
+    }
+    if (result.missingEvidence.length > 6) {
+      lines.push(`- ... ${result.missingEvidence.length - 6} more lower-priority items (see \`--format json\` for the full list)`);
     }
   }
   lines.push("");
@@ -259,6 +281,18 @@ export function formatMarkdownQaDraft(result: QaDraftResult): string {
   lines.push("");
 
   return lines.join("\n");
+}
+
+function nextStepCommand(result: QaDraftResult): string {
+  if (!result.testSuite.hasTestSuite) {
+    return firstDraftCreateCommand(result);
+  }
+  const validationCommand = result.suggestedCommands[0];
+  if (validationCommand) {
+    return validationCommand;
+  }
+  const draftPath = result.flows[0]?.draftPath;
+  return draftPath ? `review ${draftPath}` : "qamap e2e draft . --dry-run";
 }
 
 function firstDraftCreateCommand(result: QaDraftResult): string {
@@ -302,7 +336,13 @@ function buildMissingEvidence(files: E2eDraftFile[]): QaDraftMissingEvidence[] {
     for (const item of file.actionItems ?? []) {
       evidence.push(missingEvidenceFromAction(file, item));
     }
+    const actionText = normalizeEvidenceText(
+      (file.actionItems ?? []).map((item) => `${item.title} ${item.detail}`).join(" "),
+    );
     for (const blocker of file.executionBlockers ?? []) {
+      if (actionTextCoversBlocker(actionText, blocker)) {
+        continue;
+      }
       evidence.push({
         flowTitle: file.flowTitle,
         priority: "required",
@@ -312,7 +352,26 @@ function buildMissingEvidence(files: E2eDraftFile[]): QaDraftMissingEvidence[] {
       });
     }
   }
-  return uniqueMissingEvidence(evidence).slice(0, 12);
+  const unique = uniqueMissingEvidence(evidence);
+  const required = unique.filter((item) => item.priority === "required");
+  const recommended = unique.filter((item) => item.priority !== "required");
+  return [...required, ...recommended].slice(0, 12);
+}
+
+function normalizeEvidenceText(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9\uAC00-\uD7A3 ]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function actionTextCoversBlocker(actionText: string, blocker: string): boolean {
+  if (!actionText) {
+    return false;
+  }
+  const blockerTokens = normalizeEvidenceText(blocker).split(" ").filter((token) => token.length > 3);
+  if (blockerTokens.length === 0) {
+    return false;
+  }
+  const covered = blockerTokens.filter((token) => actionText.includes(token)).length;
+  return covered / blockerTokens.length >= 0.7;
 }
 
 function missingEvidenceFromAction(file: E2eDraftFile, item: E2eDraftActionItem): QaDraftMissingEvidence {

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -4523,6 +4523,10 @@ test("qa command emits a PR comment draft without requiring a manifest", async (
   assert.ok(qa.flows.some((flow) => flow.changedFiles.includes("src/pages/checkout/index.tsx")));
   assert.match(markdown, /QAMap QA Draft/);
   assert.match(markdown, /Local-first PR QA skill output/);
+  assert.match(markdown, /## At a Glance/);
+  assert.match(markdown, /- Affected: /);
+  assert.match(markdown, /- Do next: `/);
+  assert.match(markdown, /- Blocking/);
   assert.match(markdown, /Manifest: not found; using repo signals and PR diff only/);
   assert.match(markdown, /PR Comment Draft/);
   assert.match(markdown, /Affected Flow/);


### PR DESCRIPTION
## Intent

Make the first screen of `qamap qa` verdict-centric. Real-repository testing showed the report led with tool-centric metadata (root/base/readiness scores) while the decision-relevant facts sat below the fold, and blocker lines were repeated across sections.

- The markdown report now opens with an **At a Glance** section: affected flows in one line, the single next command to run (bootstrap command on testless repos, the validation command otherwise), and the top one or two blocking evidence items.
- Execution blockers whose content is already covered by a required action item are no longer emitted twice.
- Missing evidence sorts required-first and is capped at six lines with a summary of the remainder (full list stays in `--format json`).
- The skill template tells agents to start reading from At a Glance.

## Agent / Review Risk

- Additive formatting change; every existing section keeps its name and order below the new section, so documented section references stay valid.
- Blocker dedupe is token-overlap based (70% threshold) and only suppresses a blocker when a required action already conveys it; JSON output still carries all blockers.

## Validation Evidence

- [x] `pnpm test` (100/100; At a Glance assertions added to the qa report test)
- [x] `pnpm bench --baseline`: no metric changes beyond small agent-payload growth; runner choice, reach recall, and blank-action counts unchanged on all four pinned targets.
