### PR TITLE
Feat: assert observed changed-endpoint responses with diff-derived bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Observed changed-endpoint responses are now asserted, not just collected: every observed response must stay below a status ceiling derived from the handler's added code (below 400 when the diff only shows success statuses, below 500 otherwise), response-shape keys from the changed handler are emitted as promotion hints, and zero observations warn instead of failing.
+
 - Diff-added action names are also read from button and link inner text (`<button>Apply coupon</button>`), not only from attribute labels, so flows changed by copy-level edits get named after the action instead of "primary journey".
 
 - `qamap qa` now opens with an At a Glance section — the affected flows in one line, the single next command to run, and the one or two blocking evidence items — before the detailed report. Execution blockers already covered by a required action are no longer repeated, required items sort before recommended ones, and the missing-evidence list is capped with a summary line.

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -534,6 +534,12 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
 export async function generateE2eDraft(rootInput: string, options: E2eDraftOptions = {}): Promise<E2eDraftResult> {
   const root = path.resolve(rootInput);
   const plan = await generateE2ePlan(root, options);
+  const addedDiffText = await collectAddedDiffText(root, {
+    base: plan.base,
+    head: plan.head,
+    workspaceRoot: plan.workspaceRoot,
+    includeWorkingTree: options.includeWorkingTree,
+  });
   const runner = plan.recommendedRunner.name;
   const outputDirectory = path.resolve(root, options.output ?? defaultDraftOutputDirectory(runner));
   const draftLimit = options.maxDrafts && options.maxDrafts > 0 ? Math.floor(options.maxDrafts) : undefined;
@@ -552,7 +558,7 @@ export async function generateE2eDraft(rootInput: string, options: E2eDraftOptio
     const promotionGuidance = buildDraftPromotionGuidance(flow);
     const fileAlreadyExists = await exists(filePath);
     const shouldSkip = fileAlreadyExists && !options.force && !dryRun;
-    const content = shouldSkip ? ((await readTextIfExists(filePath)) ?? "") : draftContentForFlow(plan, flow, runner);
+    const content = shouldSkip ? ((await readTextIfExists(filePath)) ?? "") : draftContentForFlow(plan, flow, runner, addedDiffText);
     const todoCount = countTodos(content);
     const selfCheck = evaluateDraftSelfCheck(plan, flow, runner, content, todoCount);
     const actionItems = buildDraftActionItems(plan, flow, runner, validationSummary, promotionGuidance, selfCheck);
@@ -7090,12 +7096,17 @@ function draftExtension(runner: E2eRunnerName): string {
   return ".md";
 }
 
-function draftContentForFlow(plan: E2ePlanResult, flow: E2eFlow, runner: E2eRunnerName): string {
+function draftContentForFlow(
+  plan: E2ePlanResult,
+  flow: E2eFlow,
+  runner: E2eRunnerName,
+  addedDiffText: Record<string, string> = {},
+): string {
   if (runner === "maestro") {
     return buildMaestroDraft(plan, flow);
   }
   if (runner === "playwright") {
-    return buildPlaywrightDraft(plan, flow);
+    return buildPlaywrightDraft(plan, flow, addedDiffText);
   }
   return buildManualDraft(plan, flow);
 }
@@ -7199,7 +7210,7 @@ function maestroCommandForStep(
   };
 }
 
-function buildPlaywrightDraft(plan: E2ePlanResult, flow: E2eFlow): string {
+function buildPlaywrightDraft(plan: E2ePlanResult, flow: E2eFlow, addedDiffText: Record<string, string> = {}): string {
   const testName = flow.title.replaceAll('"', "'");
   const selectorQueue = [...flow.selectors];
   const scenario = domainScenarioForFlow(flow);
@@ -7255,6 +7266,7 @@ function buildPlaywrightDraft(plan: E2ePlanResult, flow: E2eFlow): string {
         : playwrightFallbackActionForStep(step));
     appendPlaywrightTestStep(lines, step, body);
   }
+  appendObservedResponseAssertion(lines, flow, addedDiffText);
   appendDomainScenarioComments(lines, flow, "  //");
   appendPlaywrightCoverageComments(lines, flow);
   lines.push("});");
@@ -7904,12 +7916,7 @@ function appendPlaywrightMockRouteScaffold(lines: string[], flow: E2eFlow): void
   if (flow.fixtureReadiness.status === "not-needed" || flow.fixtureReadiness.apiEndpoints.length === 0) {
     return;
   }
-  const changedEndpointHints = uniqueStrings(flow.fixtureReadiness.backendSignals.flatMap(apiEndpointFromBackendFile));
-  const observedEndpoints = changedEndpointHints.length > 0
-    ? changedEndpointHints
-    : flow.fixtureReadiness.backendSignals.length > 0
-    ? flow.fixtureReadiness.apiEndpoints
-    : [];
+  const observedEndpoints = observedEndpointsForFlow(flow);
   if (observedEndpoints.length > 0) {
     appendPlaywrightApiObservationScaffold(lines, observedEndpoints);
   }
@@ -7940,6 +7947,74 @@ function appendPlaywrightMockRouteScaffold(lines: string[], flow: E2eFlow): void
   lines.push("        body: JSON.stringify(response.body),");
   lines.push("      });");
   lines.push("    });");
+  lines.push("  }");
+}
+
+function observedEndpointsForFlow(flow: E2eFlow): string[] {
+  if (flow.fixtureReadiness.status === "not-needed" || flow.fixtureReadiness.apiEndpoints.length === 0) {
+    return [];
+  }
+  const changedEndpointHints = uniqueStrings(flow.fixtureReadiness.backendSignals.flatMap(apiEndpointFromBackendFile));
+  if (changedEndpointHints.length > 0) {
+    return changedEndpointHints;
+  }
+  return flow.fixtureReadiness.backendSignals.length > 0 ? flow.fixtureReadiness.apiEndpoints : [];
+}
+
+interface ChangedHandlerEvidence {
+  statuses: number[];
+  successOnly: boolean;
+  responseKeys: string[];
+}
+
+function collectChangedHandlerEvidence(flow: E2eFlow, addedDiffText: Record<string, string>): ChangedHandlerEvidence {
+  const statuses: number[] = [];
+  const responseKeys: string[] = [];
+  for (const file of flow.fixtureReadiness.backendSignals) {
+    const addedText = addedDiffText[file];
+    if (!addedText) {
+      continue;
+    }
+    for (const match of addedText.matchAll(/(?:status[:(]\s*|\.status\(\s*)(\d{3})\b/g)) {
+      const status = Number(match[1]);
+      if (status >= 100 && status < 600) {
+        statuses.push(status);
+      }
+    }
+    for (const match of addedText.matchAll(/(?:NextResponse|Response|res)\.json\(\s*\{([^}]{1,200})\}/g)) {
+      for (const keyMatch of match[1].matchAll(/(?:^|[,{])\s*([A-Za-z_$][\w$]*)\s*[:,}]/g)) {
+        responseKeys.push(keyMatch[1]);
+      }
+    }
+  }
+  const uniqueStatuses = [...new Set(statuses)];
+  return {
+    statuses: uniqueStatuses,
+    successOnly: uniqueStatuses.length > 0 && uniqueStatuses.every((status) => status < 400),
+    responseKeys: [...new Set(responseKeys)].slice(0, 6),
+  };
+}
+
+function appendObservedResponseAssertion(lines: string[], flow: E2eFlow, addedDiffText: Record<string, string>): void {
+  if (observedEndpointsForFlow(flow).length === 0) {
+    return;
+  }
+  const evidence = collectChangedHandlerEvidence(flow, addedDiffText);
+  const statusCeiling = evidence.successOnly ? 400 : 500;
+  lines.push("");
+  if (evidence.successOnly) {
+    lines.push(`  // The added handler code only shows success statuses (${evidence.statuses.join(", ")}), so any 4xx/5xx here is unexpected.`);
+  } else {
+    lines.push("  // Changed-endpoint check: the journey must not surface server errors from the code under test.");
+  }
+  if (evidence.responseKeys.length > 0) {
+    lines.push(`  // Response shape hint from the changed handler: { ${evidence.responseKeys.join(", ")} } — assert on these fields when promoting this draft.`);
+  }
+  lines.push("  for (const response of observedChangedApiResponses) {");
+  lines.push(`    expect(response.status, \`unexpected status from \${response.url}\`).toBeLessThan(${statusCeiling});`);
+  lines.push("  }");
+  lines.push("  if (observedChangedApiResponses.length === 0) {");
+  lines.push('    console.warn("Changed endpoints were not exercised by this draft; extend the steps above to cover them.");');
   lines.push("  }");
 }
 

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -4813,6 +4813,44 @@ test("diff-added selectors rank first and name the changed behavior", async () =
   assert.match(stepText, /pin/i);
 });
 
+test("observed changed-endpoint responses are asserted with diff-derived status bounds", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "app/api/orders"), { recursive: true });
+  await mkdir(path.join(root, "app/orders"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({ scripts: { test: "playwright test" }, dependencies: { next: "^15.0.0", "@playwright/test": "^1.56.0" } }),
+  );
+  await writeFile(path.join(root, "app/api/orders/route.ts"), "export async function POST() {\n  return Response.json({ total: 0 });\n}\n");
+  await writeFile(
+    path.join(root, "app/orders/page.tsx"),
+    "export default function OrdersPage() { return <main><button data-testid=\"submit-order\">Order</button></main>; }\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/discount"]);
+  await writeFile(
+    path.join(root, "app/api/orders/route.ts"),
+    "export async function POST() {\n  return Response.json({ total: 0, discount: 10 }, { status: 201 });\n}\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "add discount"]);
+
+  const draft = await generateE2eDraft(root, { base: "main", head: "HEAD", output: "tests/e2e", runner: "playwright" });
+  const apiDraft = draft.files.find((file) => /api/i.test(file.flowTitle));
+  assert.ok(apiDraft);
+  const spec = await readFile(path.join(root, apiDraft.path), "utf8");
+  assert.match(spec, /observedChangedApiResponses/);
+  assert.match(spec, /only shows success statuses \(201\)/);
+  assert.match(spec, /Response shape hint from the changed handler: \{ total, discount \}/);
+  assert.match(spec, /toBeLessThan\(400\)/);
+  assert.match(spec, /Changed endpoints were not exercised/);
+  assert.doesNotMatch(spec, /toBeLessThan\(500\)/);
+});
+
 test("generated drafts are not counted as test-suite evidence", async () => {
   const root = await makeTempRepo();
   await initGitRepo(root);


### PR DESCRIPTION
## Intent

Close the "collected but never asserted" gap on changed endpoints. Drafts already observe responses from endpoints whose handlers are in the diff (instead of mocking them), but a run could go green without those observations meaning anything.

- After the journey steps, every observed response is now asserted against a status ceiling derived statically from the handler's **added** code: when the diff only shows success statuses (e.g. a lone `status: 201`), the ceiling tightens to `< 400`; when the diff also adds 4xx branches, it stays `< 500` so intentional validation paths cannot flake the draft.
- Response-shape keys read from the changed handler (`Response.json({ total, discount })`) are emitted as a promotion hint comment, so whoever finishes the draft knows which fields to assert on.
- Zero observations keep the existing warn-instead-of-fail behavior — no guaranteed-fail specs.

## Agent / Review Risk

- The assertion block is emitted only when the flow has observed changed endpoints; drafts without API changes are byte-identical.
- Status/shape extraction reads only added diff lines of changed backend files, so pre-existing handler code cannot tighten or loosen the bounds.

## Validation Evidence

- [x] `pnpm test` (101/101; new regression covering the tightened ceiling, shape hint, and warn fallback)
- [x] `pnpm bench --baseline`: no metric changes on the four pinned targets (their pinned windows have no changed-endpoint flows).
- [x] Manual fixture: a handler diff adding `{ total, discount }` with `status: 201` produces `toBeLessThan(400)` plus the `{ total, discount }` hint.
