### PR TITLE
Fix: reject vue bound attributes and i18n keys as selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Vue bound attributes (`:aria-label="t('nav.search')"`, `v-bind` expressions) are no longer mistaken for literal selector values, and dotted i18n-key tokens (`menu.items.search`) are rejected as selector text, so Vue single-file components stop producing locators that can never match rendered UI.
+
 ### Changed
 
 - Observed changed-endpoint responses are now asserted, not just collected: every observed response must stay below a status ceiling derived from the handler's added code (below 400 when the diff only shows success statuses, below 500 otherwise), response-shape keys from the changed handler are emitted as promotion hints, and zero observations warn instead of failing.

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -8856,7 +8856,7 @@ function extractAttributeSelectors(
   const selectors: E2eSelector[] = [];
   for (const attribute of attributes) {
     const matcher = new RegExp(
-      `${escapeRegExp(attribute)}\\s*=\\s*(?:"([^"]+)"|'([^']+)'|\\{\\s*["'\`]([^"'\`{}]+)["'\`]\\s*\\})`,
+      `(?<![:@.\\w-])${escapeRegExp(attribute)}\\s*=\\s*(?:"([^"]+)"|'([^']+)'|\\{\\s*["'\`]([^"'\`{}]+)["'\`]\\s*\\})`,
       "g",
     );
     for (const match of text.matchAll(matcher)) {
@@ -8923,7 +8923,15 @@ function normalizeSelectorValue(value: string | undefined): string | undefined {
 }
 
 function isUsefulSelector(value: string): boolean {
-  return value.length >= 2 && value.length <= 80 && !/[{}()[\]=>]/.test(value);
+  if (value.length < 2 || value.length > 80 || /[{}()[\]=>]/.test(value)) {
+    return false;
+  }
+  // Dotted tokens without spaces are almost always i18n keys or property paths,
+  // never rendered UI text, so a locator built from them can never match.
+  if (/^[\w$-]+(?:\.[\w$-]+)+$/.test(value)) {
+    return false;
+  }
+  return true;
 }
 
 async function readPackageJson(root: string): Promise<PackageJson | undefined> {

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -4851,6 +4851,55 @@ test("observed changed-endpoint responses are asserted with diff-derived status 
   assert.doesNotMatch(spec, /toBeLessThan\(500\)/);
 });
 
+test("vue bound attributes and i18n keys are not extracted as selectors", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src/pages"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({ scripts: { test: "playwright test" }, dependencies: { vue: "^3.4.0", "@playwright/test": "^1.56.0" } }),
+  );
+  await writeFile(
+    path.join(root, "src/pages/SearchPage.vue"),
+    [
+      "<template>",
+      "  <main>",
+      "    <input placeholder=\"Search notes\" :aria-label=\"t('nav.search')\" />",
+      "    <button data-test=\"run-search\" :label=\"'menu.items.search'\">Search</button>",
+      "  </main>",
+      "</template>",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/search-copy"]);
+  await writeFile(
+    path.join(root, "src/pages/SearchPage.vue"),
+    [
+      "<template>",
+      "  <main>",
+      "    <input placeholder=\"Search notes\" :aria-label=\"t('nav.search')\" />",
+      "    <input placeholder=\"Filter by tag\" :placeholder-hint=\"t('nav.filter')\" />",
+      "    <button data-test=\"run-search\" :label=\"'menu.items.search'\">Search</button>",
+      "  </main>",
+      "</template>",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "add filter"]);
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD", runner: "playwright" });
+  const values = plan.flows.flatMap((flow) => flow.selectors.map((selector) => selector.value));
+  assert.ok(values.includes("Search notes"));
+  assert.ok(values.includes("Filter by tag"));
+  assert.ok(values.includes("run-search"));
+  assert.ok(!values.some((value) => value.includes("nav.search")), "bound i18n expression must not leak");
+  assert.ok(!values.some((value) => value.includes("menu.items.search")), "dotted i18n key must not leak");
+  assert.ok(!values.some((value) => value === "t"), "expression fragments must not leak");
+});
+
 test("generated drafts are not counted as test-suite evidence", async () => {
   const root = await makeTempRepo();
   await initGitRepo(root);


### PR DESCRIPTION
## Intent

Fix the worst Vue-repository failure from external testing: selector extraction treated Vue bound attributes as literals, so expressions and i18n keys (`:aria-label="t('nav.search')"`, `:label="'menu.items.search'"`) leaked into drafts as visible-text/label selectors — locators that can never match rendered UI.

- Attribute extraction now requires the attribute name to stand alone (a negative lookbehind rejects `:attr`, `@attr`, `v-bind:attr`, and `*-attr` forms), so only static literal attributes produce selectors.
- Selector usefulness filtering rejects dotted single-token values (`menu.items.search` shapes) — they are i18n keys or property paths, never rendered text.
- Static Vue template attributes (`placeholder="Search notes"`, `data-test="run-search"`) keep working; `data-test` was already recognized alongside `data-testid`.

## Agent / Review Risk

- The lookbehind also excludes JSX spread-adjacent or namespaced attribute shapes, which were never valid literal sources; all existing extraction tests pass unchanged.
- The dotted-token filter could in theory reject a real label like `v1.2.0` — acceptable, since version strings make poor journey selectors anyway.

## Validation Evidence

- [x] `pnpm test` (102/102; new Vue SFC regression covering bound-attribute and dotted-key rejection plus static-attribute extraction)
- [x] `pnpm bench --baseline`: no metric changes on the four pinned targets, including the legacy Vue app.
