### PR TITLE
Feat: recognize korean action labels for flow naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Korean action labels now qualify for flow and scenario naming: labels like `저장하기` or `신청하기` (36 common action stems, with `~하기/~합니다`-style endings) name the journey the same way English action words do, draft filenames keep Hangul instead of collapsing to an empty slug, and Korean submit-like labels drive `Submit` steps. This closes the known limit noted in 0.3.3.
+
 ### Changed
 
 - Slimmed the README from ~640 lines to ~100: it now carries only the demo, quick start, agent usage, positioning, and a documentation index. The full command reference moved to `docs/commands.md`, the guardrails scanner section to `docs/guardrails.md`, and positioning tables into `docs/adoption.md`.

--- a/src/domain-language.ts
+++ b/src/domain-language.ts
@@ -403,11 +403,11 @@ function behaviorLabelFromAddedText(addedText: string | undefined, domainTerm: s
     if (tokens.length === 0 || tokens.length > 4) {
       continue;
     }
-    if (tokens.length === 1 && !behaviorActionTokens.has(tokens[0]) && !isLikelyBusinessObjectToken(tokens[0])) {
+    if (tokens.length === 1 && !isActionToken(tokens[0]) && !isLikelyBusinessObjectToken(tokens[0])) {
       continue;
     }
     const title = titleCase(tokens.map(formatBehaviorToken).join(" "));
-    if (tokens.some((token) => behaviorActionTokens.has(token))) {
+    if (tokens.some((token) => isActionToken(token))) {
       return title;
     }
     fallback ??= title;
@@ -424,7 +424,7 @@ function behaviorLabelFromPath(file: string, domainTerm: string): string | undef
   if (tokens.length === 0) {
     return undefined;
   }
-  if (tokens.length === 1 && !behaviorActionTokens.has(tokens[0]) && !isLikelyBusinessObjectToken(tokens[0])) {
+  if (tokens.length === 1 && !isActionToken(tokens[0]) && !isLikelyBusinessObjectToken(tokens[0])) {
     return undefined;
   }
   return titleCase(tokens.map(formatBehaviorToken).join(" "));
@@ -480,8 +480,53 @@ function compareBehaviorScenarioCandidates(left: BehaviorScenarioCandidate, righ
   return left.title.localeCompare(right.title);
 }
 
+const koreanActionStems = [
+  "가입",
+  "검색",
+  "결제",
+  "공유",
+  "구매",
+  "다운로드",
+  "등록",
+  "로그인",
+  "만들",
+  "발송",
+  "변경",
+  "보내",
+  "복사",
+  "삭제",
+  "생성",
+  "선택",
+  "수정",
+  "시작",
+  "신고",
+  "신청",
+  "업로드",
+  "완료",
+  "이동",
+  "인증",
+  "입력",
+  "작성",
+  "저장",
+  "전송",
+  "제출",
+  "조회",
+  "주문",
+  "초대",
+  "추가",
+  "취소",
+  "편집",
+  "확인",
+];
+
+const koreanActionTokenMatcher = new RegExp(`^(?:${koreanActionStems.join("|")})(?:하기|합니다|하세요|해요|함|중)?$`);
+
+function isActionToken(token: string): boolean {
+  return behaviorActionTokens.has(token) || koreanActionTokenMatcher.test(token);
+}
+
 function hasActionToken(value: string): boolean {
-  return behaviorTokensFromText(value).some((token) => behaviorActionTokens.has(token));
+  return behaviorTokensFromText(value).some((token) => isActionToken(token));
 }
 
 async function collectUiCopyTerms(

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -4786,7 +4786,11 @@ function selectorStepLabel(selector: E2eSelector): string {
 }
 
 function actionVerbForSelector(selector: E2eSelector): string {
-  if (/\b(?:submit|send|apply|complete|confirm|save|continue|next|upload)\b/i.test(selector.value.replace(/[-_]+/g, " "))) {
+  const normalized = selector.value.replace(/[-_]+/g, " ");
+  if (/\b(?:submit|send|apply|complete|confirm|save|continue|next|upload)\b/i.test(normalized)) {
+    return "Submit";
+  }
+  if (/(?:제출|저장|보내기|전송|등록|신청|결제|구매|확인|완료)/.test(normalized)) {
     return "Submit";
   }
   return "Activate";
@@ -9175,11 +9179,12 @@ function selectorRank(kind: E2eSelectorKind): number {
 }
 
 function slugify(value: string): string {
-  return value
+  const slug = value
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/[^a-z0-9\uAC00-\uD7A3]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .slice(0, 80);
+  return slug || "draft";
 }
 
 function quoteYaml(value: string): string {

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -4944,6 +4944,39 @@ test("logic-only changes name journeys from the page's primary action", async ()
   assert.ok(!titles.some((title) => /Invoices primary journey/i.test(title)));
 });
 
+test("korean action labels name flows and survive slugified filenames", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "app/memo"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({ scripts: { test: "playwright test" }, dependencies: { next: "^15.0.0", "@playwright/test": "^1.56.0" } }),
+  );
+  await writeFile(
+    path.join(root, "app/memo/page.tsx"),
+    "export default function MemoPage() { return <main><input placeholder=\"메모를 입력하세요\" /></main>; }\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/save"]);
+  await writeFile(
+    path.join(root, "app/memo/page.tsx"),
+    "export default function MemoPage() { return <main><input placeholder=\"메모를 입력하세요\" /><button aria-label=\"저장하기\">저장</button></main>; }\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "save button"]);
+
+  const draft = await generateE2eDraft(root, { base: "main", head: "HEAD", runner: "playwright", dryRun: true });
+  const file = draft.files.find((item) => /저장/.test(item.flowTitle));
+  assert.ok(file, `expected a korean action-named flow, got: ${draft.files.map((item) => item.flowTitle).join(", ")}`);
+  assert.match(file.flowTitle, /^Memo 저장하기$/);
+  assert.match(file.path, /memo-저장하기\.spec\.ts$/);
+  const stepText = (file.draftSteps ?? []).join("\n");
+  assert.match(stepText, /저장하기/);
+});
+
 test("generated drafts are not counted as test-suite evidence", async () => {
   const root = await makeTempRepo();
   await initGitRepo(root);


### PR DESCRIPTION
## Intent

Close the localization limit documented in 0.3.3: non-English control labels could not name flows, so repositories with Korean UI copy kept generic "primary journey" names even when the diff added a clearly action-bearing control.

- 36 common Korean action stems (저장, 신청, 결제, 공유, ...) now qualify as action tokens, with `~하기/~합니다/~하세요`-style endings normalized, feeding the same naming rules as the English action vocabulary.
- Draft filenames keep Hangul (`memo-저장하기.spec.ts`) instead of collapsing to an empty slug, with a `draft` fallback for fully stripped titles.
- Korean submit-like labels (제출, 저장, 전송, ...) now produce `Submit` action steps instead of the generic `Activate`.

## Agent / Review Risk

- Token recognition is additive; English-labeled repositories are unaffected (verified: all pinned benchmark metrics unchanged).
- Hangul filenames are valid on macOS/Linux/modern Windows and in git; the previous behavior produced an empty basename for fully Korean titles, which was strictly worse.

## Validation Evidence

- [x] `pnpm test` (104/104; new regression: a diff-added Korean button names the flow, the filename keeps Hangul, and steps reference the label)
- [x] `pnpm bench --baseline`: no metric regressions; on one pinned Korean-language target, a real scenario now carries a Korean action name instead of a generic one (verified locally; details stay out of the public record by policy).
