### PR TITLE
Fix: strengthen manifest feedback reliability for 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+## 0.3.5 - 2026-07-11
+
+### Added
+
+- `manifest init` now creates reusable manual API contract flows for common server route, controller, handler, and framework-backed service modules. Each inferred flow carries API file anchors plus success-contract and invalid-request checks, so a baseline can shape later service changes instead of containing domains only.
+- The public benchmark can generate an external verification manifest from a fixture's base commit and assert manifest matches and manifest-backed QA flows against the head commit. API contract and reverse-import fixtures now protect this feedback loop in CI without executing fixture code.
+
+### Changed
+
+- A changed file that matches a declared manifest domain but no flow anchor now keeps manifest provenance on the best overlapping inferred flow. QAMap does not invent manifest checks or merge unrelated flows; it preserves the code-derived steps, selectors, and entrypoint while explaining the domain-level evidence.
+- Private repository smoke output is treated as local-only diagnostic data. Public regression coverage uses minimized synthetic fixtures and neutral sample vocabulary.
+
+### Fixed
+
+- Replaced legacy real-world-derived example vocabulary with neutral synthetic examples in tests and documentation.
+
 ## 0.3.4 - 2026-07-10
 
 ### Added
@@ -19,7 +35,7 @@
 
 - Reports are colorized when printed to an interactive terminal: headings, the At a Glance keys, status words and stage labels, priority tags, and inline commands get ANSI styling with zero dependencies. Files written with `--output`, pipes, CI logs, and machine formats (`json`, `agent`, `sarif`) are byte-identical to before; the standard `NO_COLOR` and `FORCE_COLOR` environment variables are honored.
 - Mock/fixture file detection now matches whole name tokens instead of substrings, and a bare `handler` filename no longer counts as mock evidence outside mock-style directories. Files like `useSeedlingCatalog.ts` or `errorHandler.ts` stop being misreported as fixtures, which also stops branches from being marked `ready` on the strength of ordinary source files.
-- Fixture guidance now names the concrete thing to do instead of assigning homework. QAMap statically reads the contents of discovered mock/fixture/seed files (up to 24 per plan) and extracts exports, handled routes (MSW, Mirage, express-style, Playwright `route(...)`), and response keys. Next actions become instructions like `Extend src/mocks/handlers.ts (already handles /api/invoices) to also cover /api/payments/summary` or `Reuse src/services/demoSeedService.ts (exports demoSeedService) to build a deterministic response for /api/sentiments/current`; missing-fixture guidance names the affected endpoints; generated Playwright mock bodies reuse the response keys observed in the matched fixture file instead of the `ok: true` placeholder; and fixture action-item titles carry the endpoints so the compact agent format keeps the target. Matched insights are exposed as an optional `mockInsights` array on `fixtureReadiness` in JSON output.
+- Fixture guidance now names the concrete thing to do instead of assigning homework. QAMap statically reads the contents of discovered mock/fixture/seed files (up to 24 per plan) and extracts exports, handled routes (MSW, Mirage, express-style, Playwright `route(...)`), and response keys. Next actions name the reusable fixture and uncovered endpoint; generated Playwright mock bodies reuse observed response keys instead of the `ok: true` placeholder; and fixture action-item titles carry the endpoints so the compact agent format keeps the target. Matched insights are exposed as an optional `mockInsights` array on `fixtureReadiness` in JSON output.
 - `qamap init --agent` gives agent onboarding a single command: it adds a marked `Pre-PR QA (QAMap)` section to `AGENTS.md` (created if missing, appended if present, refreshed in place on re-runs without touching surrounding content), installs the packaged skill to `.claude/skills/qamap-pr-qa/SKILL.md`, and creates a starter `qamap.config.json` when none exists. Every step is idempotent, and a locally modified skill copy is never replaced without `--force`.
 - Korean action labels now qualify for flow and scenario naming: labels like `저장하기` or `신청하기` (36 common action stems, with `~하기/~합니다`-style endings) name the journey the same way English action words do, draft filenames keep Hangul instead of collapsing to an empty slug, and Korean submit-like labels drive `Submit` steps. This closes the known limit noted in 0.3.3.
 

--- a/bench.config.json
+++ b/bench.config.json
@@ -58,9 +58,13 @@
     {
       "name": "api-orders-contract",
       "fixture": "test/benchmarks/api-orders-contract",
+      "manifestBaseline": true,
       "expect": {
         "runner": "manual",
         "minFlows": 1,
+        "minManifestMatches": 3,
+        "minManifestFlowMatches": 1,
+        "minManifestBackedFlows": 1,
         "mustReachFiles": ["src/routes/orders.ts"],
         "mustNameFlows": ["orders"],
         "mustDraftFiles": ["docs/e2e/orders-api-contract.md"],
@@ -86,10 +90,14 @@
     {
       "name": "web-shared-component",
       "fixture": "test/benchmarks/web-shared-component",
+      "manifestBaseline": true,
       "expect": {
         "runner": "playwright",
         "minFlows": 1,
         "minImportPropagatedFlows": 1,
+        "minManifestMatches": 3,
+        "minManifestFlowMatches": 1,
+        "minManifestBackedFlows": 1,
         "mustReachFiles": [
           "src/components/SubmitButton.tsx",
           "src/pages/checkout/index.tsx"

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -31,6 +31,9 @@ Each target can declare:
 | `minFlows` | Minimum number of affected flows. |
 | `minImportPropagatedFlows` | Minimum flows discovered through reverse imports. |
 | `minDiffAnchoredFlows` | Minimum flows using selector evidence introduced by the diff. |
+| `minManifestMatches` | Minimum domain, flow, and check matches from an external base manifest. |
+| `minManifestFlowMatches` | Minimum flow-level matches from the external base manifest. |
+| `minManifestBackedFlows` | Minimum QA flows that preserve manifest provenance. |
 | `mustReachFiles` | Files that the selected flows must reach. |
 | `mustNameFlows` | Product terms that must appear in a user-facing flow title. |
 | `mustNotNameFlows` | Misleading flow-title terms that must not be emitted. |
@@ -44,6 +47,8 @@ Each target can declare:
 | `maxBlankActions` | Maximum malformed or empty draft steps; public fixtures keep this at zero. |
 | `maxGenericTitles` | Maximum titles ending in generic `primary journey` or `smoke flow` wording. |
 | `maxAgentBytes` | Maximum UTF-8 payload size for `qa --format agent`. |
+
+Set `manifestBaseline: true` on a committed fixture to generate its manifest from the base snapshot into the benchmark temp directory, then pass that external manifest to analysis of the head commit. The fixture repository is never modified by this step. This protects the feedback loop itself: a baseline must affect the next PR, not merely serialize valid YAML.
 
 ## Local repositories
 
@@ -68,4 +73,4 @@ When a real repository produces a poor recommendation:
 3. Confirm `pnpm bench:ci` fails for the intended reason.
 4. Fix the inference and keep the fixture as permanent regression evidence.
 
-Do not copy proprietary code, credentials, or production data into a public fixture.
+Do not copy repository names, proprietary code, domain language, file paths, credentials, production data, or raw smoke output into a public fixture. Reduce the behavior to neutral synthetic vocabulary and keep private diagnostics outside the repository.

--- a/docs/e2e-output-examples.md
+++ b/docs/e2e-output-examples.md
@@ -367,7 +367,7 @@ If reusable repo-local evidence already exists, the PR QA output reads its conte
 
 ```txt
 Missing evidence before trusting this PR
-- [recommended] fixture: Confirm fixture coverage for /api/sentiments/current - Reuse src/services/demoSeedService.ts (exports demoSeedService) to build a deterministic response for /api/sentiments/current.
+- [recommended] fixture: Confirm fixture coverage for /api/sample/status - Reuse src/services/sampleSeed.ts (exports sampleSeed) to build a deterministic response for /api/sample/status.
 ```
 
 When an existing handler file already covers part of the flow, the next action names the file and the still-uncovered endpoints, for example `Extend src/mocks/handlers.ts (already handles /api/invoices) to also cover /api/payments/summary`. The generated Playwright mock bodies then reuse the response keys observed in that file (`invoices: "qamap-invoices"`) instead of the generic placeholder below, with a comment noting the source file.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -56,6 +56,10 @@ QAMap cannot know every team's product priorities from file paths alone. The man
 
 When a recommendation is wrong, edit the manifest path shown in QAMap output. The next branch should get better recommendations without another explanation.
 
+For server projects, the generated baseline can include manual API contract flows inferred from common route, controller, handler, and framework-backed service modules. These flows use file anchors and start with success-contract and invalid-request checks; maintainers should still review names, criticality, and project-specific failure behavior before committing them as team policy.
+
+A domain match is useful even when no declared flow anchor matches. In that case QAMap keeps the existing code-derived flow, steps, selectors, and entrypoint, and adds the manifest domain as provenance. It does not fabricate flow-level checks. Add or correct a flow anchor when the team wants the manifest to supply durable checks and runner details on later PRs.
+
 ## Concrete Bootstrap Example
 
 A first baseline can be useful before a human writes YAML by hand. Suppose the default branch has:

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -1,5 +1,19 @@
 # Release Validation
 
+## 0.3.5 - 2026-07-11
+
+Validated as a manifest-feedback reliability patch:
+
+| Gate | Current result |
+| --- | --- |
+| `pnpm test` | 127/127 passing |
+| `pnpm bench:ci` | Eight public PR fixtures pass; API and reverse-import fixtures also generate an external base manifest and require a manifest-backed head flow |
+| Coverage | Lines 86.09%, branches 83.18%, functions 94.66% |
+| `npm publish --dry-run --access public` | Passed for `@ivorycanvas/qamap@0.3.5`; 115 files, 772.8 kB packed |
+| API manifest baseline | Common server modules produce manual contract flows with API anchors and success/failure checks |
+| Domain fallback | Domain-only matches preserve manifest provenance without claiming unrelated files or inventing manifest checks |
+| Privacy | Public changes use synthetic fixtures; private smoke output remains outside the repository |
+
 ## 0.3.4 - 2026-07-10
 
 Validated before publishing `0.3.4` with a committed, CI-enforced recommendation contract instead of relying only on private smoke repositories:
@@ -216,40 +230,13 @@ The matrix below is public, fixture-backed evidence from the repository test sui
 
 See [E2E output examples](e2e-output-examples.md) for the kind of plan and draft snippets users should see from the current release.
 
-## Latest PR Validation Snapshot
+## Private Smoke Protocol
 
-Last verified on 2026-07-03 for the 0.3.1 README demo patch after removing the stale animated GIF from the README and npm tarball:
-
-| Check | Result |
-| --- | --- |
-| `pnpm test` | 95 tests passed. |
-| `git diff --check` | Passed. |
-| `pnpm pack --dry-run` | Passed; tarball includes 97 files and no committed demo GIF. |
-| `npm publish --dry-run --access public` | Passed for `@ivorycanvas/qamap@0.3.1`; package size is 289.1 kB and includes the manifest schema, quick-start docs, release docs, and `skills/qamap-pr-qa/SKILL.md`. |
-
-## Real Repository Smoke Snapshot
-
-The latest smoke run used private representative repositories and wrote draft output only under `/tmp/qamap-preview-*`. The smoke commands did not run `e2e setup` or write generated files into the target repositories. The table records public-safe target shapes rather than private repository names.
-
-2026-07-02 follow-up smoke on PR #71 ran `manifest context`, `manifest init --write /tmp/...`, `e2e plan`, and `e2e draft --dry-run` across 14 local Git repositories plus package-scoped scans for a large frontend monorepo. All commands completed without changing target repository status. The run exposed one important adoption need: users should be able to generate a manifest outside the target repo and pass it back into PR commands. PR #71 now supports that read-only preview through `--manifest <file>`.
-
-The same follow-up also showed the next quality gap. External manifest previews work, but many real branch changes did not match route/page-only manifest anchors, so generated drafts often stayed `domain-language`, `review-only`, or `near-runnable` instead of `verification-manifest`. The next release bar should improve component, function, API client, query, schema, and test anchors so manifest matches cover more than route files.
-
-| Target shape | Base/head mode | Result | Follow-up signal |
-| --- | --- | --- | --- |
-| Expo / React Native manifest baseline | `manifest init` wrote only to `/tmp/qamap-journal-note-manifest.yaml` | Generated 9 domains, 8 flows, 8 anchors, and 16 checks without changing the target repo. Direct `app/*.tsx` screens now produce specific paths such as `app/SentimentChatPage.tsx`; `+not-found.tsx` is not promoted as a product domain. | Good 0.2.x signal for baseline quality. Remaining work is richer screen/route semantics and selector-specific checks. |
-| Web monorepo package | Package scan with `--workspace-root`, feature branch compared with `main`, working tree included | Detected `web`, recommended Playwright, inferred a concrete route, produced changed-flow specs, and correctly blocked promotion because Playwright config, deterministic fixture/mock data, selector evidence, and validation evidence were missing. | Flow naming improved, but docs/design-only files can still create low-signal drafts that should be filtered or demoted. |
-| Expo / React Native app | Feature branch compared with `develop`, working tree included | Detected `expo-react-native`, recommended Maestro, found an existing Jest suite, produced multiple near-runnable YAML drafts, and gave useful blockers for missing Maestro directory plus missing stable mobile selectors. | Strongest current real-repo result; remaining gap is selector and app-specific setup quality. |
-| Nuxt / Vue web app with existing Playwright tests | `origin/develop` to `HEAD`, working tree included | Detected `web`, recommended Playwright, recognized existing test evidence, and blocked draft promotion because no Playwright config or runnable route/screen entrypoint was inferred. | Test-only or generated-test changes can still produce generic smoke draft names; QAMap should better distinguish changed tests from changed product behavior. |
-| Django-style API service | `origin/develop` to `HEAD`, working tree included | Detected `api-service`, selected manual output, found a large pytest suite, generated API contract and configuration checklists with zero TODOs, and avoided browser/device runner assumptions. | Good service classification; fixture readiness should become more endpoint-specific. |
-| Design token repository | `main` to `HEAD`, working tree included | Detected `design-tokens`, selected manual output, avoided browser/device selector requirements, and produced review-only artifact validation output. | Docs-only or style-only changes may still surface content/theme wording instead of token artifact language. |
-| Taxonomy / data catalog repository | `main` to `HEAD`, working tree included | Detected `data-catalog`, selected manual output, avoided API mock requirements, and produced review-only checklist output with no TODOs. | Catalog-specific changes are handled, but docs/config-only changes should be labeled more explicitly as low-signal. |
-
-Interpretation: the next release should be described as a planner that removes blank-page verification work by combining static analysis with repo-local manifest memory. The smoke results are useful, but they also show that many real repositories will start at `review-only` or `near-runnable` until teams add runner config, selectors, fixtures, validation evidence, and durable manifests.
+Private repositories may be used as local, read-only diagnostics, but their raw output is never release documentation or fixture input. Write manifests and drafts only to an operating-system temp directory, compare target `git status` before and after, and retain no repository names, paths, flow titles, source excerpts, or domain vocabulary in commits or pull requests. Reduce every confirmed defect to a minimal synthetic fixture before it enters the public suite.
 
 ## Ongoing Validation Notes
 
-The release candidate has passed the fixture-backed suite, package dry-run, npm publish dry-run, and representative private-repository smoke checks recorded above. For future patch releases, record only public-safe notes in this document or in release notes:
+The release candidate must pass the fixture-backed suite, package dry-run, and read-only smoke protocol. Record only public synthetic evidence in this document or in release notes:
 
 - whether the generated flow names match the team's domain language
 - whether the recommended runner is plausible
@@ -260,7 +247,7 @@ The release candidate has passed the fixture-backed suite, package dry-run, npm 
 
 ## Stop Conditions
 
-Do not publish `0.2.1` if any representative target shows one of these problems:
+Do not publish the current candidate if any representative target shows one of these problems:
 
 - generated flow names are dominated by generic folder names instead of product language
 - test-only or docs-only changes are presented as confident product journeys without low-signal wording

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.3.3",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ivorycanvas/qamap",
-      "version": "0.3.3",
+      "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Local-first QA skill that turns PR diffs into affected flows, missing evidence, and E2E drafts with no cloud or LLM token.",
   "type": "module",
   "packageManager": "pnpm@10.32.1",

--- a/scripts/bench.mjs
+++ b/scripts/bench.mjs
@@ -9,7 +9,12 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
-import { formatAgentQaDraft, generateE2ePlan, generateQaDraft } from "../dist/index.js";
+import {
+  formatAgentQaDraft,
+  generateE2ePlan,
+  generateQaDraft,
+  writeVerificationManifestBaseline,
+} from "../dist/index.js";
 
 const execFileAsync = promisify(execFile);
 const args = process.argv.slice(2);
@@ -31,6 +36,7 @@ for (const target of config.targets) {
       base: prepared.base,
       head: prepared.head,
       workspaceRoot: prepared.workspaceRoot,
+      manifestPath: prepared.manifestPath,
     };
     const startedAt = Date.now();
     const plan = await generateE2ePlan(prepared.root, options);
@@ -104,6 +110,9 @@ function scoreTarget(target, plan, qa, durationMs) {
     genericTitles: qa.flows.filter((flow) => genericTitlePattern.test(flow.title)).length,
     importPropagatedFlows: plan.flows.filter((flow) => flow.reason.includes("through imports")).length,
     diffAnchoredFlows: plan.flows.filter((flow) => (flow.selectors ?? []).some((selector) => selector.addedInDiff)).length,
+    manifestMatches: plan.verificationManifestMatches.length,
+    manifestFlowMatches: plan.verificationManifestMatches.filter((match) => match.kind === "flow").length,
+    manifestBackedFlows: qa.flows.filter((flow) => flow.source === "manifest-backed").length,
     blankActions: allSteps.filter((step) => blankActionPattern.test(step)).length,
     mustReachRecall: mustReach.length > 0 ? `${reached.length}/${mustReach.length}` : null,
     mustReachMissing: mustReach.filter((file) => !flowFiles.has(file)),
@@ -146,6 +155,15 @@ function evaluateContract(expect, result, plan, qa) {
   }
   if (expect.minDiffAnchoredFlows !== undefined && result.diffAnchoredFlows < expect.minDiffAnchoredFlows) {
     failures.push(`expected at least ${expect.minDiffAnchoredFlows} diff-anchored flow(s), got ${result.diffAnchoredFlows}`);
+  }
+  if (expect.minManifestMatches !== undefined && result.manifestMatches < expect.minManifestMatches) {
+    failures.push(`expected at least ${expect.minManifestMatches} manifest match(es), got ${result.manifestMatches}`);
+  }
+  if (expect.minManifestFlowMatches !== undefined && result.manifestFlowMatches < expect.minManifestFlowMatches) {
+    failures.push(`expected at least ${expect.minManifestFlowMatches} manifest flow match(es), got ${result.manifestFlowMatches}`);
+  }
+  if (expect.minManifestBackedFlows !== undefined && result.manifestBackedFlows < expect.minManifestBackedFlows) {
+    failures.push(`expected at least ${expect.minManifestBackedFlows} manifest-backed flow(s), got ${result.manifestBackedFlows}`);
   }
   appendMissingTerms(failures, "flow title", result.flowTitles, expect.mustNameFlows);
   appendUnexpectedTerms(failures, "flow title", result.flowTitles, expect.mustNotNameFlows);
@@ -217,6 +235,14 @@ async function materializeFixture(target, configDir) {
   await git(repositoryRoot, ["config", "user.name", "QAMap Benchmark"]);
   await git(repositoryRoot, ["add", "."]);
   await git(repositoryRoot, ["commit", "-m", "benchmark baseline"]);
+  let manifestPath;
+  if (target.manifestBaseline) {
+    manifestPath = path.join(tempRoot, "manifest.yaml");
+    await writeVerificationManifestBaseline(repositoryRoot, {
+      write: manifestPath,
+      force: true,
+    });
+  }
   await git(repositoryRoot, ["switch", "-c", "benchmark/change"]);
   if (await exists(headRoot)) {
     await fs.cp(headRoot, repositoryRoot, { recursive: true, force: true });
@@ -226,6 +252,7 @@ async function materializeFixture(target, configDir) {
   const prepared = targetPaths(target, repositoryRoot, "main", "HEAD");
   return {
     ...prepared,
+    manifestPath,
     cleanup: () => fs.rm(tempRoot, { recursive: true, force: true }),
   };
 }
@@ -266,6 +293,7 @@ function printTable(rows) {
     ["flows", 5],
     ["importPropagatedFlows", 10],
     ["diffAnchoredFlows", 10],
+    ["manifestFlowMatches", 8],
     ["blankActions", 6],
     ["genericTitles", 8],
     ["mustReachRecall", 10],
@@ -303,7 +331,7 @@ function printDeltas(baselineRows, currentRows) {
       continue;
     }
     const deltas = [];
-    for (const key of ["flows", "importPropagatedFlows", "diffAnchoredFlows", "blankActions", "genericTitles", "agentBytes"]) {
+    for (const key of ["flows", "importPropagatedFlows", "diffAnchoredFlows", "manifestFlowMatches", "blankActions", "genericTitles", "agentBytes"]) {
       const diff = (current[key] ?? 0) - (before[key] ?? 0);
       if (diff !== 0) {
         deltas.push(`${key} ${diff > 0 ? "+" : ""}${diff}`);
@@ -318,6 +346,7 @@ function shortLabel(key) {
     contractPassed: "contract",
     importPropagatedFlows: "viaImport",
     diffAnchoredFlows: "diffAnchor",
+    manifestFlowMatches: "manifest",
     blankActions: "blank",
     genericTitles: "generic",
     mustReachRecall: "reach",

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -6540,9 +6540,52 @@ async function buildManifestDraftFlows(
     .filter((match) => match.kind === "flow")
     .slice(0, 4);
   const checkMatches = plan.verificationManifestMatches.filter((match) => match.kind === "check");
-  return Promise.all(
+  const flowDrafts = await Promise.all(
     flowMatches.map((match) => buildManifestDraftFlow(plan, match, checkMatches, baseFlows)),
   );
+  const flowMatchedFiles = new Set(flowMatches.flatMap((match) => match.matchedFiles));
+  const domainDrafts = await Promise.all(
+    plan.verificationManifestMatches
+      .filter((match) => match.kind === "domain" && match.matchedFiles.some((file) => !flowMatchedFiles.has(file)))
+      .slice(0, 4)
+      .map((match) => buildManifestDomainDraftFlow(plan, match, baseFlows)),
+  );
+  return [...flowDrafts, ...domainDrafts.filter((flow): flow is DraftE2eFlow => Boolean(flow))].slice(0, 4);
+}
+
+async function buildManifestDomainDraftFlow(
+  plan: E2ePlanResult,
+  match: VerificationManifestMatch,
+  baseFlows: E2eFlow[],
+): Promise<DraftE2eFlow | undefined> {
+  const manifestFiles = normalizeScenarioFilesForRoot(plan, match.matchedFiles);
+  const baseFlow = bestOverlappingBaseFlowForManifestMatch(manifestFiles, baseFlows);
+  if (!baseFlow || isVerificationOnlyFlow(baseFlow)) {
+    return undefined;
+  }
+  // A domain path can cover many independent flows. Preserve manifest
+  // provenance on the best overlapping flow without claiming every matched
+  // domain file belongs to that single draft.
+  const files = baseFlow.files;
+  const flow: Omit<DraftE2eFlow, "languageBrief"> = {
+    ...baseFlow,
+    reason: `${match.reason} ${baseFlow.reason}`,
+    files,
+    entrypoints: uniqueEntrypoints([
+      ...baseFlow.entrypoints,
+      ...(await inferFlowEntrypoints(plan.root, files, plan.recommendedRunner.name)),
+    ]),
+    selectors: uniqueSelectors([
+      ...baseFlow.selectors,
+      ...(await inferFlowSelectors(plan.root, files, plan.recommendedRunner.name)),
+    ]),
+    draftSource: "verification-manifest",
+    manifestMatch: match,
+  };
+  return {
+    ...flow,
+    languageBrief: buildFlowLanguageBrief(flow),
+  };
 }
 
 async function buildManifestDraftFlow(
@@ -6608,6 +6651,13 @@ function bestBaseFlowForManifestMatch(files: string[], baseFlows: E2eFlow[]): E2
     }
   }
   return best && best.score > 0 ? best.flow : baseFlows[0];
+}
+
+function bestOverlappingBaseFlowForManifestMatch(files: string[], baseFlows: E2eFlow[]): E2eFlow | undefined {
+  const ranked = baseFlows
+    .map((flow) => ({ flow, score: fileOverlapScore(files, flow.files) }))
+    .sort((left, right) => right.score - left.score);
+  return ranked[0]?.score > 0 ? ranked[0].flow : undefined;
 }
 
 function coreFlowForManifestMatch(plan: E2ePlanResult, match: VerificationManifestMatch): MatchedCoreFlow | undefined {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -702,15 +702,22 @@ function buildVerificationManifestBaseline(
   files: ProjectFile[],
 ): VerificationManifest {
   const context = buildManifestContext(root, manifestRoot, files);
-  const behaviorFiles = files
-    .filter((file) => isBehaviorFile(file.path))
+  const manifestFiles = files
     .map((file) => ({
       ...file,
       path: toPosixPath(path.relative(manifestRoot, path.join(root, file.path))),
     }))
     .filter((file) => !file.path.startsWith("../"));
+  const behaviorFiles = manifestFiles.filter((file) => isBehaviorFile(file.path));
   const domains = mergeDomainsById(buildBaselineDomains(behaviorFiles, context), buildPythonAppDomains(files, manifestRoot, root)).slice(0, 12);
-  const flows = buildBaselineFlows(behaviorFiles, domains, inferRunner(files), context).slice(0, 16);
+  const runner = inferRunner(files);
+  const uiFlows = buildBaselineFlows(behaviorFiles, domains, runner, context);
+  const apiFlows = buildBaselineApiFlows(manifestFiles, domains, runner);
+  const flows = apiFlows.length === 0
+    ? uiFlows.slice(0, 16)
+    : uiFlows.length === 0
+      ? apiFlows.slice(0, 16)
+      : dedupeFlows([...uiFlows.slice(0, 12), ...apiFlows.slice(0, 4)]).slice(0, 16);
 
   return {
     $schema: verificationManifestSchemaUrl,
@@ -1620,6 +1627,160 @@ function buildBaselineFlows(
   return interleaveFlowsByDomain(dedupeFlows(scored.map((entry) => entry.flow)));
 }
 
+function buildBaselineApiFlows(
+  files: ProjectFile[],
+  domains: VerificationManifestDomain[],
+  runner: VerificationManifestRunner,
+): VerificationManifestFlow[] {
+  const serviceProject = runner === "manual" && hasApiServiceSignal(files);
+  const grouped = new Map<string, {
+    domain?: VerificationManifestDomain;
+    name: string;
+    anchors: VerificationManifestAnchor[];
+  }>();
+
+  for (const file of files) {
+    if (!isApiBehaviorFile(file.path, runner, serviceProject)) {
+      continue;
+    }
+    const domain = bestDomainForFile(domains, file.path);
+    const subject = domain?.name ?? apiSubjectFromFile(file.path);
+    const id = slugify(`${domain?.id ?? subject} api contract`);
+    if (!id) {
+      continue;
+    }
+    const symbol = /\.[cm]?[jt]sx?$/.test(file.path) && file.text
+      ? (exportedSymbolFromText(file.text, path.basename(file.path).replace(/\.[^.]+$/, "")) ?? undefined)
+      : undefined;
+    const anchor: VerificationManifestAnchor = {
+      kind: "api",
+      path: file.path,
+      symbol,
+      source: "inferred",
+      confidence: symbol ? "high" : "medium",
+    };
+    const existing = grouped.get(id);
+    if (existing) {
+      if (!existing.anchors.some((candidate) => candidate.path === anchor.path)) {
+        existing.anchors.push(anchor);
+      }
+      continue;
+    }
+    grouped.set(id, {
+      domain,
+      name: `${subject} API contract`,
+      anchors: [anchor],
+    });
+  }
+
+  return [...grouped.entries()]
+    .map(([id, value]) => ({
+      id,
+      domain: value.domain?.id,
+      name: value.name,
+      runner: "manual" as const,
+      anchors: value.anchors.slice(0, 6),
+      checks: [
+        {
+          id: "response-contract",
+          title: `Return the expected ${value.name.replace(/ API contract$/, "")} response contract`,
+          type: "contract" as const,
+        },
+        {
+          id: "invalid-request",
+          title: "Reject invalid requests without partial side effects",
+          type: "failure" as const,
+        },
+      ],
+      source: {
+        kind: "inferred" as const,
+        confidence: "medium" as const,
+        from: ["api-route-file"],
+      },
+    }))
+    .sort((left, right) => right.anchors.length - left.anchors.length || left.id.localeCompare(right.id));
+}
+
+function isApiBehaviorFile(
+  file: string,
+  runner: VerificationManifestRunner,
+  serviceProject: boolean,
+): boolean {
+  const normalized = toPosixPath(file);
+  if (/(?:^|\/)(?:tests?|__tests__|e2e|dist|build|out|\.output|__generated__)(?:\/|$)/i.test(normalized)) {
+    return false;
+  }
+  if (runner !== "manual") {
+    return false;
+  }
+  return (
+    /(?:^|\/)(?:api|routes?|controllers?|handlers?)\/.+\.(?:[cm]?[jt]s|py|go|rs|java|kt|cs|rb)$/i.test(normalized) ||
+    /(?:^|\/)(?:api|routes?|controllers?|handlers?|views)(?:\/[^/]+|[_-][^/]+)?\.py$/i.test(normalized) ||
+    /(?:^|\/)(?:urls|views|api|controllers?|handlers?)\.py$/i.test(normalized) ||
+    (serviceProject && isNamedServiceModule(normalized))
+  );
+}
+
+function isNamedServiceModule(file: string): boolean {
+  return (
+    /(?:^|\/)src\/(?:.*\/)?(?:domains?|features?|modules?|services?)\/.+\.(?:[cm]?[jt]s|py|go|rs|java|kt|cs|rb)$/i.test(file) ||
+    /(?:^|\/)[^/]*(?:controller|endpoint|gateway|handler|repository|resolver|router|service|use-?case)[^/]*\.(?:[cm]?[jt]s|py|go|rs|java|kt|cs|rb)$/i.test(file)
+  );
+}
+
+function hasApiServiceSignal(files: ProjectFile[]): boolean {
+  const serverDependencies = new Set([
+    "@hapi/hapi",
+    "@nestjs/core",
+    "express",
+    "fastify",
+    "hono",
+    "koa",
+    "restify",
+  ]);
+  for (const file of files) {
+    if (!file.text) {
+      continue;
+    }
+    const basename = path.basename(file.path).toLowerCase();
+    if (basename === "package.json") {
+      try {
+        const parsed = JSON.parse(file.text) as {
+          dependencies?: Record<string, unknown>;
+          devDependencies?: Record<string, unknown>;
+        };
+        const dependencies = { ...parsed.dependencies, ...parsed.devDependencies };
+        if ([...serverDependencies].some((dependency) => dependencies[dependency] !== undefined)) {
+          return true;
+        }
+      } catch {
+        continue;
+      }
+    }
+    if (
+      ["requirements.txt", "pyproject.toml", "pipfile"].includes(basename) &&
+      /\b(?:django|fastapi|flask|litestar|sanic|starlette)\b/i.test(file.text)
+    ) {
+      return true;
+    }
+    if (basename === "go.mod" && /\b(?:gin-gonic|gofiber|labstack\/echo)\b/i.test(file.text)) {
+      return true;
+    }
+    if (basename === "cargo.toml" && /\b(?:actix-web|axum|rocket)\b/i.test(file.text)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function apiSubjectFromFile(file: string): string {
+  const segments = toPosixPath(file).split("/").filter(Boolean);
+  const basename = (segments.at(-1) ?? "api").replace(/\.[^.]+$/, "");
+  const generic = /^(?:api|controller|controllers|handler|handlers|index|route|routes|urls|view|views)$/i;
+  const candidate = generic.test(basename) ? (segments.at(-2) ?? "api") : basename;
+  return titleCase(candidate) || "API";
+}
+
 const productSignalMatcher =
   /login|signin|sign-in|signup|sign-up|register|auth|password|payment|pay\b|checkout|billing|subscription|purchase|order|cart|onboarding|settings|account|profile|search|upload|home/i;
 
@@ -2266,7 +2427,7 @@ function domainCandidateFromPath(file: string): { id: string; name: string; from
       }
     }
     // The basename may only speak for itself when the file sits directly
-    // under the route dir (app/SentimentChatPage.tsx), not when a
+    // under the route dir (app/SampleChatPage.tsx), not when a
     // structural directory owns the subtree. Router-convention names
     // (_layout, +not-found, (group)) never qualify.
     if (segments.length === routeIndex + 2) {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const TOOL_NAME = "QAMap";
-export const VERSION = "0.3.4";
+export const VERSION = "0.3.5";

--- a/test/manifest-feedback.test.mjs
+++ b/test/manifest-feedback.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+import {
+  generateE2ePlan,
+  generateQaDraft,
+  loadVerificationManifest,
+  matchVerificationManifest,
+  writeVerificationManifestBaseline,
+} from "../dist/index.js";
+
+const execFileAsync = promisify(execFile);
+
+test("manifest init creates reusable API contract flows", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "qamap-manifest-api-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await mkdir(path.join(root, "src/services"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      name: "sample-api-service",
+      private: true,
+      dependencies: { fastify: "5.0.0" },
+      scripts: { test: "node --test" },
+    }),
+  );
+  await writeFile(
+    path.join(root, "src/services/sample-service.ts"),
+    [
+      "export async function listSamples() {",
+      "  return { items: [] };",
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  const result = await writeVerificationManifestBaseline(root);
+  const apiFlow = result.manifest.flows.find((flow) => flow.anchors.some((anchor) => anchor.kind === "api"));
+  assert.ok(apiFlow, "expected an API contract flow in the generated baseline");
+  assert.equal(apiFlow.runner, "manual");
+  assert.equal(apiFlow.anchors[0].path, "src/services/sample-service.ts");
+  assert.deepEqual(apiFlow.checks.map((check) => check.type), ["contract", "failure"]);
+
+  const manifest = await loadVerificationManifest(root);
+  const matches = matchVerificationManifest(manifest, [{ status: "M", path: "src/services/sample-service.ts" }]);
+  assert.equal(matches.filter((match) => match.kind === "flow").length, 1);
+  assert.equal(matches.filter((match) => match.kind === "check").length, 2);
+});
+
+test("manifest init keeps generic service modules out of API flows without server evidence", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "qamap-manifest-library-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await mkdir(path.join(root, "src/services"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({ name: "sample-library", private: true }),
+  );
+  await writeFile(
+    path.join(root, "src/services/sample-service.ts"),
+    "export function formatSample() { return 'sample'; }\n",
+  );
+
+  const result = await writeVerificationManifestBaseline(root);
+  assert.equal(result.manifest.flows.some((flow) => flow.anchors.some((anchor) => anchor.kind === "api")), false);
+});
+
+test("domain-only manifest matches preserve manifest provenance in QA drafts", async (t) => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "qamap-manifest-domain-"));
+  const root = path.join(tempRoot, "repo");
+  const manifestPath = path.join(tempRoot, "manifest.yaml");
+  t.after(() => rm(tempRoot, { recursive: true, force: true }));
+  await mkdir(path.join(root, "src/services/sample/api"), { recursive: true });
+  await mkdir(path.join(root, "src/services/sample/store"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      name: "sample-package",
+      private: true,
+      scripts: { test: "node --test" },
+    }),
+  );
+  const recordPath = path.join(root, "src/services/sample/recordService.ts");
+  const clientPath = path.join(root, "src/services/sample/api/client.ts");
+  const statePath = path.join(root, "src/services/sample/store/sessionState.ts");
+  await writeFile(recordPath, "export const record = () => true;\n");
+  await writeFile(clientPath, "export const endpoint = '/sample';\n");
+  await writeFile(statePath, "export const sessionState = new Map();\n");
+  await git(root, ["init", "-b", "main"]);
+  await git(root, ["config", "user.email", "test@qamap.local"]);
+  await git(root, ["config", "user.name", "QAMap Test"]);
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "baseline"]);
+  await writeFile(
+    manifestPath,
+    JSON.stringify({
+      version: 1,
+      domains: [
+        {
+          id: "sample",
+          name: "Sample",
+          paths: ["src/services/sample/**"],
+          criticality: "medium",
+          source: { kind: "declared", confidence: "high", from: ["team-review"] },
+        },
+      ],
+      flows: [],
+    }),
+  );
+  await git(root, ["switch", "-c", "feature/change"]);
+  await writeFile(recordPath, "export const record = () => 'changed';\n");
+  await writeFile(clientPath, "export const endpoint = '/sample/v2';\n");
+  await writeFile(statePath, "export const sessionState = new Map([['ready', true]]);\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "change sample page"]);
+
+  const options = { base: "main", head: "HEAD", manifestPath };
+  const plan = await generateE2ePlan(root, options);
+  assert.equal(plan.verificationManifestMatches.filter((match) => match.kind === "domain").length, 1);
+  assert.equal(plan.verificationManifestMatches.filter((match) => match.kind === "flow").length, 0);
+  assert.ok(plan.flows.length >= 2);
+
+  const qa = await generateQaDraft(root, options);
+  assert.equal(qa.flows.length, plan.flows.length);
+  assert.equal(qa.flows.filter((flow) => flow.source === "manifest-backed").length, 1);
+});
+
+async function git(cwd, args) {
+  await execFileAsync("git", args, { cwd });
+}

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -2394,14 +2394,14 @@ test("qa command points API-dependent flows at existing repo mock and seed files
       },
     }),
   );
-  await writeFile(path.join(root, "app.json"), JSON.stringify({ expo: { name: "Journal Fixture" } }));
+  await writeFile(path.join(root, "app.json"), JSON.stringify({ expo: { name: "Sample Fixture" } }));
   await writeFile(
     path.join(root, "src/services/metricsMockService.ts"),
     "export const metricsMockService = { success: () => ({ status: 'ready' }) };\n",
   );
   await writeFile(
-    path.join(root, "src/services/demoSeedService.ts"),
-    "export const demoSeedService = { seed: async () => 1 };\n",
+    path.join(root, "src/services/sampleSeed.ts"),
+    "export const sampleSeed = { seed: async () => 1 };\n",
   );
   await writeFile(
     path.join(root, "ios/Pods/boost/boost/random/detail/generator_seed_seq.hpp"),
@@ -2412,25 +2412,25 @@ test("qa command points API-dependent flows at existing repo mock and seed files
     "export function HomePage() { return null; }\n",
   );
   await writeFile(
-    path.join(root, "src/services/sentimentService.ts"),
-    "export async function loadSentiment() { return { score: 1 }; }\n",
+    path.join(root, "src/services/sampleStatusService.ts"),
+    "export async function loadSampleStatus() { return { status: 'ready' }; }\n",
   );
   await git(root, ["add", "."]);
   await git(root, ["commit", "-m", "base"]);
   await git(root, ["branch", "-M", "main"]);
 
-  await git(root, ["switch", "-c", "feature/sentiment-api"]);
+  await git(root, ["switch", "-c", "feature/sample-api"]);
   await writeFile(
-    path.join(root, "src/services/sentimentService.ts"),
+    path.join(root, "src/services/sampleStatusService.ts"),
     [
-      "export async function loadSentiment() {",
-      "  const response = await fetch('/api/sentiments/current');",
+      "export async function loadSampleStatus() {",
+      "  const response = await fetch('/api/sample/status');",
       "  return response.json();",
       "}",
     ].join("\n"),
   );
   await git(root, ["add", "."]);
-  await git(root, ["commit", "-m", "load sentiment api"]);
+  await git(root, ["commit", "-m", "load sample api"]);
 
   const qa = await generateQaDraft(root, { base: "main", head: "HEAD", runner: "maestro" });
   const markdown = formatMarkdownQaDraft(qa);
@@ -2440,10 +2440,10 @@ test("qa command points API-dependent flows at existing repo mock and seed files
   assert.equal(fixtureGap.priority, "recommended");
   assert.match(
     fixtureGap.detail,
-    /Reuse src\/services\/demoSeedService\.ts \(exports demoSeedService\) to build a deterministic response for \/api\/sentiments\/current/,
+    /Reuse src\/services\/sampleSeed\.ts \(exports sampleSeed\) to build a deterministic response for \/api\/sample\/status/,
   );
   assert.doesNotMatch(fixtureGap.detail, /ios\/Pods/);
-  assert.match(markdown, /src\/services\/demoSeedService\.ts/);
+  assert.match(markdown, /src\/services\/sampleSeed\.ts/);
   assert.doesNotMatch(markdown, /ios\/Pods/);
 });
 
@@ -6035,8 +6035,8 @@ test("manifest init keeps Expo app file domains specific", async () => {
   await writeFile(path.join(root, "app/+not-found.tsx"), "export default function NotFound() { return null; }\n");
   await writeFile(path.join(root, "app/_layout.tsx"), "export default function Layout() { return null; }\n");
   await writeFile(
-    path.join(root, "app/SentimentChatPage.tsx"),
-    "export default function SentimentChatPage() { return <Button title=\"Send\" />; }\n",
+    path.join(root, "app/SampleChatPage.tsx"),
+    "export default function SampleChatPage() { return <Button title=\"Send\" />; }\n",
   );
   await writeFile(
     path.join(root, "app/SettingsPage.tsx"),
@@ -6047,10 +6047,10 @@ test("manifest init keeps Expo app file domains specific", async () => {
   const manifest = await loadVerificationManifest(root);
 
   assert.equal(manifest.domains.some((domain) => domain.id === "not-found"), false);
-  assert.ok(manifest.domains.some((domain) => domain.id === "sentimentchatpage"));
-  assert.ok(manifest.domains.some((domain) => domain.paths.includes("app/SentimentChatPage.tsx")));
+  assert.ok(manifest.domains.some((domain) => domain.id === "samplechatpage"));
+  assert.ok(manifest.domains.some((domain) => domain.paths.includes("app/SampleChatPage.tsx")));
   assert.ok(manifest.domains.some((domain) => domain.paths.includes("app/SettingsPage.tsx")));
-  assert.ok(manifest.flows.some((flow) => flow.domain === "sentimentchatpage"));
+  assert.ok(manifest.flows.some((flow) => flow.domain === "samplechatpage"));
   assert.equal(manifest.flows.some((flow) => flow.domain === "not-found"), false);
 });
 


### PR DESCRIPTION
## Intent

Prepare QAMap 0.3.5 as a focused manifest-feedback reliability patch. A generated baseline should affect the next change instead of only producing valid YAML.

## Changes

- Infer conservative manual API contract flows from common server structures when repository-level server evidence exists.
- Preserve manifest provenance when a changed file matches a declared domain but no flow anchor, without inventing checks or merging unrelated flows.
- Generate external base manifests inside committed benchmark fixtures and require manifest-backed head flows in CI.
- Replace legacy real-world-derived examples with neutral synthetic vocabulary and document a strict private-smoke protocol.
- Align package metadata and release validation with 0.3.5.

## Validation

- `pnpm run release:check`
- 127/127 tests passed
- Public benchmark contract: 8/8
- Coverage: lines 86.09%, branches 83.18%, functions 94.66%
- `npm publish --dry-run --access public`
- Read-only local smoke matrix completed with every target worktree unchanged

## Security and privacy

- No target repository names, paths, flow titles, source excerpts, or domain vocabulary are included in this PR.
- Local smoke manifests, reports, and drafts were written only to operating-system temp directories.
- No target repository files, commits, pushes, or pull requests were created.

## Release scope

This PR prepares version 0.3.5 only. It does not publish npm, create a Git tag, or create a GitHub Release.
