### PR TITLE
Feat: colorize terminal reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- Reports are colorized when printed to an interactive terminal: headings, the At a Glance keys, status words (blocked/needs-work/ready and friends), priority tags, and inline commands get ANSI styling with zero dependencies. Files written with `--output`, pipes, CI logs, and machine formats (`json`, `agent`, `sarif`) are byte-identical to before; the standard `NO_COLOR` and `FORCE_COLOR` environment variables are honored.
+
+### Added
+
 - Korean action labels now qualify for flow and scenario naming: labels like `저장하기` or `신청하기` (36 common action stems, with `~하기/~합니다`-style endings) name the journey the same way English action words do, draft filenames keep Hangul instead of collapsing to an empty slug, and Korean submit-like labels drive `Submit` steps. This closes the known limit noted in 0.3.3.
 
 ### Changed

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,6 +43,7 @@ import { formatMarkdownReviewReport, formatReviewReport, reviewProject } from ".
 import { scanProject } from "./scanner.js";
 import { isAtLeastSeverity, isSeverity } from "./severity.js";
 import { formatMarkdownTestPlan, generateTestPlan } from "./test-plan.js";
+import { colorizeReport, shouldColorize } from "./terminal.js";
 import { formatMarkdownVerifyReport, formatVerifyReport, verifyChange } from "./verify.js";
 import type { QAMapConfig } from "./types.js";
 import type { Severity } from "./types.js";
@@ -858,7 +859,7 @@ async function printOrWrite(output: string, outputPath?: string): Promise<void> 
     await fs.writeFile(resolvedOutputPath, output, "utf8");
     console.log(`Wrote ${resolvedOutputPath}`);
   } else {
-    console.log(output.trimEnd());
+    console.log(shouldColorize() ? colorizeReport(output.trimEnd()) : output.trimEnd());
   }
 }
 

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1,0 +1,64 @@
+// Terminal presentation for human-facing reports. Colors are additive sugar:
+// they are applied only when writing to an interactive terminal, so files,
+// pipes, CI logs, and machine formats always receive the plain text.
+
+const RESET = "[0m";
+const BOLD = "[1m";
+const DIM = "[2m";
+const RED = "[31m";
+const GREEN = "[32m";
+const YELLOW = "[33m";
+const CYAN = "[36m";
+
+export function shouldColorize(stream: NodeJS.WriteStream = process.stdout): boolean {
+  if (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== "") {
+    return false;
+  }
+  if (process.env.FORCE_COLOR !== undefined && process.env.FORCE_COLOR !== "" && process.env.FORCE_COLOR !== "0") {
+    return true;
+  }
+  return Boolean(stream.isTTY);
+}
+
+export function colorizeReport(text: string): string {
+  // Machine formats pass through untouched.
+  const head = text.trimStart();
+  if (head.startsWith("{") || head.startsWith("[")) {
+    return text;
+  }
+  return text
+    .split("\n")
+    .map((line) => colorizeLine(line))
+    .join("\n");
+}
+
+function colorizeLine(line: string): string {
+  if (/^#{1,3} /.test(line)) {
+    return `${BOLD}${CYAN}${line}${RESET}`;
+  }
+  if (line.startsWith("> ")) {
+    return `${DIM}${line}${RESET}`;
+  }
+  let output = line;
+  output = output.replace(
+    /^(- (?:Affected|Do next|Blocking(?: \d+)?|Base|Head|Project|Recommended runner|Manifest|Readiness|Draft flows)):/,
+    `${BOLD}$1${RESET}:`,
+  );
+  output = output.replace(/\[(required|missing|error)\]/g, `${RED}[$1]${RESET}`);
+  output = output.replace(/\[(recommended|warning)\]/g, `${YELLOW}[$1]${RESET}`);
+  output = output.replace(/\[(covered|ready|created|pass)\]/g, `${GREEN}[$1]${RESET}`);
+  output = output.replace(
+    /\b(Readiness|runnable|self-check|Status|status)(\[0m)?: (blocked|failed|fail|missing)\b/g,
+    `$1$2: ${RED}$3${RESET}`,
+  );
+  output = output.replace(
+    /\b(Readiness|runnable|self-check|Status|status)(\[0m)?: (needs-work|near-runnable|review-only|warning|proposed)\b/g,
+    `$1$2: ${YELLOW}$3${RESET}`,
+  );
+  output = output.replace(
+    /\b(Readiness|runnable|self-check|Status|status)(\[0m)?: (ready|runnable-candidate|pass|passed|created|applied)\b/g,
+    `$1$2: ${GREEN}$3${RESET}`,
+  );
+  output = output.replace(/`([^`\n]+)`/g, `${CYAN}$1${RESET}`);
+  return output;
+}

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -4977,6 +4977,40 @@ test("korean action labels name flows and survive slugified filenames", async ()
   assert.match(stepText, /저장하기/);
 });
 
+test("terminal colorizer decorates reports only and passes machine formats through", async () => {
+  const { colorizeReport, shouldColorize } = await import("../dist/terminal.js");
+
+  const report = [
+    "# QAMap QA Draft",
+    "> quoted note",
+    "- Do next: `qamap e2e setup`",
+    "- [required] fixture: add data",
+    "- Readiness: blocked (0/100)",
+  ].join("\n");
+  const colored = colorizeReport(report);
+  assert.match(colored, /\u001b\[1m\u001b\[36m# QAMap QA Draft\u001b\[0m/);
+  assert.match(colored, /\u001b\[2m> quoted note\u001b\[0m/);
+  assert.match(colored, /\u001b\[31m\[required\]\u001b\[0m/);
+  assert.match(colored, /Readiness\u001b\[0m: \u001b\[31mblocked\u001b\[0m/);
+  assert.match(colored, /\u001b\[36mqamap e2e setup\u001b\[0m/);
+
+  const json = JSON.stringify({ schema: { name: "qamap.qa" } });
+  assert.equal(colorizeReport(json), json);
+
+  const previousNoColor = process.env.NO_COLOR;
+  const previousForce = process.env.FORCE_COLOR;
+  process.env.NO_COLOR = "1";
+  delete process.env.FORCE_COLOR;
+  assert.equal(shouldColorize({ isTTY: true }), false);
+  delete process.env.NO_COLOR;
+  process.env.FORCE_COLOR = "1";
+  assert.equal(shouldColorize({ isTTY: false }), true);
+  delete process.env.FORCE_COLOR;
+  assert.equal(shouldColorize({ isTTY: false }), false);
+  if (previousNoColor !== undefined) process.env.NO_COLOR = previousNoColor;
+  if (previousForce !== undefined) process.env.FORCE_COLOR = previousForce;
+});
+
 test("generated drafts are not counted as test-suite evidence", async () => {
   const root = await makeTempRepo();
   await initGitRepo(root);


### PR DESCRIPTION
## Intent

Make the first run look like a product instead of a log dump. The human-facing reports were plain markdown text in the terminal; this adds dependency-free ANSI styling applied only at print time.

- New `src/terminal.ts`: headings render bold cyan, the intro note dims, At a Glance keys bold, `[required]`/`[missing]` red and `[recommended]` yellow and `[covered]`/`[pass]` green, status values after `Readiness:`/`runnable:`/`self-check:` colored by severity, and inline backtick commands cyan.
- Styling applies only when stdout is an interactive terminal: `--output` files, pipes, CI logs, and machine formats (`json`, `agent`, `sarif`) remain byte-identical. `NO_COLOR` and `FORCE_COLOR` are honored per convention.

## Agent / Review Risk

- Presentation-only, gated at the single print call site; the whole existing test suite exercises the non-TTY path and passes unchanged, plus a unit test covers the colorizer rules, JSON passthrough, and the env-variable gates.

## Validation Evidence

- [x] `pnpm test` (105/105)
- [x] Visual check with `FORCE_COLOR=1` on the demo repository: headings, verdict keys, statuses, and commands styled as intended.
