### PR TITLE
Feat: report draft readiness as a four-stage journey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,12 @@
 
 ### Added
 
-- Reports are colorized when printed to an interactive terminal: headings, the At a Glance keys, status words (blocked/needs-work/ready and friends), priority tags, and inline commands get ANSI styling with zero dependencies. Files written with `--output`, pipes, CI logs, and machine formats (`json`, `agent`, `sarif`) are byte-identical to before; the standard `NO_COLOR` and `FORCE_COLOR` environment variables are honored.
-
-### Added
-
+- Reports are colorized when printed to an interactive terminal: headings, the At a Glance keys, status words and stage labels, priority tags, and inline commands get ANSI styling with zero dependencies. Files written with `--output`, pipes, CI logs, and machine formats (`json`, `agent`, `sarif`) are byte-identical to before; the standard `NO_COLOR` and `FORCE_COLOR` environment variables are honored.
 - Korean action labels now qualify for flow and scenario naming: labels like `저장하기` or `신청하기` (36 common action stems, with `~하기/~합니다`-style endings) name the journey the same way English action words do, draft filenames keep Hangul instead of collapsing to an empty slug, and Korean submit-like labels drive `Submit` steps. This closes the known limit noted in 0.3.3.
 
 ### Changed
 
+- Human reports now describe draft readiness as a stage on a fixed four-step journey (`Stage: setup needed (1 of 4) — readiness 0/100`) instead of a verdict (`Readiness: blocked (0/100)`), and the blocked-level recommendation says "keep these drafts review-only and start with X" instead of "do not treat these drafts as runnable". A fresh repository reads as being at the start of a path, not as failing. Machine formats are unchanged: `readiness.level` keeps the `blocked`/`needs-work`/`near-runnable`/`ready` values, and the stage-to-level mapping is documented in `docs/commands.md`.
 - Slimmed the README from ~640 lines to ~100: it now carries only the demo, quick start, agent usage, positioning, and a documentation index. The full command reference moved to `docs/commands.md`, the guardrails scanner section to `docs/guardrails.md`, and positioning tables into `docs/adoption.md`.
 
 ## 0.3.3 - 2026-07-05

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -23,6 +23,15 @@ Use `pnpm dlx @ivorycanvas/qamap ...` for one-off runs without installing QAMap 
 
 Human-facing reports (`text` and `markdown` formats) open with an **At a Glance** section — the affected flows in one line, the single next command to run, and the one or two blocking evidence items — before the detailed sections. When printed to an interactive terminal the report is colorized (headings, statuses, priority tags, inline commands); files written with `--output`, pipes, CI logs, and the machine formats (`json`, `agent`, `sarif`) are always plain. The standard `NO_COLOR` and `FORCE_COLOR` environment variables are honored.
 
+Draft readiness is reported as a **stage on a fixed four-step journey**, for example `Stage: setup needed (1 of 4) — readiness 0/100`. A fresh repository usually starts at stage 1 — that is the expected starting point, not a failure. Each stage maps to a stable `readiness.level` value in the `json` and `agent` formats, which keeps machine output unchanged:
+
+| Stage line | JSON `readiness.level` | Meaning |
+| --- | --- | --- |
+| `setup needed (1 of 4)` | `blocked` | Drafts describe the flow but need runner config or other required setup before they can run. |
+| `draft in progress (2 of 4)` | `needs-work` | Drafts exist; close the required action items to make them runnable. |
+| `almost runnable (3 of 4)` | `near-runnable` | Run the drafts locally and clear the remaining review items. |
+| `ready to run (4 of 4)` | `ready` | Drafts are ready to try as local regression evidence. |
+
 
 ## What QAMap Produces
 

--- a/docs/e2e-output-examples.md
+++ b/docs/e2e-output-examples.md
@@ -19,7 +19,7 @@ Summary
 - Project: Web
 - Recommended runner: Playwright
 - Manifest: not found; using repo signals and PR diff only
-- Readiness: near-runnable
+- Stage: almost runnable (3 of 4)
 
 PR Comment Draft
 - Affected flow: Checkout UI smoke flow
@@ -349,7 +349,7 @@ Draft action items should make the next developer action explicit:
 
 ```txt
 Action summary:
-- readiness score: 64/100 (needs-work)
+- readiness stage: draft in progress (2 of 4), score 64/100
 - runnable status: near-runnable
 - self-check: pass or warning based on generated starter code and execution profile
 - top blocker: No Playwright config file was detected.

--- a/docs/quickstart-demo.md
+++ b/docs/quickstart-demo.md
@@ -168,7 +168,7 @@ Summary
 - Project: Web
 - Recommended runner: Playwright
 - Manifest: .qamap/manifest.yaml
-- Readiness: near-runnable
+- Stage: almost runnable (3 of 4)
 
 PR Comment Draft
 - Affected flow: Checkout purchase

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -362,6 +362,21 @@ export interface E2eDraftReadinessSummary {
   topBlockers: string[];
 }
 
+// Human reports render readiness as a stage on a fixed journey instead of a
+// verdict, so a first run reads as "you are at the start", not "you failed".
+// JSON/agent output keeps the raw level values as the stable contract.
+const draftReadinessStages: Record<E2eDraftReadinessLevel, { position: number; label: string }> = {
+  blocked: { position: 1, label: "setup needed" },
+  "needs-work": { position: 2, label: "draft in progress" },
+  "near-runnable": { position: 3, label: "almost runnable" },
+  ready: { position: 4, label: "ready to run" },
+};
+
+export function formatDraftReadinessStage(summary: Pick<E2eDraftReadinessSummary, "level" | "score">): string {
+  const stage = draftReadinessStages[summary.level];
+  return `${stage.label} (${stage.position} of 4) — readiness ${summary.score}/100`;
+}
+
 export interface E2eDraftResult {
   tool: {
     name: string;
@@ -2184,8 +2199,8 @@ function draftReadinessRecommendation(level: E2eDraftReadinessLevel, blockers: s
       : "Close required action items before treating the drafts as regression evidence.";
   }
   return blocker
-    ? `Do not treat these drafts as runnable yet. Start with: ${withTerminalPeriod(blocker)}`
-    : "Do not treat these drafts as runnable until required setup and validation gaps are closed.";
+    ? `Keep these drafts review-only for now and start with: ${withTerminalPeriod(blocker)}`
+    : "Keep these drafts review-only until the required setup and validation gaps are closed.";
 }
 
 function withTerminalPeriod(value: string): string {
@@ -2861,7 +2876,7 @@ export function formatMarkdownE2eDraft(result: E2eDraftResult): string {
   lines.push("## Draft Readiness Summary");
   lines.push("");
   lines.push(
-    `Score: ${result.readinessSummary.score}/100 (${result.readinessSummary.level}) - ${escapeMarkdownInline(result.readinessSummary.recommendation)}`,
+    `Stage: ${formatDraftReadinessStage(result.readinessSummary)}. ${escapeMarkdownInline(result.readinessSummary.recommendation)}`,
   );
   lines.push(
     `Summary: ${result.actionSummary.required} required action${result.actionSummary.required === 1 ? "" : "s"}, ${result.actionSummary.recommended} recommended action${result.actionSummary.recommended === 1 ? "" : "s"}.`,
@@ -2991,7 +3006,7 @@ export function formatMarkdownE2eSetup(result: E2eSetupResult): string {
       lines.push(`- Output directory: \`${escapeMarkdownInline(result.draftOutputDirectory)}\``);
     }
     if (result.draftReadinessSummary) {
-      lines.push(`- Readiness: ${result.draftReadinessSummary.level} (${result.draftReadinessSummary.score}/100)`);
+      lines.push(`- Stage: ${formatDraftReadinessStage(result.draftReadinessSummary)}`);
     }
     for (const file of result.draftFiles) {
       const details = [

--- a/src/qa.ts
+++ b/src/qa.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { generateE2eDraft } from "./e2e.js";
+import { formatDraftReadinessStage, generateE2eDraft } from "./e2e.js";
 import type {
   E2eDraftActionItem,
   E2eDraftFile,
@@ -175,7 +175,7 @@ export function formatMarkdownQaDraft(result: QaDraftResult): string {
   lines.push(`- Project: ${formatProjectType(result.project)}`);
   lines.push(`- Recommended runner: ${formatRunnerName(result.runner)}`);
   lines.push(`- Manifest: ${result.manifestPath ? `\`${escapeMarkdownInline(result.manifestPath)}\`` : "not found; using repo signals and PR diff only"}`);
-  lines.push(`- Readiness: ${result.readiness.level} (${result.readiness.score}/100)`);
+  lines.push(`- Stage: ${formatDraftReadinessStage(result.readiness)}`);
   lines.push(`- Draft flows: ${result.flows.length}`);
   lines.push("");
 

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -41,7 +41,7 @@ function colorizeLine(line: string): string {
   }
   let output = line;
   output = output.replace(
-    /^(- (?:Affected|Do next|Blocking(?: \d+)?|Base|Head|Project|Recommended runner|Manifest|Readiness|Draft flows)):/,
+    /^(- (?:Affected|Do next|Blocking(?: \d+)?|Base|Head|Project|Recommended runner|Manifest|Stage|Draft flows)):/,
     `${BOLD}$1${RESET}:`,
   );
   output = output.replace(/\[(required|missing|error)\]/g, `${RED}[$1]${RESET}`);
@@ -57,6 +57,14 @@ function colorizeLine(line: string): string {
   );
   output = output.replace(
     /\b(Readiness|runnable|self-check|Status|status)(\[0m)?: (ready|runnable-candidate|pass|passed|created|applied)\b/g,
+    `$1$2: ${GREEN}$3${RESET}`,
+  );
+  output = output.replace(
+    /\b(Stage)(\[0m)?: (setup needed|draft in progress|almost runnable)\b/g,
+    `$1$2: ${YELLOW}$3${RESET}`,
+  );
+  output = output.replace(
+    /\b(Stage)(\[0m)?: (ready to run)\b/g,
     `$1$2: ${GREEN}$3${RESET}`,
   );
   output = output.replace(/`([^`\n]+)`/g, `${CYAN}$1${RESET}`);

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -2688,7 +2688,7 @@ test("generateE2ePlan captures Playwright execution profile and self-check block
   assert.deepEqual(draftFile.executionBlockers?.filter((blocker) => /Playwright|baseURL|start command/i.test(blocker)), []);
   assert.match(formatMarkdownE2eDraft(draft), /near-runnable/);
   assert.match(formatMarkdownE2eDraft(draft), /## Draft Self Checks/);
-  assert.match(formatMarkdownE2eDraft(draft), /Score: \d+\/100/);
+  assert.match(formatMarkdownE2eDraft(draft), /Stage: [a-z ]+ \(\d of 4\) — readiness \d+\/100/);
   assert.match(spec, /Execution profile:/);
   assert.match(spec, /Start command: pnpm run dev/);
   assert.match(spec, /Test command: pnpm run test:e2e/);
@@ -4985,13 +4985,13 @@ test("terminal colorizer decorates reports only and passes machine formats throu
     "> quoted note",
     "- Do next: `qamap e2e setup`",
     "- [required] fixture: add data",
-    "- Readiness: blocked (0/100)",
+    "- Stage: setup needed (1 of 4) — readiness 0/100",
   ].join("\n");
   const colored = colorizeReport(report);
   assert.match(colored, /\u001b\[1m\u001b\[36m# QAMap QA Draft\u001b\[0m/);
   assert.match(colored, /\u001b\[2m> quoted note\u001b\[0m/);
   assert.match(colored, /\u001b\[31m\[required\]\u001b\[0m/);
-  assert.match(colored, /Readiness\u001b\[0m: \u001b\[31mblocked\u001b\[0m/);
+  assert.match(colored, /Stage\u001b\[0m: \u001b\[33msetup needed\u001b\[0m/);
   assert.match(colored, /\u001b\[36mqamap e2e setup\u001b\[0m/);
 
   const json = JSON.stringify({ schema: { name: "qamap.qa" } });


### PR DESCRIPTION
## Intent

Reframe readiness reporting from a verdict into a journey, so a first run on a fresh repository reads as "you are at the start of a path" instead of "you failed".

- Human reports (`qamap qa`, `qamap e2e draft`, `qamap e2e apply`) now render `Stage: setup needed (1 of 4) — readiness 0/100` instead of `Readiness: blocked (0/100)`, using four fixed stages: `setup needed` → `draft in progress` → `almost runnable` → `ready to run`.
- The blocked-level recommendation now says "Keep these drafts review-only for now and start with: …" instead of "Do not treat these drafts as runnable yet."
- The terminal colorizer styles stage labels (yellow while in progress, green when ready) and bolds the new `Stage` key.
- `docs/commands.md` documents the stage-to-level mapping; `docs/e2e-output-examples.md` and `docs/quickstart-demo.md` examples match the new lines.

## Agent / Review Risk

- Machine formats are untouched: `readiness.level` keeps the stable `blocked`/`needs-work`/`near-runnable`/`ready` values in `json` and `agent` output, so agent and CI consumers see no change. Verified via the pinned benchmark, which reads the JSON level and still reports `blocked` where expected.
- Only presentation strings and one recommendation sentence changed; scoring and level thresholds are identical.

## Validation Evidence

- [x] `npm test` (105/105)
- [x] Pinned benchmark unchanged against baseline: reach 9/9, blank actions 0, generic titles 0/1/1/0, runner 4/4, JSON readiness levels intact.
- [x] Manual run on the demo repository: `- Stage: draft in progress (2 of 4) — readiness 51/100` renders in the summary, colorized correctly under `FORCE_COLOR=1`, plain when piped.