### PR TITLE
Feat: name logic-only changes after the surface's primary action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- When a diff changes only logic or styles on a surface (no labeled elements added), the journey is now named after the surface's primary action-bearing control ("Invoices Send" instead of "Invoices primary journey"). Diffs that add labeled elements keep the existing diff-derived naming, so previously named flows are unaffected. A few common action verbs (send, share, export, download, print) were added to the action vocabulary. Known limit: non-English control labels do not yet qualify as action names.
+
 ### Fixed
 
 - Vue bound attributes (`:aria-label="t('nav.search')"`, `v-bind` expressions) are no longer mistaken for literal selector values, and dotted i18n-key tokens (`menu.items.search`) are rejected as selector text, so Vue single-file components stop producing locators that can never match rendered UI.

--- a/src/domain-language.ts
+++ b/src/domain-language.ts
@@ -82,7 +82,8 @@ export async function buildDomainLanguageSummary(
     .sort(compareTerms)
     .slice(0, 12);
   const behaviorScenarios = buildBehaviorScenarioSuggestions(terms, files, addedDiffText);
-  const scenarios = buildScenarioSuggestions(terms, coreFlows, domains, behaviorScenarios);
+  const fallbackBehaviors = await buildFullTextBehaviorFallbacks(root, terms, domains, behaviorScenarios, addedDiffText);
+  const scenarios = buildScenarioSuggestions(terms, coreFlows, domains, behaviorScenarios, fallbackBehaviors);
 
   return {
     terms,
@@ -130,6 +131,7 @@ function buildScenarioSuggestions(
   coreFlows: MatchedCoreFlow[],
   domains: MatchedDomain[],
   behaviorScenarios: DomainScenarioSuggestion[] = [],
+  fallbackBehaviors: Map<string, string> = new Map(),
 ): DomainScenarioSuggestion[] {
   const scenarios: DomainScenarioSuggestion[] = [];
 
@@ -171,9 +173,12 @@ function buildScenarioSuggestions(
       }
       continue;
     }
+    const domainFallback = fallbackBehaviors.get(domain.name);
     scenarios.push({
-      title: primaryJourneyTitle(domain.name),
-      intent: `Use "${domain.name}" as the shared name for this changed behavior until the team chooses a more specific scenario.`,
+      title: domainFallback ? `${domain.name} ${domainFallback}` : primaryJourneyTitle(domain.name),
+      intent: domainFallback
+        ? `The changed surface's primary "${domainFallback}" action names this journey; rename it if the team uses a better word.`
+        : `Use "${domain.name}" as the shared name for this changed behavior until the team chooses a more specific scenario.`,
       checks: [
         `Start from the normal entry point for ${domain.name}.`,
         `Complete the main ${domain.name} action with realistic data.`,
@@ -192,9 +197,12 @@ function buildScenarioSuggestions(
     .filter((item) => item.source !== "core-flow")
     .filter((item) => !hasBehaviorScenarioForTerm(item, behaviorScenarios))
     .slice(0, 5)) {
+    const termFallback = fallbackBehaviors.get(term.term);
     scenarios.push({
-      title: primaryJourneyTitle(term.term),
-      intent: `Use "${term.term}" as the shared name for this changed behavior until the team chooses a better domain term.`,
+      title: termFallback ? `${term.term} ${termFallback}` : primaryJourneyTitle(term.term),
+      intent: termFallback
+        ? `The changed surface's primary "${termFallback}" action names this journey; rename it if the team uses a better word.`
+        : `Use "${term.term}" as the shared name for this changed behavior until the team chooses a better domain term.`,
       checks: [
         `Start from the normal entry point for ${term.term}.`,
         `Complete the main ${term.term} action with realistic data.`,
@@ -207,6 +215,59 @@ function buildScenarioSuggestions(
   }
 
   return dedupeScenarios(scenarios).slice(0, 6);
+}
+
+async function buildFullTextBehaviorFallbacks(
+  root: string,
+  terms: DomainLanguageTerm[],
+  domains: MatchedDomain[],
+  behaviorScenarios: DomainScenarioSuggestion[],
+  addedDiffText: Record<string, string>,
+): Promise<Map<string, string>> {
+  const fallbacks = new Map<string, string>();
+  const candidates: Array<{ name: string; files: string[] }> = [
+    ...domains.map((domain) => ({ name: domain.name, files: domain.matchedFiles })),
+    ...terms
+      .filter((term) => term.source !== "core-flow")
+      .filter((term) => !hasBehaviorScenarioForTerm(term, behaviorScenarios))
+      .map((term) => ({ name: term.term, files: term.files })),
+  ];
+  for (const candidate of candidates.slice(0, 8)) {
+    if (fallbacks.has(candidate.name)) {
+      continue;
+    }
+    const uiFiles = candidate.files.filter((file) => /\.(?:tsx|jsx|vue|svelte)$/i.test(file)).slice(0, 2);
+    if (uiFiles.length === 0) {
+      continue;
+    }
+    // Gate: when the diff itself added labeled elements, naming intent belongs to the
+    // diff-added path (even when its filters declined) — never to pre-existing controls.
+    const addedHasLabels = uiFiles.some((file) => {
+      const addedText = addedDiffText[file];
+      if (!addedText) {
+        return false;
+      }
+      // .search() never reads or mutates lastIndex, unlike .test() on /g regexes.
+      return addedText.search(addedLabelMatcher) !== -1 || addedText.search(addedActionTextMatcher) !== -1;
+    });
+    if (addedHasLabels) {
+      continue;
+    }
+    for (const file of uiFiles) {
+      let fullText: string;
+      try {
+        fullText = await fs.readFile(path.join(root, file), "utf8");
+      } catch {
+        continue;
+      }
+      const behavior = behaviorLabelFromAddedText(fullText, candidate.name);
+      if (behavior) {
+        fallbacks.set(candidate.name, behavior);
+        break;
+      }
+    }
+  }
+  return fallbacks;
 }
 
 function primaryJourneyTitle(name: string): string {
@@ -820,4 +881,9 @@ const behaviorActionTokens = new Set([
   "update",
   "upload",
   "verify",
+  "send",
+  "share",
+  "export",
+  "download",
+  "print",
 ]);

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -4900,6 +4900,50 @@ test("vue bound attributes and i18n keys are not extracted as selectors", async 
   assert.ok(!values.some((value) => value === "t"), "expression fragments must not leak");
 });
 
+test("logic-only changes name journeys from the page's primary action", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "app/invoices"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({ scripts: { test: "playwright test" }, dependencies: { next: "^15.0.0", "@playwright/test": "^1.56.0" } }),
+  );
+  await writeFile(
+    path.join(root, "app/invoices/page.tsx"),
+    [
+      "const sort = (rows: number[]) => rows;",
+      "export default function InvoicesPage() {",
+      "  return <main>",
+      "    <button data-testid=\"send-invoice\">Send invoice</button>",
+      "  </main>;",
+      "}",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/sort-desc"]);
+  await writeFile(
+    path.join(root, "app/invoices/page.tsx"),
+    [
+      "const sort = (rows: number[]) => [...rows].reverse();",
+      "export default function InvoicesPage() {",
+      "  return <main>",
+      "    <button data-testid=\"send-invoice\">Send invoice</button>",
+      "  </main>;",
+      "}",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "sort desc"]);
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD", runner: "playwright" });
+  const titles = plan.domainLanguage.scenarios.map((scenario) => scenario.title);
+  assert.ok(titles.some((title) => /Invoices Send/i.test(title)), `expected action-named scenario, got: ${titles.join(", ")}`);
+  assert.ok(!titles.some((title) => /Invoices primary journey/i.test(title)));
+});
+
 test("generated drafts are not counted as test-suite evidence", async () => {
   const root = await makeTempRepo();
   await initGitRepo(root);


### PR DESCRIPTION
## Intent

Reduce the remaining "X primary journey" names for the most common real-world PR shape: logic- or style-only changes to a page that adds no labeled elements.

- When a term or matched domain would fall back to the generic name AND the diff's added lines contain no labels at all, the surface's own primary action-bearing control names the journey ("Invoices Send" instead of "Invoices primary journey"), with an intent line that marks the name's origin.
- Gate: diffs that DID add labeled elements never take this path — naming intent stays with the diff-derived rules, so every previously named flow (including the README demo) is byte-stable.
- Added five common verbs (send, share, export, download, print) to the action vocabulary.
- Fixed a latent statefulness bug found while testing: gate checks now use `String.search` because `RegExp.test` on the shared global matchers leaked `lastIndex` into later `matchAll` clones, making unrelated extraction order-dependent across a process.

## Agent / Review Risk

- Non-English control labels still do not qualify as action names (token filters are Latin-oriented), so repositories with localized UI keep generic names for logic-only diffs — documented as a known limit in the changelog.
- Benchmark: zero regressions on all four pinned targets; their generic counts are unchanged for exactly that localization reason.

## Validation Evidence

- [x] `pnpm test` (103/103; new regression: logic-only diff names the journey from the page's control, and the gate keeps labeled-diff fixtures stable)
- [x] `pnpm bench --baseline`: no metric regressions.
- [x] README demo repository re-verified: flow name unchanged ("Notes primary journey"), so no demo/GIF churn.
