### PR TITLE
Fix: measure generic titles on user-facing qa flows

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -24,7 +24,7 @@ node scripts/bench.mjs --baseline bench-results/<file>.json   # delta vs a saved
 - `viaImport` — flows produced through the reverse import graph (shared-file changes reaching surfaces).
 - `diffAnchor` — flows whose selector set includes at least one selector introduced by the diff itself; higher means drafts act on what the change added instead of pre-existing UI.
 - `blank` — steps with blank action slots (must stay 0).
-- `generic` — flows with content-free names (`... primary journey`, `... smoke flow`); lower is better.
+- `generic` — user-facing draft flow titles with content-free names (`... primary journey`, `... smoke flow`); lower is better. Measured on the `qa` result (what a reader sees), not on internal plan candidates — baselines saved before this definition changed are not comparable for this column.
 - `reach` — recall of `mustReachFiles`; missing files are listed per target.
 - `agentBytes` — size of the `--format agent` payload.
 

--- a/scripts/bench.mjs
+++ b/scripts/bench.mjs
@@ -58,7 +58,7 @@ for (const target of config.targets) {
     runnerExpected: expect.runner ?? null,
     runnerCorrect: expect.runner ? plan.recommendedRunner.name === expect.runner : null,
     flows: plan.flows.length,
-    genericTitles: plan.flows.filter((flow) => genericTitlePattern.test(flow.title)).length,
+    genericTitles: qa.flows.filter((flow) => genericTitlePattern.test(flow.title)).length,
     importPropagatedFlows: plan.flows.filter((flow) => flow.reason.includes("through imports")).length,
     diffAnchoredFlows: plan.flows.filter((flow) => (flow.selectors ?? []).some((selector) => selector.addedInDiff)).length,
     blankActions: allSteps.filter((step) => blankActionPattern.test(step)).length,


### PR DESCRIPTION
## Intent

Fix a benchmark measurement bug: the `generic` column counted internal plan candidate titles, which structurally end in "smoke flow", so the metric could never improve no matter how good user-facing names became.

- `generic` now counts content-free names on the `qa` result's flow titles — what a reader actually sees.
- docs/benchmarking.md documents the definition change and that older baselines are not comparable for this column.
- Corrected readings on the four pinned targets show the naming work landed: user-facing generic titles are now 0/1/1/0, and the remaining ones are legitimately styled API-checklist flows.

## Agent / Review Risk

- Benchmark tooling only; no product code changes.

## Validation Evidence

- [x] `pnpm bench --save`: new baseline recorded with the corrected column.
