### PR TITLE
Feat: add qamap init --agent one-command onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Reports are colorized when printed to an interactive terminal: headings, the At a Glance keys, status words and stage labels, priority tags, and inline commands get ANSI styling with zero dependencies. Files written with `--output`, pipes, CI logs, and machine formats (`json`, `agent`, `sarif`) are byte-identical to before; the standard `NO_COLOR` and `FORCE_COLOR` environment variables are honored.
+- `qamap init --agent` gives agent onboarding a single command: it adds a marked `Pre-PR QA (QAMap)` section to `AGENTS.md` (created if missing, appended if present, refreshed in place on re-runs without touching surrounding content), installs the packaged skill to `.claude/skills/qamap-pr-qa/SKILL.md`, and creates a starter `qamap.config.json` when none exists. Every step is idempotent, and a locally modified skill copy is never replaced without `--force`.
 - Korean action labels now qualify for flow and scenario naming: labels like `저장하기` or `신청하기` (36 common action stems, with `~하기/~합니다`-style endings) name the journey the same way English action words do, draft filenames keep Hangul instead of collapsing to an empty slug, and Korean submit-like labels drive `Submit` steps. This closes the known limit noted in 0.3.3.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Stop re-explaining the same QA context to your agent on every PR:
 qamap qa --format agent
 ```
 
-One minified JSON object (`schema: qamap.qa`, ~2 KB for a small PR) with affected flows, draft paths, required evidence, and the PR checklist — the decision content of the full report at a fraction of the context cost. A portable skill template ships in the package ([skills/qamap-pr-qa/SKILL.md](skills/qamap-pr-qa/SKILL.md)), and `qamap context --write AGENTS.md` teaches agents in a repo to run QAMap themselves. Details: [agent skill guide](docs/agent-skill.md).
+One minified JSON object (`schema: qamap.qa`, ~2 KB for a small PR) with affected flows, draft paths, required evidence, and the PR checklist — the decision content of the full report at a fraction of the context cost. To make agents run this themselves, run `qamap init --agent` once: it adds a Pre-PR QA section to `AGENTS.md` and installs the packaged skill ([skills/qamap-pr-qa/SKILL.md](skills/qamap-pr-qa/SKILL.md)) into `.claude/skills/`. Details: [agent skill guide](docs/agent-skill.md).
 
 ## Why QAMap
 

--- a/docs/agent-skill.md
+++ b/docs/agent-skill.md
@@ -8,6 +8,22 @@ The goal is not to replace a reviewer or claim QA passed. The goal is to remove 
 What user flow did this PR touch, what should be tested, and what evidence is missing?
 ```
 
+## One-Command Setup
+
+The fastest way to make a repository agent-ready is:
+
+```sh
+npx @ivorycanvas/qamap init --agent .
+```
+
+It performs three idempotent steps:
+
+- adds a marked `Pre-PR QA (QAMap)` section to `AGENTS.md` (created if missing, appended if present; re-runs refresh only the marked section and never touch your own content)
+- installs the packaged skill to `.claude/skills/qamap-pr-qa/SKILL.md` so Claude Code discovers it as a project skill (a locally modified copy is left alone unless you pass `--force`)
+- creates a starter `qamap.config.json` when the repository has none
+
+After that, agents that read `AGENTS.md` or project skills will run the QA pass below on their own. The rest of this document explains what that pass does and how to wire it manually on other agent surfaces.
+
 ## Recommended Agent Step
 
 Run this before writing a PR body or asking for review. Agents should prefer the compact agent format — one minified JSON object (about 2 KB for a typical small PR) instead of a long report:
@@ -39,7 +55,7 @@ Use it when an agent surface supports local skill folders, instruction folders, 
 After installing QAMap as a dev dependency, inspect the template:
 
 ```sh
-cat node_modules/qamap/skills/qamap-pr-qa/SKILL.md
+cat node_modules/@ivorycanvas/qamap/skills/qamap-pr-qa/SKILL.md
 ```
 
 Or from a cloned QAMap repository:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -78,6 +78,7 @@ That means QAMap is most valuable when it becomes the team's verification base: 
 | `qamap doctor services/listing --workspace-root .` | Scan a monorepo package while using root guardrails. |
 | `qamap context . --write AGENTS.md` | Generate starter agent instructions for the repo. |
 | `qamap init .` | Create a starter `qamap.config.json`. |
+| `qamap init --agent .` | One-command agent onboarding: add a marked QAMap Pre-PR QA section to `AGENTS.md`, install the packaged skill to `.claude/skills/qamap-pr-qa/SKILL.md`, and create `qamap.config.json` if missing. Idempotent; existing `AGENTS.md` content is preserved. |
 
 For monorepos, pass `--workspace-root` when scanning a package. Package-local checks still use the package directory, while repo-level guardrails such as `AGENTS.md`, `.github/workflows`, `LICENSE`, `SECURITY.md`, and `CONTRIBUTING.md` are read from the workspace root.
 

--- a/src/agent-init.ts
+++ b/src/agent-init.ts
@@ -1,0 +1,140 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { detectDlxCommand } from "./context.js";
+import { pathExists } from "./fs.js";
+import { writeDefaultConfig } from "./config.js";
+
+export type AgentInitFileStatus = "created" | "updated" | "unchanged" | "skipped";
+
+export interface AgentInitFile {
+  path: string;
+  status: AgentInitFileStatus;
+  detail: string;
+}
+
+export interface AgentInitResult {
+  root: string;
+  files: AgentInitFile[];
+  nextCommand: string;
+}
+
+const SECTION_START = "<!-- qamap:agent:start -->";
+const SECTION_END = "<!-- qamap:agent:end -->";
+const SKILL_RELATIVE_PATH = path.join("skills", "qamap-pr-qa", "SKILL.md");
+const SKILL_TARGET_RELATIVE_PATH = path.join(".claude", "skills", "qamap-pr-qa", "SKILL.md");
+
+export async function initAgentSetup(rootInput: string, options: { force?: boolean } = {}): Promise<AgentInitResult> {
+  const root = path.resolve(rootInput);
+  const dlxCommand = await detectDlxCommand(root);
+  const nextCommand = `${dlxCommand} qa . --base origin/main --head HEAD --format agent`;
+
+  const files: AgentInitFile[] = [];
+  files.push(await upsertAgentsSection(root, dlxCommand));
+  files.push(await copyPackagedSkill(root, options.force ?? false));
+  files.push(await ensureDefaultConfig(root));
+
+  return { root, files, nextCommand };
+}
+
+export function buildAgentQaSection(dlxCommand: string): string {
+  return [
+    SECTION_START,
+    "## Pre-PR QA (QAMap)",
+    "",
+    "Before opening or updating a pull request, run this local, token-free QA pass:",
+    "",
+    "```sh",
+    `${dlxCommand} qa . --base origin/main --head HEAD --format agent`,
+    "```",
+    "",
+    "- The output is one compact JSON object (`schema: qamap.qa`) with the affected user flows, missing QA evidence, and a PR checklist.",
+    "- Address every `requiredEvidence` item before handing the pull request to a human.",
+    "- If `requiredBootstrap` lists steps, run the reported `firstDraftCommand` to create the first runnable E2E starter draft.",
+    "- Treat the result as QA planning evidence, not as proof that browser, device, or manual QA passed.",
+    "- The full agent workflow lives in `.claude/skills/qamap-pr-qa/SKILL.md` when installed via `qamap init --agent`.",
+    SECTION_END,
+  ].join("\n");
+}
+
+async function upsertAgentsSection(root: string, dlxCommand: string): Promise<AgentInitFile> {
+  const agentsPath = path.join(root, "AGENTS.md");
+  const relativePath = "AGENTS.md";
+  const section = buildAgentQaSection(dlxCommand);
+
+  if (!(await pathExists(agentsPath))) {
+    const content = `# Agent Instructions\n\n${section}\n`;
+    await fs.writeFile(agentsPath, content, "utf8");
+    return { path: relativePath, status: "created", detail: "created with the QAMap Pre-PR QA section" };
+  }
+
+  const existing = await fs.readFile(agentsPath, "utf8");
+  const startIndex = existing.indexOf(SECTION_START);
+  const endIndex = existing.indexOf(SECTION_END);
+
+  if (startIndex !== -1 && endIndex !== -1 && endIndex > startIndex) {
+    const updated = existing.slice(0, startIndex) + section + existing.slice(endIndex + SECTION_END.length);
+    if (updated === existing) {
+      return { path: relativePath, status: "unchanged", detail: "QAMap section already up to date" };
+    }
+    await fs.writeFile(agentsPath, updated, "utf8");
+    return { path: relativePath, status: "updated", detail: "refreshed the QAMap Pre-PR QA section in place" };
+  }
+
+  const separator = existing.endsWith("\n\n") ? "" : existing.endsWith("\n") ? "\n" : "\n\n";
+  await fs.writeFile(agentsPath, `${existing}${separator}${section}\n`, "utf8");
+  return { path: relativePath, status: "updated", detail: "appended the QAMap Pre-PR QA section; existing content untouched" };
+}
+
+async function copyPackagedSkill(root: string, force: boolean): Promise<AgentInitFile> {
+  const sourcePath = path.join(packageRoot(), SKILL_RELATIVE_PATH);
+  const targetPath = path.join(root, SKILL_TARGET_RELATIVE_PATH);
+  const relativePath = SKILL_TARGET_RELATIVE_PATH;
+
+  const skillContent = await fs.readFile(sourcePath, "utf8");
+
+  if (await pathExists(targetPath)) {
+    const existing = await fs.readFile(targetPath, "utf8");
+    if (existing === skillContent) {
+      return { path: relativePath, status: "unchanged", detail: "packaged skill already installed" };
+    }
+    if (!force) {
+      return { path: relativePath, status: "skipped", detail: "differs from the packaged skill; pass --force to replace it" };
+    }
+    await fs.writeFile(targetPath, skillContent, "utf8");
+    return { path: relativePath, status: "updated", detail: "replaced with the packaged skill (--force)" };
+  }
+
+  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+  await fs.writeFile(targetPath, skillContent, "utf8");
+  return { path: relativePath, status: "created", detail: "installed the packaged QAMap PR QA skill" };
+}
+
+async function ensureDefaultConfig(root: string): Promise<AgentInitFile> {
+  const configPath = path.join(root, "qamap.config.json");
+  if (await pathExists(configPath)) {
+    return { path: "qamap.config.json", status: "unchanged", detail: "existing config kept" };
+  }
+  await writeDefaultConfig(root, "qamap.config.json", false);
+  return { path: "qamap.config.json", status: "created", detail: "default config written" };
+}
+
+function packageRoot(): string {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+}
+
+export function formatAgentInitReport(result: AgentInitResult): string {
+  const lines: string[] = [];
+  lines.push("# QAMap Agent Setup");
+  lines.push("");
+  for (const file of result.files) {
+    lines.push(`- [${file.status}] \`${file.path}\` — ${file.detail}`);
+  }
+  lines.push("");
+  lines.push("Agents that read `AGENTS.md` (or the installed skill) will now run QAMap before handing off a pull request.");
+  lines.push("");
+  lines.push("Try it yourself:");
+  lines.push("");
+  lines.push(`  ${result.nextCommand}`);
+  return lines.join("\n");
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { loadConfig, writeDefaultConfig } from "./config.js";
+import { formatAgentInitReport, initAgentSetup } from "./agent-init.js";
 import { generateAgentContext } from "./context.js";
 import { defaultDomainManifestPath, writeDefaultDomainManifest } from "./domains.js";
 import { buildDoctorResult, formatDoctorReport, formatMarkdownDoctorReport } from "./doctor.js";
@@ -81,6 +82,7 @@ interface ParsedOptions {
   manifestPath?: string;
   recordHistory?: boolean;
   dryRun?: boolean;
+  agent?: boolean;
 }
 
 async function main(argv: string[]): Promise<number> {
@@ -485,6 +487,11 @@ async function main(argv: string[]): Promise<number> {
 
   if (command === "init") {
     const options = parseOptions(rest);
+    if (options.agent) {
+      const result = await initAgentSetup(options.path, { force: options.force });
+      await printOrWrite(formatAgentInitReport(result));
+      return 0;
+    }
     const outputPath = await writeDefaultConfig(options.path, options.write ?? "qamap.config.json", options.force);
     console.log(`Wrote ${outputPath}`);
     return 0;
@@ -512,6 +519,11 @@ function parseOptions(args: string[]): ParsedOptions {
 
     if (arg === "--force") {
       options.force = true;
+      continue;
+    }
+
+    if (arg === "--agent") {
+      options.agent = true;
       continue;
     }
 
@@ -903,6 +915,9 @@ Start here, from inside your repository, on the branch you want to check:
       branches get sharper recommendations. Optional — qa works without it.
 
 Handing the result to a coding agent? Add: --format agent
+Want your agent to run QAMap by itself? Run once: qamap init --agent
+      Adds a Pre-PR QA section to AGENTS.md and installs the packaged
+      QAMap skill, so agents run the QA pass before every handoff.
 
 Full command reference: qamap help`);
 }
@@ -935,6 +950,7 @@ Usage:
   qamap history init [path]
   qamap context [path] [--write [file]] [--force]
   qamap init [path] [--write <file>] [--force]
+  qamap init --agent [path] [--force]
 
 Severities:
   info, low, medium, high
@@ -972,6 +988,7 @@ Examples:
   qamap test-plan services/listing --workspace-root . --base origin/main --head HEAD --include-working-tree
   qamap context . --write AGENTS.md
   qamap init .
+  qamap init --agent .
 `);
 }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -113,6 +113,11 @@ async function detectPackageManager(root: string): Promise<string | undefined> {
   return undefined;
 }
 
+export async function detectDlxCommand(rootInput: string): Promise<string> {
+  const packageManager = await detectPackageManager(path.resolve(rootInput));
+  return dlxCommandFor(packageManager);
+}
+
 function dlxCommandFor(packageManager: string | undefined): string {
   const normalized = packageManager?.split("@")[0];
   if (normalized === "pnpm") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
+export { buildAgentQaSection, formatAgentInitReport, initAgentSetup } from "./agent-init.js";
 export { defaultConfig, loadConfig, writeDefaultConfig } from "./config.js";
-export { generateAgentContext } from "./context.js";
+export { detectDlxCommand, generateAgentContext } from "./context.js";
 export { buildDomainLanguageSummary } from "./domain-language.js";
 export {
   defaultDomainManifestPath,

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -45,8 +45,8 @@ function colorizeLine(line: string): string {
     `${BOLD}$1${RESET}:`,
   );
   output = output.replace(/\[(required|missing|error)\]/g, `${RED}[$1]${RESET}`);
-  output = output.replace(/\[(recommended|warning)\]/g, `${YELLOW}[$1]${RESET}`);
-  output = output.replace(/\[(covered|ready|created|pass)\]/g, `${GREEN}[$1]${RESET}`);
+  output = output.replace(/\[(recommended|warning|skipped)\]/g, `${YELLOW}[$1]${RESET}`);
+  output = output.replace(/\[(covered|ready|created|updated|pass)\]/g, `${GREEN}[$1]${RESET}`);
   output = output.replace(
     /\b(Readiness|runnable|self-check|Status|status)(\[0m)?: (blocked|failed|fail|missing)\b/g,
     `$1$2: ${RED}$3${RESET}`,

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -6043,6 +6043,60 @@ test("reviewProject uses workspace root guardrails for package branches", async 
   );
 });
 
+test("initAgentSetup creates AGENTS.md, installs the packaged skill, and stays idempotent", async () => {
+  const { initAgentSetup, formatAgentInitReport } = await import("../dist/agent-init.js");
+  const root = await makeTempRepo();
+  await writeFile(path.join(root, "package.json"), JSON.stringify({ name: "smoke" }));
+
+  const first = await initAgentSetup(root);
+  assert.deepEqual(first.files.map((file) => file.status), ["created", "created", "created"]);
+  const agents = await readFile(path.join(root, "AGENTS.md"), "utf8");
+  assert.match(agents, /<!-- qamap:agent:start -->/);
+  assert.match(agents, /npx @ivorycanvas\/qamap qa \. --base origin\/main --head HEAD --format agent/);
+  assert.match(agents, /requiredEvidence/);
+  const skill = await readFile(path.join(root, ".claude", "skills", "qamap-pr-qa", "SKILL.md"), "utf8");
+  assert.match(skill, /name: qamap-pr-qa/);
+  await stat(path.join(root, "qamap.config.json"));
+
+  const second = await initAgentSetup(root);
+  assert.deepEqual(second.files.map((file) => file.status), ["unchanged", "unchanged", "unchanged"]);
+  const report = formatAgentInitReport(second);
+  assert.match(report, /# QAMap Agent Setup/);
+  assert.match(report, /npx @ivorycanvas\/qamap qa \./);
+});
+
+test("initAgentSetup appends to an existing AGENTS.md and refreshes only its own section", async () => {
+  const { initAgentSetup } = await import("../dist/agent-init.js");
+  const root = await makeTempRepo();
+  await writeFile(path.join(root, "package.json"), JSON.stringify({ name: "smoke" }));
+  await writeFile(path.join(root, "AGENTS.md"), "# Team Rules\n\n- Never push to main.\n");
+
+  const first = await initAgentSetup(root);
+  assert.equal(first.files[0].status, "updated");
+  const appended = await readFile(path.join(root, "AGENTS.md"), "utf8");
+  assert.ok(appended.startsWith("# Team Rules"));
+  assert.match(appended, /Never push to main/);
+  assert.match(appended, /<!-- qamap:agent:end -->/);
+
+  await writeFile(path.join(root, "AGENTS.md"), appended.replace("token-free QA pass", "OLD WORDING"));
+  const refreshed = await initAgentSetup(root);
+  assert.equal(refreshed.files[0].status, "updated");
+  const current = await readFile(path.join(root, "AGENTS.md"), "utf8");
+  assert.ok(current.startsWith("# Team Rules"));
+  assert.doesNotMatch(current, /OLD WORDING/);
+
+  await writeFile(
+    path.join(root, ".claude", "skills", "qamap-pr-qa", "SKILL.md"),
+    "locally modified",
+  );
+  const skipped = await initAgentSetup(root);
+  assert.equal(skipped.files[1].status, "skipped");
+  const forced = await initAgentSetup(root, { force: true });
+  assert.equal(forced.files[1].status, "updated");
+  const skill = await readFile(path.join(root, ".claude", "skills", "qamap-pr-qa", "SKILL.md"), "utf8");
+  assert.match(skill, /name: qamap-pr-qa/);
+});
+
 test("generateAgentContext reflects npm scripts and repository boundaries", async () => {
   const root = await makeTempRepo();
   await writeFile(


### PR DESCRIPTION
## Intent

Make agent onboarding a single command, so "wire QAMap into your agent workflow" stops being a documentation walkthrough and becomes ten seconds of setup.

`qamap init --agent` performs three idempotent steps:

- adds a marked `Pre-PR QA (QAMap)` section to `AGENTS.md` — created when the file is missing, appended when it exists, and refreshed in place between `<!-- qamap:agent:start/end -->` markers on re-runs, so surrounding team-authored content is never touched
- installs the packaged skill to `.claude/skills/qamap-pr-qa/SKILL.md` so Claude Code discovers it as a project skill; a locally modified copy is reported as `skipped` and only replaced with `--force`
- creates a starter `qamap.config.json` when none exists

The bare `qamap` start screen now advertises the command, `docs/agent-skill.md` opens with the one-command path, and `docs/commands.md` documents the new usage. Also fixes a stale `node_modules/qamap/...` path in `docs/agent-skill.md` left from the rename (the package is `@ivorycanvas/qamap`).

## Agent / Review Risk

- The generated `AGENTS.md` section makes only claims verified against the current `--format agent` output (`requiredEvidence`, `requiredBootstrap` as a step list, `firstDraftCommand`).
- File writes are additive and idempotent; nothing existing is overwritten without `--force`, and re-runs report `unchanged`.
- `qamap init` without the flag is byte-identical to before.

## Validation Evidence

- [x] `npm test` (107/107, including two new tests: fresh-repo create + idempotency, and existing-`AGENTS.md` append/refresh/skip/force behavior)
- [x] Manual smoke on a scratch project: create → re-run `unchanged` → team `AGENTS.md` preserved on append → marked section refreshed in place → modified skill `skipped`, replaced with `--force`.