### PR TITLE
Chore: release 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.3.3 - 2026-07-05
+
 ### Changed
 
 - When a diff changes only logic or styles on a surface (no labeled elements added), the journey is now named after the surface's primary action-bearing control ("Invoices Send" instead of "Invoices primary journey"). Diffs that add labeled elements keep the existing diff-derived naming, so previously named flows are unaffected. A few common action verbs (send, share, export, download, print) were added to the action vocabulary. Known limit: non-English control labels do not yet qualify as action names.

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -1,5 +1,18 @@
 # Release Validation
 
+## 0.3.3 - 2026-07-05
+
+Validated before publishing `0.3.3` (at-a-glance qa verdict, diff-anchored action naming incl. button/link text and logic-only fallbacks, observed-response assertions with diff-derived status bounds, Vue bound-attribute/i18n selector fixes):
+
+| Gate | Result |
+| --- | --- |
+| `pnpm test` | 103/103 passing |
+| `pnpm scan` (self-scan) | 0 findings |
+| Coverage thresholds (lines/branches/functions >= 80) | Passing |
+| `pnpm bench` against the four pinned local benchmark targets | Runner choice 4/4, labeled must-reach recall 9/9, blank actions 0, no metric regressions vs the 0.3.2 baseline |
+| README demo repository | Flow names and recorded demo unchanged |
+
+
 ## 0.3.2 - 2026-07-04
 
 Validated before publishing `0.3.2` (reverse import graph, diff-anchored steps and names, workspace-member project detection, Python service classification, start-here CLI guide):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Local-first QA skill that turns PR diffs into affected flows, missing evidence, and E2E drafts with no cloud or LLM token.",
   "type": "module",
   "packageManager": "pnpm@10.32.1",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const TOOL_NAME = "QAMap";
-export const VERSION = "0.3.2";
+export const VERSION = "0.3.3";


### PR DESCRIPTION
## Intent

Prepare the `0.3.3` release: version bump, dated changelog, and a release-validation entry for today's quality round.

Ships everything merged since `0.3.2`: the At a Glance qa verdict (#83), action naming from added button/link text (#84), observed-response assertions with diff-derived status bounds (#85), Vue bound-attribute and i18n-key selector fixes (#86), and logic-only-change naming from the surface's primary action (#87).

## Agent / Review Risk

- Version metadata and docs only; no engine changes.

## Validation Evidence

- [x] `pnpm run release:check` (build, 103/103 tests, self-scan 0 findings, whitespace, coverage 85.6/82.3/94.7, pack dry-run)
- [x] `pnpm bench`: no regressions vs the 0.3.2 baseline on the four pinned targets.

## Maintainer Notes

- Publishing requires an npm token; the working tree is otherwise release-ready after merge (publish → tag `v0.3.3` → GitHub release).
