### PR TITLE
Feat: prepare 0.4.0 intent-first QA design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,18 @@
 
 - Added the first framework-neutral Behavior Graph contract with stable content-derived node and edge ids, evidence provenance, direct and propagated impact, deterministic graph merging, adapter diagnostics, and an analyzer adapter interface for future language and framework support.
 - Added a compatibility adapter that maps existing inferred flows, entrypoints, steps, assertions, selectors, fixtures, and changed source files into the graph. `generateE2ePlan` now exposes this additive graph without changing current runner recommendations or human reports.
+- Added a verification-manifest Behavior Graph adapter. Matched domains, flows, checks, routes, selectors, and source files now retain reviewed manifest provenance and package-scoped impact inside the graph.
+- Added public Vue and SvelteKit branch fixtures that require changed selectors, success signals, exact routes, draft paths, and Behavior Graph node kinds to remain useful without React-specific assumptions.
+- Added a shipped Behavior Graph JSON Schema and exported runtime enum constants so local consumers and future adapters can validate graph version 1 without an LLM or cloud service.
 
 ### Changed
 
 - Documented the architecture and conservative pre-1.0 version policy: compatible graph and adapter improvements remain patch work, while the next minor is reserved for a complete explicit diff-to-evidence execution slice.
+
+### Fixed
+
+- Test and benchmark fixtures no longer make a CLI repository look like a design-token or data-catalog project, and a real `package.json` bin entry takes precedence over incidental artifact files.
+- SvelteKit convention files such as `+page.svelte` now resolve to their containing route (`/settings`) instead of adding a false `/page` segment.
 
 ## 0.3.5 - 2026-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,31 @@
 
 ## Unreleased
 
-## 0.3.6 - 2026-07-11
+## 0.4.0 - 2026-07-12
 
 ### Added
 
 - Added the first framework-neutral Behavior Graph contract with stable content-derived node and edge ids, evidence provenance, direct and propagated impact, deterministic graph merging, adapter diagnostics, and an analyzer adapter interface for future language and framework support.
-- Added a compatibility adapter that maps existing inferred flows, entrypoints, steps, assertions, selectors, fixtures, and changed source files into the graph. `generateE2ePlan` now exposes this additive graph without changing current runner recommendations or human reports.
+- Added a compatibility adapter that maps existing inferred flows, entrypoints, steps, assertions, selectors, fixtures, and changed source files into the graph.
 - Added a verification-manifest Behavior Graph adapter. Matched domains, flows, checks, routes, selectors, and source files now retain reviewed manifest provenance and package-scoped impact inside the graph.
+- Added deterministic Change Intent analysis. Behavior-bearing commits are grouped by normalized product evidence, connected to added diff symbols, assigned confidence and review requirements, and converted into ordered trigger, condition, action, state-change, side-effect, and observable-outcome lifecycles.
+- Added runner-independent primary, failure, boundary, and state-transition QA scenarios derived from each lifecycle. Medium- and high-confidence intent now replaces generic `primary journey` and `smoke flow` candidates before Playwright, Maestro, or manual draft compilation.
+- Added the `qamap.change-intent` Behavior Graph adapter with commit provenance, intent contracts, lifecycle nodes, scenario assertions, source links, and direct or propagated impact.
+- Added Change Intent, lifecycle, and QA scenarios to Markdown, JSON, dry-run, and the additive `qamap.qa` agent format contract.
 - Added public Vue and SvelteKit branch fixtures that require changed selectors, success signals, exact routes, draft paths, and Behavior Graph node kinds to remain useful without React-specific assumptions.
+- Added synthetic web preferences and mobile reminder lifecycle benchmarks. The public matrix now rejects generic titles and directly requires intent names, lifecycle stages, QA scenario axes, commit-backed graph nodes, selectors, outcomes, and draft paths.
 - Added a shipped Behavior Graph JSON Schema and exported runtime enum constants so local consumers and future adapters can validate graph version 1 without an LLM or cloud service.
 
 ### Changed
 
-- Documented the architecture and conservative pre-1.0 version policy: compatible graph and adapter improvements remain patch work, while the next minor is reserved for a complete explicit diff-to-evidence execution slice.
+- Human reports now present change intent and QA design before runner setup. Playwright, Maestro, and manual output are labeled automation adapters rather than the primary recommendation.
+- Documented the architecture and conservative pre-1.0 version policy: compatible analyzer and adapter improvements remain patch work, while the next minor is reserved for explicit temporary execution and normalized evidence.
 
 ### Fixed
 
 - Test and benchmark fixtures no longer make a CLI repository look like a design-token or data-catalog project, and a real `package.json` bin entry takes precedence over incidental artifact files.
 - SvelteKit convention files such as `+page.svelte` now resolve to their containing route (`/settings`) instead of adding a false `/page` segment.
+- Language syntax such as TypeScript `export` and `async` no longer contaminates intent clustering or lifecycle state inference, and ordinary web click handlers no longer fabricate external entry-payload scenarios.
 
 ## 0.3.5 - 2026-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Added
+
+- Added the first framework-neutral Behavior Graph contract with stable content-derived node and edge ids, evidence provenance, direct and propagated impact, deterministic graph merging, adapter diagnostics, and an analyzer adapter interface for future language and framework support.
+- Added a compatibility adapter that maps existing inferred flows, entrypoints, steps, assertions, selectors, fixtures, and changed source files into the graph. `generateE2ePlan` now exposes this additive graph without changing current runner recommendations or human reports.
+
+### Changed
+
+- Documented the architecture and conservative pre-1.0 version policy: compatible graph and adapter improvements remain patch work, while the next minor is reserved for a complete explicit diff-to-evidence execution slice.
+
 ## 0.3.5 - 2026-07-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.3.6 - 2026-07-11
+
 ### Added
 
 - Added the first framework-neutral Behavior Graph contract with stable content-derived node and edge ids, evidence provenance, direct and propagated impact, deterministic graph merging, adapter diagnostics, and an analyzer adapter interface for future language and framework support.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@
 [![npm version](https://img.shields.io/npm/v/@ivorycanvas/qamap.svg)](https://www.npmjs.com/package/@ivorycanvas/qamap)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**A local, zero-LLM QA map for code changes. QAMap turns any PR diff into affected behavior, missing evidence, and deterministic E2E drafts. No cloud. No source upload. No token.**
+**A local, zero-LLM PR QA designer. QAMap turns commit intent and code diffs into evidence-backed behavior lifecycles, missing QA, and deterministic automation drafts. No cloud. No source upload. No token.**
 
-QAMap reads git changes, project structure, runner signals, selectors, and optional repo QA memory, then answers the question every reviewer asks: *"This PR looks plausible — which user flow could it break, and what should we verify before merge?"* It focuses on the judgment step ("what deserves testing"), not on competing with LLMs at writing test code.
+QAMap reads commit subjects and bodies, git changes, project structure, selectors, existing tests, and optional repo QA memory, then answers the question every reviewer asks: *"What behavior did this PR intend to change, how does that behavior move through the product, and what should we verify before merge?"* Playwright, Maestro, and manual checklists are output adapters after that judgment, not the product recommendation itself.
 
 ```txt
-PR diff
+PR commits + diff
   -> qamap qa
-  -> affected flows + missing evidence + PR checklist + E2E starter draft
+  -> change intent + behavior lifecycle + QA scenarios + missing evidence
+  -> optional Playwright / Maestro / manual draft
 
 Optional team memory (.qamap/manifest.yaml)
   -> sharper recommendations on every future PR
@@ -23,17 +24,19 @@ Optional team memory (.qamap/manifest.yaml)
 
 A real, unedited recording on a Next.js app with **zero committed tests**: `qamap qa` names the affected flow, `qamap e2e setup` writes the Playwright config and a starter spec, and `npm run test:e2e` finishes with `1 passed`. First-run assertions are smoke checks — the point is a runnable starting point, not finished coverage.
 
-Every report now opens with the verdict (trimmed real output):
+Every report opens with intent and behavior before automation tooling (trimmed output):
 
 ```txt
 ## At a Glance
 
-- Affected behavior: Checkout Submit
-- Verify before merge: ... this outcome is verified: visible text "Order confirmed" appears?
+- Change intent: Submit checkout and persist the confirmed order [high]
+- Behavior lifecycle: trigger: submit checkout -> side-effect: create order -> observable-outcome: show order confirmation
+- Affected behavior: Submit checkout and persist the confirmed order
+- Verify before merge: the confirmed order is visible and survives re-entry
 - Evidence found: changed file src/pages/checkout/index.tsx; route: /checkout (high); web-test-id: checkout-submit (...)
 - Proposed draft: `tests/e2e/checkout-submit.spec.ts` (near runnable)
-- Next command: `qamap e2e setup . --runner playwright`
 - Missing before trust: Add deterministic fixture or mock data for /api/checkout (...)
+- Automation adapter: Playwright
 ```
 
 ## Install & Quick Start
@@ -56,11 +59,12 @@ Stop re-explaining the same QA context to your agent on every PR:
 qamap qa --format agent
 ```
 
-One minified JSON object (`schema: qamap.qa`, ~2 KB for a small PR) with affected flows, draft paths, required evidence, and the PR checklist — the decision content of the full report at a fraction of the context cost. The shape is a documented, versioned contract: [agent format contract](docs/agent-format.md). To make agents run this themselves, run `qamap init --agent` once: it adds a Pre-PR QA section to `AGENTS.md` and installs the packaged skill ([skills/qamap-pr-qa/SKILL.md](skills/qamap-pr-qa/SKILL.md)) into `.claude/skills/`. Details: [agent skill guide](docs/agent-skill.md).
+One minified JSON object (`schema: qamap.qa`) with change intents, lifecycle stages, QA scenarios, affected flows, required evidence, and draft paths. It carries the decision content of the full report at a fraction of the context cost. The shape is a documented, versioned contract: [agent format contract](docs/agent-format.md). To make agents run this themselves, run `qamap init --agent` once: it adds a Pre-PR QA section to `AGENTS.md` and installs the packaged skill ([skills/qamap-pr-qa/SKILL.md](skills/qamap-pr-qa/SKILL.md)) into `.claude/skills/`. Details: [agent skill guide](docs/agent-skill.md).
 
 ## Why QAMap
 
-- **Judgment first, generation second.** LLMs write test code well; deciding *what deserves testing* for a given diff is the missing layer. QAMap fills it statically, deterministically, for free.
+- **Intent and lifecycle before runner choice.** QAMap groups behavior-bearing commits, connects them to diff symbols, and proposes success, failure, boundary, and state-transition QA before selecting an automation adapter.
+- **Judgment first, generation second.** Deciding *what deserves testing* for a given change is the missing layer. QAMap makes that judgment statically, deterministically, and locally for free.
 - **The repo remembers.** Team QA knowledge lives in `.qamap/manifest.yaml`, reviewed once and reused on every PR — instead of re-prompting an agent each session.
 - **Honest output.** Drafts state what blocks them from being trusted; changed endpoints are observed, never mocked away; generated specs never assert what cannot pass. Configuration, docs, generated artifacts, and changed tests stay in verification mode instead of fabricating a product-journey E2E.
 
@@ -69,15 +73,15 @@ Positioning against recorders, LLM test generation, and impact-analysis tools: [
 <details>
 <summary>한국어 소개</summary>
 
-QAMap는 AI 코딩 에이전트가 만든 PR을 리뷰하기 전에 로컬에서 실행하는 QA 초안 CLI입니다.
+QAMap는 PR을 리뷰하기 전에 로컬에서 실행하는 zero-LLM QA 설계 CLI입니다.
 
-PR diff와 repo 구조를 읽고 어떤 사용자 플로우가 영향받았는지, 어떤 E2E 또는 체크리스트가 필요한지, fixture/selector/assertion/runner/validation 근거 중 무엇이 부족한지 정리합니다. 클라우드나 LLM 토큰을 쓰지 않습니다.
+PR 커밋 의도와 diff, repo 구조를 읽고 변경 의도, 기능 생명주기, 정상·실패·경계·상태 전환 QA, 부족한 fixture/selector/assertion 근거를 정리합니다. 그 다음 기존 테스트 환경에 맞춰 Playwright, Maestro 또는 수동 체크리스트 초안을 제시합니다. 클라우드나 LLM 토큰을 쓰지 않습니다.
 
 ```sh
 pnpm dlx @ivorycanvas/qamap qa . --base origin/main --head HEAD
 ```
 
-에이전트에게 넘길 때는 `--format agent`를 붙이면 같은 판단 내용을 약 2KB의 JSON으로 받을 수 있어, 매 세션 repo 탐색에 토큰을 쓰지 않아도 됩니다.
+에이전트에게 넘길 때는 `--format agent`를 붙이면 같은 판단 내용을 압축된 JSON으로 받을 수 있어, 매 세션 repo 탐색에 토큰을 반복해서 쓰지 않아도 됩니다.
 
 목표는 거대한 QA 플랫폼이 아니라, 유지보수자가 매번 에이전트에게 프로젝트 맥락과 검증 방법을 다시 설명하느라 쓰는 시간을 줄여주는 작고 선명한 도구입니다. Manifest 없이 바로 시작하고, 반복해서 틀리는 추천은 `.qamap/manifest.yaml`에 팀의 QA 언어로 보정해 향후 PR 추천을 개선합니다.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm version](https://img.shields.io/npm/v/@ivorycanvas/qamap.svg)](https://www.npmjs.com/package/@ivorycanvas/qamap)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**A local-first QA skill for AI-generated PRs. QAMap turns a PR diff into affected flows, missing evidence, and E2E drafts. No cloud. No LLM token.**
+**A local, zero-LLM QA map for code changes. QAMap turns any PR diff into affected behavior, missing evidence, and deterministic E2E drafts. No cloud. No source upload. No token.**
 
 QAMap reads git changes, project structure, runner signals, selectors, and optional repo QA memory, then answers the question every reviewer asks: *"This PR looks plausible — which user flow could it break, and what should we verify before merge?"* It focuses on the judgment step ("what deserves testing"), not on competing with LLMs at writing test code.
 
@@ -97,8 +97,9 @@ pnpm dlx @ivorycanvas/qamap qa . --base origin/main --head HEAD
 | [Configuration](docs/configuration.md) | `qamap.config.json` policy options |
 | [GitHub Action](docs/github-action.md) | PR annotations, summaries, and comments in CI |
 | [Benchmarking](docs/benchmarking.md) | Scoring output quality against pinned repositories |
+| [Architecture](docs/architecture.md) | Behavior Graph, adapter boundaries, execution safety, and migration order |
 | [Roadmap](docs/roadmap.md) | Where this is going |
 
 ## Project Status
 
-QAMap is early and pre-`1.0`; the public API may change. Issues and pull requests are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md). QAMap does not replace review, tests, or security tooling; it removes the blank-page work that makes teams skip good verification.
+QAMap is early and pre-`1.0`; the public API may change. Issues and pull requests are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md). QAMap does not replace review, tests, or security tooling; it removes the blank-page work that makes teams skip good verification. AI-assisted PRs are an important use case, not a requirement.

--- a/bench.config.example.json
+++ b/bench.config.example.json
@@ -12,6 +12,7 @@
         "mustReachFiles": ["app/checkout/page.tsx"],
         "mustNameFlows": ["checkout"],
         "mustDraftFiles": ["checkout"],
+        "mustFindEntrypoints": ["/checkout"],
         "mustFindSelectors": ["apply-coupon"],
         "mustFindSuccessSignals": ["Discount applied"],
         "maxBlankActions": 0,

--- a/bench.config.example.json
+++ b/bench.config.example.json
@@ -8,6 +8,7 @@
       "head": "<head-sha>",
       "expect": {
         "runner": "playwright",
+        "mustHaveBehaviorKinds": ["flow", "surface", "source", "assertion", "locator"],
         "mustReachFiles": ["app/checkout/page.tsx"],
         "mustNameFlows": ["checkout"],
         "mustDraftFiles": ["checkout"],
@@ -24,7 +25,8 @@
       "base": "<base-sha>",
       "head": "<head-sha>",
       "expect": {
-        "runner": "maestro"
+        "runner": "maestro",
+        "mustHaveBehaviorKinds": ["flow", "surface", "source", "assertion", "locator"]
       }
     }
   ]

--- a/bench.config.example.json
+++ b/bench.config.example.json
@@ -8,7 +8,14 @@
       "head": "<head-sha>",
       "expect": {
         "runner": "playwright",
-        "mustHaveBehaviorKinds": ["flow", "surface", "source", "assertion", "locator"],
+        "minChangeIntents": 1,
+        "minHighConfidenceIntents": 1,
+        "minCommitBehaviorNodes": 1,
+        "mustHaveBehaviorKinds": ["flow", "contract", "surface", "source", "assertion", "locator"],
+        "mustNameIntents": ["checkout"],
+        "mustIncludeLifecycle": ["submit", "confirmation"],
+        "mustIncludeQaScenarios": ["failure"],
+        "mustFindIntentEvidence": ["checkout"],
         "mustReachFiles": ["app/checkout/page.tsx"],
         "mustNameFlows": ["checkout"],
         "mustDraftFiles": ["checkout"],
@@ -17,7 +24,7 @@
         "mustFindSuccessSignals": ["Discount applied"],
         "maxBlankActions": 0,
         "maxGenericTitles": 0,
-        "maxAgentBytes": 4096
+        "maxAgentBytes": 8192
       }
     },
     {

--- a/bench.config.json
+++ b/bench.config.json
@@ -41,6 +41,44 @@
       }
     },
     {
+      "name": "web-vue-account",
+      "fixture": "test/benchmarks/web-vue-account",
+      "expect": {
+        "runner": "playwright",
+        "minFlows": 1,
+        "minDiffAnchoredFlows": 1,
+        "mustHaveBehaviorKinds": ["flow", "surface", "source", "assertion", "locator"],
+        "mustReachFiles": ["src/pages/account.vue"],
+        "mustNameFlows": ["account"],
+        "mustDraftFiles": ["tests/e2e/account-save.spec.ts"],
+        "mustFindEntrypoints": ["/account"],
+        "mustFindSelectors": ["account-save"],
+        "mustFindSuccessSignals": ["Account saved"],
+        "maxBlankActions": 0,
+        "maxGenericTitles": 0,
+        "maxAgentBytes": 4096
+      }
+    },
+    {
+      "name": "web-sveltekit-settings",
+      "fixture": "test/benchmarks/web-sveltekit-settings",
+      "expect": {
+        "runner": "playwright",
+        "minFlows": 1,
+        "minDiffAnchoredFlows": 1,
+        "mustHaveBehaviorKinds": ["flow", "surface", "source", "assertion", "locator"],
+        "mustReachFiles": ["src/routes/settings/+page.svelte"],
+        "mustNameFlows": ["settings"],
+        "mustDraftFiles": ["tests/e2e/settings-save.spec.ts"],
+        "mustFindEntrypoints": ["/settings"],
+        "mustFindSelectors": ["settings-save"],
+        "mustFindSuccessSignals": ["Settings saved"],
+        "maxBlankActions": 0,
+        "maxGenericTitles": 0,
+        "maxAgentBytes": 4096
+      }
+    },
+    {
       "name": "expo-maestro-profile",
       "fixture": "test/benchmarks/expo-maestro-profile",
       "expect": {

--- a/bench.config.json
+++ b/bench.config.json
@@ -79,6 +79,61 @@
       }
     },
     {
+      "name": "web-preferences-lifecycle",
+      "fixture": "test/benchmarks/web-preferences-lifecycle",
+      "commitMessage": "feat: submit notification preferences, persist the selected timezone, and show the saved state after the request completes",
+      "expect": {
+        "runner": "playwright",
+        "minFlows": 1,
+        "minChangeIntents": 1,
+        "minHighConfidenceIntents": 1,
+        "minCommitBehaviorNodes": 3,
+        "minDiffAnchoredFlows": 1,
+        "mustHaveBehaviorKinds": ["flow", "contract", "state", "effect", "assertion", "source", "locator"],
+        "mustReachFiles": ["src/pages/preferences.tsx"],
+        "mustNameIntents": ["submit notification preferences"],
+        "mustNameFlows": ["submit notification preferences"],
+        "mustNotNameFlows": ["primary journey", "smoke flow"],
+        "mustDraftFiles": ["tests/e2e/submit-notification-preferences"],
+        "mustIncludeLifecycle": ["persist the selected timezone", "show the saved state", "after the request completes"],
+        "mustIncludeQaScenarios": ["Failure, timeout, and retry handling", "Re-entry and stale state recovery"],
+        "mustFindIntentEvidence": ["submit notification preferences"],
+        "mustFindEntrypoints": ["/preferences"],
+        "mustFindSelectors": ["preferences-save"],
+        "mustFindSuccessSignals": ["Preferences saved"],
+        "maxBlankActions": 0,
+        "maxGenericTitles": 0,
+        "maxAgentBytes": 8192
+      }
+    },
+    {
+      "name": "mobile-reminder-lifecycle",
+      "fixture": "test/benchmarks/mobile-reminder-lifecycle",
+      "commitMessage": "feat: schedule a summary reminder after survey completion, resync it when preferences change, and open the linked summary when tapped",
+      "expect": {
+        "runner": "maestro",
+        "minFlows": 1,
+        "minChangeIntents": 1,
+        "minHighConfidenceIntents": 1,
+        "minCommitBehaviorNodes": 3,
+        "minDiffAnchoredFlows": 1,
+        "mustHaveBehaviorKinds": ["flow", "contract", "state", "effect", "assertion", "source", "locator"],
+        "mustReachFiles": ["src/services/summaryReminder.ts", "src/screens/SurveyCompleteScreen.tsx"],
+        "mustNameIntents": ["schedule a summary reminder"],
+        "mustNameFlows": ["schedule a summary reminder"],
+        "mustNotNameFlows": ["primary journey", "smoke flow"],
+        "mustDraftFiles": [".maestro/schedule-a-summary-reminder-after-survey-completion"],
+        "mustIncludeLifecycle": ["after survey completion", "resync it when preferences change", "open the linked summary"],
+        "mustIncludeQaScenarios": ["Scheduling, calendar, and duplicate boundary", "Entry payload and destination routing"],
+        "mustFindIntentEvidence": ["schedule a summary reminder"],
+        "mustFindSelectors": ["summary-reminder-toggle", "summary-reminder-preview"],
+        "mustFindSuccessSignals": ["Summary reminder scheduled"],
+        "maxBlankActions": 0,
+        "maxGenericTitles": 0,
+        "maxAgentBytes": 8192
+      }
+    },
+    {
       "name": "expo-maestro-profile",
       "fixture": "test/benchmarks/expo-maestro-profile",
       "expect": {

--- a/bench.config.json
+++ b/bench.config.json
@@ -8,6 +8,7 @@
         "runner": "playwright",
         "minFlows": 1,
         "minDiffAnchoredFlows": 1,
+        "mustHaveBehaviorKinds": ["flow", "surface", "source", "assertion", "locator"],
         "mustReachFiles": ["src/pages/checkout/index.tsx"],
         "mustNameFlows": ["checkout"],
         "mustDraftFiles": ["tests/e2e/checkout-submit.spec.ts"],
@@ -27,6 +28,7 @@
         "runner": "playwright",
         "minFlows": 1,
         "minDiffAnchoredFlows": 1,
+        "mustHaveBehaviorKinds": ["flow", "surface", "source", "assertion", "locator"],
         "mustReachFiles": ["src/pages/orders/index.tsx"],
         "mustNameFlows": ["orders"],
         "mustDraftFiles": ["tests/e2e/orders-refresh.spec.ts"],
@@ -45,6 +47,7 @@
         "runner": "maestro",
         "minFlows": 1,
         "minDiffAnchoredFlows": 1,
+        "mustHaveBehaviorKinds": ["flow", "surface", "source", "assertion", "locator"],
         "mustReachFiles": ["src/screens/ProfileScreen.tsx"],
         "mustNameFlows": ["profile"],
         "mustDraftFiles": [".maestro/profile-save.yaml"],
@@ -65,6 +68,7 @@
         "minManifestMatches": 3,
         "minManifestFlowMatches": 1,
         "minManifestBackedFlows": 1,
+        "mustHaveBehaviorKinds": ["flow", "source", "assertion"],
         "mustReachFiles": ["src/routes/orders.ts"],
         "mustNameFlows": ["orders"],
         "mustDraftFiles": ["docs/e2e/orders-api-contract.md"],
@@ -79,6 +83,7 @@
       "expect": {
         "runner": "manual",
         "minFlows": 1,
+        "mustHaveBehaviorKinds": ["flow", "source", "assertion"],
         "mustReachFiles": ["tokens/color.json"],
         "mustNameFlows": ["color"],
         "mustDraftFiles": ["docs/e2e/color-design-token-contract-checklist.md"],
@@ -98,6 +103,7 @@
         "minManifestMatches": 3,
         "minManifestFlowMatches": 1,
         "minManifestBackedFlows": 1,
+        "mustHaveBehaviorKinds": ["flow", "surface", "source", "assertion", "locator"],
         "mustReachFiles": [
           "src/components/SubmitButton.tsx",
           "src/pages/checkout/index.tsx"
@@ -115,6 +121,7 @@
       "expect": {
         "runner": "manual",
         "minFlows": 1,
+        "mustHaveBehaviorKinds": ["flow", "source", "assertion"],
         "mustReachFiles": [
           "android/app/build.gradle",
           "app.json",
@@ -137,6 +144,7 @@
       "expect": {
         "runner": "maestro",
         "minFlows": 1,
+        "mustHaveBehaviorKinds": ["flow", "source", "assertion"],
         "mustReachFiles": [
           ".maestro/notification-primary-journey.yaml",
           ".maestro/search-primary-journey.yaml"

--- a/bench.config.json
+++ b/bench.config.json
@@ -68,6 +68,7 @@
         "minManifestMatches": 3,
         "minManifestFlowMatches": 1,
         "minManifestBackedFlows": 1,
+        "minManifestBehaviorNodes": 3,
         "mustHaveBehaviorKinds": ["flow", "source", "assertion"],
         "mustReachFiles": ["src/routes/orders.ts"],
         "mustNameFlows": ["orders"],
@@ -103,6 +104,7 @@
         "minManifestMatches": 3,
         "minManifestFlowMatches": 1,
         "minManifestBackedFlows": 1,
+        "minManifestBehaviorNodes": 3,
         "mustHaveBehaviorKinds": ["flow", "surface", "source", "assertion", "locator"],
         "mustReachFiles": [
           "src/components/SubmitButton.tsx",

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -1,6 +1,6 @@
 # Adopting QAMap
 
-QAMap works best when teams treat it as the local QA pass for AI-assisted PRs, not as a replacement for review or security tooling.
+QAMap works best when teams treat it as the local QA design pass for any PR, not as a replacement for review or security tooling.
 
 ## First Run
 
@@ -16,7 +16,7 @@ For coding agents, request the compact machine-readable summary instead:
 pnpm dlx @ivorycanvas/qamap qa . --base origin/main --head HEAD --format agent
 ```
 
-When the qa output looks useful, preview and then write the draft E2E files:
+First confirm the inferred commit intent, lifecycle, confidence, and runner-independent QA scenarios. When that judgment looks useful, preview and then write the adapter-specific draft files:
 
 ```sh
 pnpm dlx @ivorycanvas/qamap e2e draft . --base origin/main --head HEAD --dry-run
@@ -58,8 +58,8 @@ Start advisory, then tighten the gate once the findings are understood.
 
 | Phase | Command | Goal |
 | --- | --- | --- |
-| 1. PR QA draft | `qamap qa . --base origin/main --head HEAD` | Get the affected flow, suggested E2E/checklist draft, missing evidence, and PR checklist for a branch. |
-| 2. Agent handoff | `qamap qa . --base origin/main --head HEAD --format agent` | Give coding agents the same decision content as compact JSON instead of a long report. |
+| 1. PR QA design | `qamap qa . --base origin/main --head HEAD` | Get commit-backed intent, behavior lifecycle, QA scenarios, affected flows, and missing evidence. |
+| 2. Agent handoff | `qamap qa . --base origin/main --head HEAD --format agent` | Give coding agents the same intent and scenario evidence as compact JSON instead of a long report. |
 | 3. E2E preview | `qamap e2e draft . --base origin/main --head HEAD --dry-run` | Preview generated draft paths, readiness, action items, and blockers before writing files. |
 | 4. E2E apply | `qamap e2e draft . --base origin/main --head HEAD` | Write draft files once the preview looks useful enough to review. |
 | 5. QA memory | `qamap manifest init .` (from the default branch) | Create `.qamap/manifest.yaml` so future PR recommendations reuse reviewed team QA language. |
@@ -188,11 +188,13 @@ On the guardrails side, QAMap is not trying to replace the larger security ecosy
 
 ## Why This Is Different From Recorders And Generators
 
-Recorders such as browser or mobile test studios are useful when you already know the flow to exercise. QAMap starts one step earlier: it asks what the PR changed, which repo-owned QA memory applies, and what test artifact should exist before merge.
+Recorders such as browser or mobile test studios are useful when you already know the flow to exercise. QAMap starts one step earlier: it asks what the PR commits intended to change, which lifecycle and risk axes follow from the diff, which repo-owned QA memory applies, and what test artifact should exist before merge.
 
 A good QAMap result should answer:
 
-- which product flow changed
+- which commit-backed behavior intent changed, with confidence and review requirements
+- which trigger, condition, action, state change, side effect, and observable outcome form its lifecycle
+- which primary, failure, boundary, and state-transition QA scenarios follow from that lifecycle
 - which manifest domain, flow, and checks caused the recommendation
 - which draft test file was generated or previewed
 - which success, failure, edge, contract, or visual cases the draft covers
@@ -201,7 +203,7 @@ A good QAMap result should answer:
 
 That is the product bet: one human correction to the repo-local manifest should improve future PR recommendations without another LLM prompt.
 
-You do not need a manifest to start. Without one, QAMap uses the PR diff, package signals, routes, selectors, runner config, and existing tests. Add a manifest only when the team wants durable QA language that improves future recommendations.
+You do not need a manifest to start. Without one, QAMap uses commit subjects and bodies, the PR diff, package signals, routes, selectors, runner config, and existing tests. Add a manifest only when the team wants durable QA language that improves future recommendations.
 
 ## What QAMap Is For
 
@@ -211,9 +213,9 @@ QAMap is intentionally small:
 - static by default: it does not execute scanned project code
 - no-token by default: it does not call an LLM API
 - verification-focused: it tells reviewers what evidence is missing, not how to style code
-- PR QA skill output: `qamap qa` turns a branch into a PR-ready affected-flow summary, suggested E2E/checklist draft, missing evidence list, and copyable checklist
+- PR QA skill output: `qamap qa` turns a branch into change intent, behavior lifecycle, QA scenarios, affected-flow evidence, optional automation drafts, and a copyable checklist
 - packaged agent skill: `skills/qamap-pr-qa/SKILL.md` gives coding agents a compact PR QA workflow for running QAMap before handoff
-- domain-aware E2E drafting: it turns branch changes into flow language, draft specs, readiness summaries, and action items
+- intent-aware E2E drafting: it derives runner-independent QA first, then compiles the selected path into Playwright, Maestro, or manual artifacts
 - repo-local verification base: shared manifests can be committed, while generated run history stays ignored by default
 - context-aware baseline generation: manifest init can use repo-local context, ADRs, goals, agent instructions, harness files, skills, and runbooks as advisory bootstrap signals
 - harness/skill role hints: instruction-derived context is classified as agent skill, harness config, workflow lifecycle, verification rubric, safety policy, release policy, or test runner context
@@ -224,5 +226,4 @@ QAMap is intentionally small:
 It is built for teams using AI coding agents, MCP-powered tools, or any workflow where an agent can read, edit, test, commit, or open pull requests.
 
 For PR verification, QAMap treats the repository itself as the working base: committed manifests hold durable team language, ignored local history holds generated run observations, and the current branch diff supplies what changed now.
-
 

--- a/docs/agent-format.md
+++ b/docs/agent-format.md
@@ -1,6 +1,6 @@
 # Agent Format Contract
 
-`qamap qa --format agent` prints one line of JSON (~2–4KB) designed to be pasted into a coding agent's context instead of the full markdown report. This page is the contract for that output: what the fields mean, what an agent may rely on, and how the format is allowed to change.
+`qamap qa --format agent` prints one compact line of JSON designed to be pasted into a coding agent's context instead of the full markdown report. Small heuristic changes are usually 2–4KB; evidence-rich intent lifecycles can be larger. This page is the contract for that output: what the fields mean, what an agent may rely on, and how the format is allowed to change.
 
 ```sh
 qamap qa . --base origin/main --head HEAD --format agent
@@ -19,10 +19,11 @@ qamap qa . --base origin/main --head HEAD --format agent
 The intended loop for a coding agent:
 
 1. Run the command above and parse stdout as JSON.
-2. If `readiness.level` is `blocked` or `needs-work`, treat generated drafts as review-only; `requiredBootstrap` lists what unlocks the next stage.
-3. Use `flows[].changedFiles`, `flows[].evidence`, and `flows[].reviewQuestion` to understand why the flow was selected. Use `steps`, `selectors`, and `successSignal` to write or review tests; `runnable` says how much to trust the generated draft.
-4. Surface `requiredEvidence` in the PR description, and paste `prChecklist` items into the PR body.
-5. Run `commands` to validate.
+2. Read `intents` first. Confirm its commit evidence, confidence, lifecycle, and QA scenarios before treating runner-specific output as correct. When `reviewRequired` is true, ask a human to confirm the intent.
+3. If `readiness.level` is `blocked` or `needs-work`, treat generated drafts as review-only; `requiredBootstrap` lists what unlocks the next stage.
+4. Use `flows[].changedFiles`, `flows[].evidence`, and `flows[].reviewQuestion` to understand why the flow was selected. Use `steps`, `selectors`, and `successSignal` to write or review tests; `runnable` says how much to trust the generated draft.
+5. Surface `requiredEvidence` in the PR description, and paste `prChecklist` items into the PR body.
+6. Run `commands` to validate.
 
 ## Fields
 
@@ -31,10 +32,11 @@ The intended loop for a coding agent:
 | `schema` | object | `{ name: "qamap.qa", version: 1 }` — check before parsing. |
 | `base`, `head` | string | Git refs the diff was computed from. |
 | `project` | string | Detected project type (for example `web`, `react-native`, `node`, `unknown`). |
-| `runner` | string | Recommended E2E runner: `maestro`, `playwright`, or `manual`. |
+| `runner` | string | Automation output adapter selected after QA intent analysis: `maestro`, `playwright`, or `manual`. |
 | `manifest` | string \| null | Verification manifest path in use, or `null` when the run used repo signals and the PR diff only. |
 | `readiness` | object | `score` (0–100) and `level` (`ready` \| `near-runnable` \| `needs-work` \| `blocked`). Human reports render the same value as a four-stage journey; the machine value is stable. |
 | `testSuite` | object | `present` (boolean) and `files` (number of detected test files). |
+| `intents` | array | Evidence-backed change intents (capped). Each includes `title`, `confidence`, `reviewRequired`, commit/diff `evidence`, ordered `lifecycle` phases, and runner-independent QA `scenarios` with assertions. Empty when commit and diff evidence cannot support a behavior intent. |
 | `firstDraftCommand` | string? | One command that creates the first E2E draft. Present only when the repository has no test suite and the diff reaches a product journey. |
 | `flows` | array | Affected user flows, most relevant first (capped). Each has `title`, `source`, `draft`, optional `runnable`, `entry`, and `verificationMode`, plus `changedFiles`, `reviewQuestion`, `successSignal`, `steps`, `selectors`, and short `evidence` reasons. Test-only changes expose `existingEvidence`; configuration, docs, generated artifacts, and changed tests use `verificationMode`, keep `draft` only as a fallback artifact path, and omit `firstDraftCommand` rather than inventing a required product journey. |
 | `requiredEvidence` | array | Required-priority QA evidence still missing, capped at 8: `flow`, `kind`, `title`. |
@@ -48,5 +50,5 @@ List fields are capped to keep the payload small; caps may grow within version 1
 ## Example
 
 ```json
-{"schema":{"name":"qamap.qa","version":1},"base":"main","head":"HEAD","project":"web","runner":"playwright","manifest":null,"readiness":{"score":51,"level":"needs-work"},"testSuite":{"present":false,"files":0},"firstDraftCommand":"qamap e2e setup . --runner playwright","flows":[{"title":"Checkout Submit","source":"domain-language","draft":"tests/e2e/checkout-submit.spec.ts","runnable":"near-runnable","entry":"route: /checkout (high)","changedFiles":["src/pages/checkout/index.tsx"],"reviewQuestion":"Can a reviewer confirm that Checkout Submit still works from this entrypoint and this outcome is verified: visible text Order confirmed appears?","successSignal":"visible text Order confirmed appears","steps":["Fill Email with realistic data.","Submit Submit using Checkout Submit."],"selectors":["web-test-id: checkout-submit"],"evidence":["Primary entrypoint inferred as route /checkout."]}],"requiredEvidence":[{"flow":"Checkout Submit","kind":"runner","title":"Configure Playwright execution"}],"recommendedEvidenceCount":2,"requiredBootstrap":[{"title":"Configure Playwright before making drafts required","action":"Run qamap e2e setup . --runner playwright."}],"prChecklist":["Review the generated draft path: tests/e2e/checkout-submit.spec.ts."],"commands":["npm run build"]}
+{"schema":{"name":"qamap.qa","version":1},"base":"main","head":"HEAD","project":"web","runner":"playwright","manifest":null,"readiness":{"score":51,"level":"needs-work"},"testSuite":{"present":false,"files":0},"intents":[{"title":"Submit checkout and persist the confirmed order","confidence":"high","reviewRequired":false,"evidence":["feat: submit checkout and persist the confirmed order"],"lifecycle":[{"phase":"trigger","label":"Submit checkout."},{"phase":"side-effect","label":"Create the order."},{"phase":"observable-outcome","label":"Show order confirmation."}],"scenarios":[{"priority":"critical","kind":"primary","title":"Submit checkout and persist the confirmed order","assertions":["Verify order confirmation is visible."]}]}],"firstDraftCommand":"qamap e2e setup . --runner playwright","flows":[{"title":"Submit checkout and persist the confirmed order","source":"commit-and-diff-intent","draft":"tests/e2e/submit-checkout-and-persist-the-confirmed-order.spec.ts","runnable":"near-runnable","entry":"route: /checkout (high)","changedFiles":["src/pages/checkout/index.tsx"],"reviewQuestion":"Can a reviewer confirm that the changed checkout lifecycle is verified?","successSignal":"visible text Order confirmed appears","steps":["Submit checkout.","Create the order.","Verify order confirmation is visible."],"selectors":["web-test-id: checkout-submit"],"evidence":["Commit and diff evidence support this change intent."]}],"requiredEvidence":[],"recommendedEvidenceCount":2,"requiredBootstrap":[],"prChecklist":["Review the generated intent-backed draft."],"commands":["npm run build"]}
 ```

--- a/docs/agent-skill.md
+++ b/docs/agent-skill.md
@@ -68,10 +68,13 @@ If your agent supports symlinked skills, point its skill directory at `skills/qa
 
 ## What The Agent Should Do With The Output
 
-Use the `PR Comment Draft` section as review context:
+Use `Change Intent Evidence` and the `PR Comment Draft` as review context:
 
+- commit-backed intent, confidence, and whether human review is required
+- ordered behavior lifecycle
+- primary, failure, boundary, and state-transition QA scenarios
 - affected flow
-- recommended runner
+- automation adapter selected after QA design
 - draft E2E or checklist path
 - missing fixture, selector, assertion, runner, or validation evidence
 - PR checklist items

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,6 +20,8 @@ The repository, not a model session, is the source of truth. Source code supplie
 
 `src/behavior.ts` defines the framework-neutral intermediate representation. A graph contains stable nodes, typed edges, confidence, evidence, and direct or propagated change impact.
 
+Generated graphs identify the shipped contract through `schema/qamap-behavior.schema.json` and `schemaVersion: 1`. The schema URL and node, edge, surface, and evidence enums are exported from the package so adapters and consumers can reject unsupported shapes deterministically.
+
 Initial node kinds cover:
 
 - domains and flows;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,16 +5,33 @@ QAMap is moving from deterministic PR-to-draft heuristics toward a local, change
 The target pipeline is:
 
 ```txt
-base/head diff
+commit range + base/head diff
+  -> change intent analysis
   -> analyzer adapters
   -> behavior graph
-  -> impact selection
-  -> deterministic QA scenarios
+  -> behavior lifecycle + impact selection
+  -> runner-independent QA scenarios
+  -> Playwright / Maestro / manual adapter
   -> explicit local execution
   -> normalized evidence and verdict
 ```
 
-The repository, not a model session, is the source of truth. Source code supplies observable structure, while `.qamap/manifest.yaml` supplies reviewed product intent that code alone cannot prove.
+The repository, not a model session, is the source of truth. Commit subjects and bodies provide author intent, source code supplies observable structure, and `.qamap/manifest.yaml` supplies reviewed product intent that commits and code alone cannot prove.
+
+## Change Intent
+
+`src/change-intent.ts` reads behavior-bearing commits in the selected base/head range and joins related `feat`, `fix`, `hotfix`, `perf`, and supporting `refactor` commits through normalized domain terms. Added diff symbols provide independent evidence for triggers, conditions, state changes, side effects, and observable outcomes.
+
+Each intent contains:
+
+- the original commit evidence and source scope;
+- an explicit confidence and `reviewRequired` flag;
+- an ordered behavior lifecycle;
+- runner-independent primary, failure, boundary, and state-transition QA scenarios.
+
+One richly evidenced squash commit can reach high confidence. A title without connected diff evidence cannot. Working-tree-only inference is always low confidence and review-required. Release, docs, style, CI, and test-only commits do not become product intents.
+
+The analysis is deterministic and local. It does not execute repository code, contact GitHub, upload source, or call an LLM.
 
 ## Behavior Graph
 
@@ -31,7 +48,7 @@ Initial node kinds cover:
 
 Initial edges describe containment, entrypoints, ordering, expected outcomes, fixture use, locators, implementation sources, and diff impact.
 
-Every inferred node must retain provenance. A node without a source, diff, selector, fixture, test, manifest, or named inference reason should not influence a QA verdict.
+Every inferred node must retain provenance. A node without a commit, source, diff, selector, fixture, test, manifest, or named inference reason should not influence a QA verdict.
 
 Node and edge ids are content-derived and stable. Re-running analysis against the same repository state must produce the same graph identity even when report timestamps differ.
 
@@ -40,6 +57,8 @@ Node and edge ids are content-derived and stable. Re-running analysis against th
 The first graph integration uses `qamap.inferred-flow-compat`. It translates the existing E2E flow observations into the new graph so the IR can be introduced without changing existing CLI recommendations.
 
 This adapter is a migration bridge, not the final analysis architecture. Framework adapters should gradually emit graph fragments directly, after which draft generation will consume the graph instead of the graph consuming completed drafts.
+
+`qamap.change-intent` is the first direct product adapter. It emits intent contracts, lifecycle actions/states/effects, scenario assertions, source links, and commit provenance before an automation runner is selected.
 
 ## Analyzer Adapters
 
@@ -102,11 +121,11 @@ Playwright, Maestro, and other tools are executor implementations. They are not 
 
 ## Migration Order
 
-1. Keep current CLI output stable while graph identity and adapter isolation mature.
+1. Derive change intent and runner-independent QA scenarios from commit and diff evidence.
 2. Move route, screen, endpoint, selector, fixture, and contract discovery into graph-producing adapters.
 3. Compare base and head graphs to select affected behavior rather than relying on file categories alone.
-4. Compile graph paths into deterministic QA scenarios.
+4. Compile selected graph paths through Playwright, Maestro, or manual adapters.
 5. Add explicit, temporary execution and normalized evidence.
 6. Add manifest accept, reject, and repair commands so reviewed outcomes improve later analysis.
 
-The next minor version is earned only when the complete diff-to-evidence vertical slice is usable for at least one supported stack. Internal graph work and backward-compatible adapter improvements remain patch releases during `0.x` development.
+Version `0.4.0` establishes the commit-to-intent-to-scenario slice for synthetic web and mobile lifecycle changes. The next minor is reserved for a policy-controlled scenario execution and normalized evidence slice; compatible analyzer and adapter improvements remain patch releases during `0.x` development.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,110 @@
+# Architecture
+
+QAMap is moving from deterministic PR-to-draft heuristics toward a local, change-aware QA engine. The core must remain useful without cloud services, source upload, or LLM calls.
+
+The target pipeline is:
+
+```txt
+base/head diff
+  -> analyzer adapters
+  -> behavior graph
+  -> impact selection
+  -> deterministic QA scenarios
+  -> explicit local execution
+  -> normalized evidence and verdict
+```
+
+The repository, not a model session, is the source of truth. Source code supplies observable structure, while `.qamap/manifest.yaml` supplies reviewed product intent that code alone cannot prove.
+
+## Behavior Graph
+
+`src/behavior.ts` defines the framework-neutral intermediate representation. A graph contains stable nodes, typed edges, confidence, evidence, and direct or propagated change impact.
+
+Initial node kinds cover:
+
+- domains and flows;
+- routes, screens, endpoints, commands, and artifact surfaces;
+- actions, states, effects, contracts, and assertions;
+- fixtures, locators, and source files.
+
+Initial edges describe containment, entrypoints, ordering, expected outcomes, fixture use, locators, implementation sources, and diff impact.
+
+Every inferred node must retain provenance. A node without a source, diff, selector, fixture, test, manifest, or named inference reason should not influence a QA verdict.
+
+Node and edge ids are content-derived and stable. Re-running analysis against the same repository state must produce the same graph identity even when report timestamps differ.
+
+## Compatibility Adapter
+
+The first graph integration uses `qamap.inferred-flow-compat`. It translates the existing E2E flow observations into the new graph so the IR can be introduced without changing existing CLI recommendations.
+
+This adapter is a migration bridge, not the final analysis architecture. Framework adapters should gradually emit graph fragments directly, after which draft generation will consume the graph instead of the graph consuming completed drafts.
+
+## Analyzer Adapters
+
+An analyzer adapter has two operations:
+
+```ts
+interface BehaviorAnalyzerAdapter {
+  id: string;
+  version: string;
+  detect(context): Detection;
+  analyze(context): BehaviorGraphFragment;
+}
+```
+
+Detection must be evidence-based and may decline a repository. Analysis failures are isolated and reported as diagnostics so one optional adapter cannot erase useful output from the others.
+
+Adapters should be layered:
+
+1. language adapters provide symbols, imports, calls, and schemas;
+2. framework adapters provide routes, screens, handlers, and lifecycle conventions;
+3. repository adapters provide manifests, tests, fixtures, and local policy;
+4. executor adapters compile selected scenarios for an existing runner.
+
+Support is reported by capability rather than a single yes/no framework badge:
+
+| Level | Contract |
+| --- | --- |
+| Deep | Behavior impact, deterministic scenarios, and local execution are supported. |
+| Structural | Routes, contracts, existing tests, and validation commands are understood. |
+| Generic | Diff and dependency evidence are available; QAMap does not invent a product journey. |
+
+TypeScript-based web stacks are the first deep-analysis target because the existing import, route, selector, and fixture signals already provide a useful base. Vue, Nuxt, and SvelteKit should reuse the common web behavior model rather than fork the QA pipeline. Mobile, API, Python, Go, and JVM support should enter through the same adapter contract.
+
+## Manifest Boundary
+
+The generated graph is local cache material and should not be committed in full. The verification manifest stores only durable, reviewed knowledge:
+
+- important flows and criticality;
+- expected and forbidden outcomes;
+- auth, permission, fixture, and environment requirements;
+- stable anchors and invariants;
+- accepted corrections and suppressions.
+
+This keeps first-run setup light while allowing one human correction to improve later PRs deterministically.
+
+## Execution Boundary
+
+`qamap qa` remains static and read-only. It must not execute scanned project code.
+
+Future execution belongs to an explicit `qamap verify` mode with a visible execution plan. The intended safeguards are:
+
+- generated tests live in an operating-system temporary directory by default;
+- target repository files are not modified unless a separate write command is requested;
+- commands, environment variables, network access, and time limits are policy controlled;
+- existing mocks and fixtures are preferred over fabricated data;
+- missing setup becomes `not verifiable`, never a false pass;
+- source code and evidence remain local and no LLM is called.
+
+Playwright, Maestro, and other tools are executor implementations. They are not the product-level recommendation shown first to users.
+
+## Migration Order
+
+1. Keep current CLI output stable while graph identity and adapter isolation mature.
+2. Move route, screen, endpoint, selector, fixture, and contract discovery into graph-producing adapters.
+3. Compare base and head graphs to select affected behavior rather than relying on file categories alone.
+4. Compile graph paths into deterministic QA scenarios.
+5. Add explicit, temporary execution and normalized evidence.
+6. Add manifest accept, reject, and repair commands so reviewed outcomes improve later analysis.
+
+The next minor version is earned only when the complete diff-to-evidence vertical slice is usable for at least one supported stack. Internal graph work and backward-compatible adapter improvements remain patch releases during `0.x` development.

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -14,6 +14,7 @@ The command fails when any target violates its declared expectations. The initia
 
 - a web app with no tests;
 - a web app with Playwright and an existing mock handler;
+- Vue and SvelteKit web changes with framework-native route files;
 - an Expo app with Maestro;
 - an API service that should produce a contract checklist instead of a browser journey;
 - a design-token repository that should stay on artifact verification;
@@ -43,6 +44,7 @@ Each target can declare:
 | `mustIncludeSteps` | Behavior terms that must appear in draft steps. |
 | `mustFindSelectors` | Stable selector evidence that must be recovered from the repository. |
 | `mustFindSuccessSignals` | Observable outcome text that must appear in the flow's success criteria. |
+| `mustFindEntrypoints` | Route, screen, or command entrypoints that affected flows must recover. |
 | `mustFindEvidence` | Required evidence or fixture terms that must be reported. |
 | `mustNotFindEvidence` | Evidence terms that would be false positives for this change. |
 | `mustRecommendCommands` | Commands the setup or validation path must expose. |

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -34,6 +34,7 @@ Each target can declare:
 | `minManifestMatches` | Minimum domain, flow, and check matches from an external base manifest. |
 | `minManifestFlowMatches` | Minimum flow-level matches from the external base manifest. |
 | `minManifestBackedFlows` | Minimum QA flows that preserve manifest provenance. |
+| `mustHaveBehaviorKinds` | Behavior Graph node kinds that must be present, such as `flow`, `surface`, `source`, `assertion`, or `locator`. |
 | `mustReachFiles` | Files that the selected flows must reach. |
 | `mustNameFlows` | Product terms that must appear in a user-facing flow title. |
 | `mustNotNameFlows` | Misleading flow-title terms that must not be emitted. |
@@ -63,6 +64,8 @@ node scripts/bench.mjs --baseline bench-results/<file>.json
 When both files exist, `pnpm bench` prefers the gitignored local config. CI always passes `--config bench.config.json --assert`, so private paths cannot affect the public quality gate.
 
 Saved results include flow titles, draft paths, recall gaps, readiness, agent payload size, and timing. Use a saved baseline to see heuristic movement, but treat the committed expectation contract as the merge gate.
+
+Every benchmark target also enforces the Behavior Graph base contract: graph schema version 1, at least one graph flow for every planned flow, at least one impacted node for a non-empty diff, and no edge whose endpoint is missing. The table reports `graph n/i` as total nodes versus impacted nodes. These checks keep the graph connected to real PR analysis while framework-specific adapters are introduced incrementally.
 
 ## Adding a regression
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -34,6 +34,7 @@ Each target can declare:
 | `minManifestMatches` | Minimum domain, flow, and check matches from an external base manifest. |
 | `minManifestFlowMatches` | Minimum flow-level matches from the external base manifest. |
 | `minManifestBackedFlows` | Minimum QA flows that preserve manifest provenance. |
+| `minManifestBehaviorNodes` | Minimum Behavior Graph nodes carrying verification-manifest evidence. |
 | `mustHaveBehaviorKinds` | Behavior Graph node kinds that must be present, such as `flow`, `surface`, `source`, `assertion`, or `locator`. |
 | `mustReachFiles` | Files that the selected flows must reach. |
 | `mustNameFlows` | Product terms that must appear in a user-facing flow title. |

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -2,7 +2,7 @@
 
 QAMap's unit tests prove that the implementation behaves as coded. The benchmark contract checks a different question: does a representative PR receive a useful QA answer?
 
-`bench.config.json` is committed and runs in CI. Each target under `test/benchmarks/` contains a `base/` repository snapshot and a `head/` overlay. The runner materializes them as a temporary Git repository with a `main` baseline and one feature commit. QAMap reads those repositories but never installs dependencies or executes their code.
+`bench.config.json` is committed and runs in CI. Each target under `test/benchmarks/` contains a `base/` repository snapshot and a `head/` overlay. The runner materializes them as a temporary Git repository with a `main` baseline and one feature commit. Intent fixtures set a synthetic `commitMessage` so commit-to-lifecycle behavior is part of the contract. QAMap reads those repositories but never installs dependencies or executes their code.
 
 ## Run the public contract
 
@@ -15,6 +15,8 @@ The command fails when any target violates its declared expectations. The initia
 - a web app with no tests;
 - a web app with Playwright and an existing mock handler;
 - Vue and SvelteKit web changes with framework-native route files;
+- a web preferences change that must become submit, persistence, request-failure, and re-entry QA instead of a generic journey;
+- a mobile reminder change that must become scheduling, calendar, duplicate, resynchronization, and entry-routing QA;
 - an Expo app with Maestro;
 - an API service that should produce a contract checklist instead of a browser journey;
 - a design-token repository that should stay on artifact verification;
@@ -28,8 +30,12 @@ Each target can declare:
 
 | Field | Meaning |
 | --- | --- |
-| `runner` | Expected `playwright`, `maestro`, or `manual` recommendation. |
+| `commitMessage` | Synthetic feature-commit message used when materializing a fixture. |
+| `runner` | Expected `playwright`, `maestro`, or `manual` output adapter. Runner correctness alone is not a useful intent benchmark. |
 | `minFlows` | Minimum number of affected flows. |
+| `minChangeIntents` | Minimum evidence-backed Change Intents. |
+| `minHighConfidenceIntents` | Minimum intents supported strongly enough by commit and diff evidence to avoid mandatory review. |
+| `minCommitBehaviorNodes` | Minimum Behavior Graph nodes carrying commit provenance. |
 | `minImportPropagatedFlows` | Minimum flows discovered through reverse imports. |
 | `minDiffAnchoredFlows` | Minimum flows using selector evidence introduced by the diff. |
 | `minManifestMatches` | Minimum domain, flow, and check matches from an external base manifest. |
@@ -37,6 +43,11 @@ Each target can declare:
 | `minManifestBackedFlows` | Minimum QA flows that preserve manifest provenance. |
 | `minManifestBehaviorNodes` | Minimum Behavior Graph nodes carrying verification-manifest evidence. |
 | `mustHaveBehaviorKinds` | Behavior Graph node kinds that must be present, such as `flow`, `surface`, `source`, `assertion`, or `locator`. |
+| `mustNameIntents` | Concrete terms that must appear in the inferred intent title. |
+| `mustNotNameIntents` | Misleading terms that must not appear in inferred intent titles. |
+| `mustIncludeLifecycle` | Trigger, condition, action, state, effect, or outcome terms that must survive in the ordered lifecycle. |
+| `mustIncludeQaScenarios` | Failure, boundary, state-transition, or primary QA terms that must be proposed before runner compilation. |
+| `mustFindIntentEvidence` | Commit or diff terms that must remain attached to intent provenance. |
 | `mustReachFiles` | Files that the selected flows must reach. |
 | `mustNameFlows` | Product terms that must appear in a user-facing flow title. |
 | `mustNotNameFlows` | Misleading flow-title terms that must not be emitted. |
@@ -66,7 +77,7 @@ node scripts/bench.mjs --baseline bench-results/<file>.json
 
 When both files exist, `pnpm bench` prefers the gitignored local config. CI always passes `--config bench.config.json --assert`, so private paths cannot affect the public quality gate.
 
-Saved results include flow titles, draft paths, recall gaps, readiness, agent payload size, and timing. Use a saved baseline to see heuristic movement, but treat the committed expectation contract as the merge gate.
+Saved results include intent titles, lifecycle and scenario terms, flow titles, draft paths, recall gaps, readiness, agent payload size, and timing. Use a saved baseline to see heuristic movement, but treat the committed expectation contract as the merge gate.
 
 Every benchmark target also enforces the Behavior Graph base contract: graph schema version 1, at least one graph flow for every planned flow, at least one impacted node for a non-empty diff, and no edge whose endpoint is missing. The table reports `graph n/i` as total nodes versus impacted nodes. These checks keep the graph connected to real PR analysis while framework-specific adapters are introduced incrementally.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -21,7 +21,7 @@ Use `pnpm dlx @ivorycanvas/qamap ...` for one-off runs without installing QAMap 
 
 ## Reading The Output
 
-Human-facing reports (`text` and `markdown` formats) open with an **At a Glance** section: affected behavior, the reviewer question to answer before merge, concrete repository evidence, the proposed draft path, the next command, and the one or two missing trust requirements. When printed to an interactive terminal the report is colorized (headings, statuses, priority tags, inline commands); files written with `--output`, pipes, CI logs, and the machine formats (`json`, `agent`, `sarif`) are always plain. The standard `NO_COLOR` and `FORCE_COLOR` environment variables are honored.
+Human-facing reports (`text` and `markdown` formats) open with an **At a Glance** section: evidence-backed change intent, behavior lifecycle, affected behavior, the reviewer question to answer before merge, concrete repository evidence, the proposed draft path, and missing trust requirements. Runner information appears later as an automation adapter. When printed to an interactive terminal the report is colorized (headings, statuses, priority tags, inline commands); files written with `--output`, pipes, CI logs, and the machine formats (`json`, `agent`, `sarif`) are always plain. The standard `NO_COLOR` and `FORCE_COLOR` environment variables are honored.
 
 Draft readiness is reported as a **stage on a fixed four-step journey**, for example `Stage: setup needed (1 of 4) — readiness 0/100`. A fresh repository usually starts at stage 1 — that is the expected starting point, not a failure. Each stage maps to a stable `readiness.level` value in the `json` and `agent` formats, which keeps machine output unchanged:
 
@@ -37,7 +37,9 @@ Draft readiness is reported as a **stage on a fixed four-step journey**, for exa
 
 On a changed branch, QAMap tries to produce reviewable verification artifacts instead of only saying "write more tests":
 
-- a branch-aware verification plan that names the changed domain, actor, trigger, goal, success signal, and edge cases
+- a commit-and-diff-backed change intent with confidence, review requirements, and source evidence
+- an ordered trigger, condition, action, state-change, side-effect, and observable-outcome lifecycle
+- runner-independent primary, failure, boundary, and state-transition QA scenarios
 - draft Playwright, Maestro, CLI command, or manual checklist files when the repository shape supports them
 - a repo-level verification manifest loop where humans correct durable flows once and later PRs get sharper route/check/test draft suggestions
 - a runner setup proposal that explains why Playwright or Maestro fits the changed surface and which files/commands would be created if the team accepts it
@@ -61,9 +63,9 @@ That means QAMap is most valuable when it becomes the team's verification base: 
 | `qamap eval . --base origin/main --head HEAD --pr-body-file pr-body.md` | Score change readiness across intent, risk, tests, and review size. |
 | `qamap github-action . --mode review --base origin/main --head HEAD` | Generate GitHub Action annotations, step summary, and PR comment body. |
 | `qamap test-plan . --base origin/main --head HEAD --include-working-tree` | Suggest domain test scenarios for changed files. |
-| `qamap qa . --base origin/main --head HEAD` | One-command PR QA: affected flows, missing QA evidence, a PR checklist, and E2E starter drafts, opening with At a Glance. |
-| `qamap qa . --base origin/main --head HEAD --format agent` | The same decision content as one ~2-4KB JSON line for coding agents — a versioned contract documented in [docs/agent-format.md](agent-format.md). |
-| `qamap e2e plan . --base origin/main --head HEAD` | Suggest E2E runner, bootstrap steps, user flows, coverage targets, existing test evidence, and missing testability hooks for changed files. |
+| `qamap qa . --base origin/main --head HEAD` | One-command PR QA: change intent, behavior lifecycle, QA scenarios, affected flows, missing evidence, and optional automation drafts. |
+| `qamap qa . --base origin/main --head HEAD --format agent` | The same decision content as one compact JSON line for coding agents — a versioned contract documented in [docs/agent-format.md](agent-format.md). |
+| `qamap e2e plan . --base origin/main --head HEAD` | Derive change intent and QA scenarios, then map them to coverage, test evidence, testability gaps, and an automation adapter. |
 | `qamap e2e plan . --base origin/main --head HEAD --record-history` | Save a compact local run snapshot under `.qamap/runs/` while keeping JSON/Markdown output usable. |
 | `qamap e2e setup . --runner playwright` | Explicitly apply the accepted runner setup and create the first changed-flow E2E draft without overwriting existing files. |
 | `qamap e2e draft . --base origin/main --head HEAD --dry-run` | Preview generated Maestro, Playwright, or manual E2E drafts without writing files. |
@@ -90,7 +92,9 @@ For monorepos, pass `--workspace-root` when scanning a package. Package-local ch
 
 `qamap test-plan` turns changed file paths into a review-ready domain test checklist. It also discovers common validation commands from `package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, Gradle files, and Maven `pom.xml`. Add `--include-working-tree` for local, uncommitted changes while iterating.
 
-`qamap e2e plan` turns changed file paths into a first-pass E2E testing plan. It detects whether a project looks like Expo/React Native, web, API/service, or CLI package, recommends a runner such as Maestro or Playwright, starts backend services with an API contract checklist, starts executable packages with a CLI command verification checklist, suggests bootstrap steps for repos with little or no test history, suggests domain language for the changed behavior, suggests candidate user flows, adds coverage targets, compares those targets with existing test-suite evidence when tests are present, flags API-dependent flows that need mock or fixture responses, and points out missing stable selectors such as `testID` or `data-testid` before anyone starts writing tests from a blank file.
+`qamap e2e plan` first reads behavior-bearing commits in the selected base/head range. Related `feat`, `fix`, `hotfix`, `perf`, and supporting `refactor` commits are grouped into change intents, then connected to added diff symbols. The result is an evidence-backed lifecycle and a set of runner-independent primary, failure, boundary, and state-transition scenarios. Low-confidence or working-tree-only intent remains review-required instead of becoming trusted regression policy.
+
+After that judgment, QAMap detects whether the target looks like Expo/React Native, web, API/service, CLI, or another repository shape and selects a Maestro, Playwright, or manual output adapter. The plan compares scenario targets with existing test evidence, identifies required mocks and fixtures, and reports missing stable selectors such as `testID` or `data-testid`. Runner detection is an implementation detail, not the first value shown to the user.
 
 The plan also includes an execution profile: detected start command, test command, Playwright `baseURL`, mobile app id, runner config files, env fixture files, confidence, and blockers. This keeps generated E2E drafts honest about whether they are runnable candidates or still review-only scaffolds.
 
@@ -100,7 +104,7 @@ When a repository does not already have the selected E2E runner, the plan includ
 
 When run at a monorepo root, the E2E plan also reports changed app/package targets. This helps a maintainer move from a broad workspace diff to scoped commands such as `qamap e2e plan services/listing --workspace-root . --base origin/main --head HEAD`, where package-specific runner detection and flow naming are usually sharper.
 
-Each candidate flow also includes a flow language brief: actor, trigger, goal, success signal, reviewer question, and edge cases. The brief keeps generated tests tied to product behavior rather than only changed file names.
+Each candidate flow also includes a flow language brief: actor, trigger, goal, success signal, reviewer question, and edge cases. Intent-backed flows additionally retain the original commits, ordered lifecycle, QA scenarios, confidence, and review requirement so generated tests can be traced to evidence rather than only changed file names.
 
 The bootstrap section answers what must happen before generated drafts can be treated as real regression coverage. For example, a testless web project can get required steps for Playwright setup, first draft generation, stable selector work, fixture/mock data, and missing validation evidence, plus recommended steps for `.qamap/manifest.yaml`, `.qamap/domains.yml`, `.qamap/flows.yml`, and local history recording.
 
@@ -207,6 +211,8 @@ Pass `--record-history` when you want QAMap to keep a compact local snapshot of 
 
 The draft result is meant to be useful as a PR artifact, not only as generated files. Markdown and JSON output include:
 
+- `changeAnalysis`: commit-backed intents, confidence, review requirements, source evidence, lifecycle stages, and runner-independent QA scenarios
+- intent-backed draft files retain `intentId`, `intentConfidence`, `lifecycle`, and `qaScenarios`; generated files include the same evidence as comments
 - `languageBrief`: actor, trigger, goal, success signal, reviewer question, and edge cases for each draft file
 - `promotionStatus`: whether the draft is a `commit-candidate`, `needs-review`, or `low-signal`
 - `runnableStatus`: whether the draft is a `runnable-candidate`, `near-runnable`, or `review-only`

--- a/docs/e2e-output-examples.md
+++ b/docs/e2e-output-examples.md
@@ -15,20 +15,31 @@ The output should be specific enough to paste into a PR comment:
 ```txt
 # QAMap QA Draft
 
+At a Glance
+- Change intent: Submit checkout and persist the confirmed order [high]
+- Behavior lifecycle: trigger: Submit checkout -> side-effect: Create order -> observable-outcome: Show order confirmation
+- Affected behavior: Submit checkout and persist the confirmed order
+
+Change Intent Evidence
+- Commit: feat: submit checkout and persist the confirmed order
+- Critical scenario: Submit checkout and persist the confirmed order
+  - Assert: order confirmation is visible and persisted
+- Recommended scenario: Failure, timeout, and retry handling
+
 Summary
 - Project: Web
-- Recommended runner: Playwright
+- Automation adapter: Playwright
 - Manifest: not found; using repo signals and PR diff only
 - Stage: almost runnable (3 of 4)
 
 PR Comment Draft
-- Affected flow: Checkout UI smoke flow
+- Affected flow: Submit checkout and persist the confirmed order
 - User journey: Customer -> Open route /checkout -> Complete checkout with realistic form data
 - Success signal: confirmation state is visible after submit
 - Changed files: src/pages/checkout/index.tsx
 
 Suggested E2E / QA Draft
-- tests/e2e/checkout-ui-smoke-flow.spec.ts: near runnable
+- tests/e2e/submit-checkout-and-persist-the-confirmed-order.spec.ts: near runnable
 - Open route /checkout.
 - Fill checkout email.
 - Submit checkout.
@@ -139,7 +150,7 @@ flows:
 
 ```txt
 Project: Web
-Recommended runner: Playwright
+Automation adapter: Playwright
 Execution profile: high
 Start command: pnpm run dev
 Test command: pnpm run test:e2e
@@ -224,7 +235,7 @@ For an Expo or React Native change, QAMap should recommend Maestro and carry mob
 
 ```txt
 Project: Expo / React Native
-Recommended runner: Maestro
+Automation adapter: Maestro
 
 Flow: Ink Drawing UI smoke flow
 Actor: User
@@ -269,7 +280,7 @@ For backend changes such as `src/v1/listing/utils.ts`, QAMap should not invent a
 
 ```txt
 Project: API / service
-Recommended runner: Manual
+Automation adapter: Manual
 
 Flow: Listing API contract smoke checklist
 Actor: API consumer or upstream service
@@ -296,7 +307,7 @@ For an npm package that exposes `package.json` bin entries, QAMap should not inv
 
 ```txt
 Project: CLI
-Recommended runner: Manual
+Automation adapter: Manual
 
 Flow: CLI command verification checklist
 Actor: CLI user or maintainer
@@ -460,9 +471,12 @@ Related Changed Files
 Good QAMap output should answer these questions quickly:
 
 - What behavior did this branch probably change?
+- Which commits and diff symbols support that intent, and how confident is the inference?
+- What trigger, condition, state change, side effect, and observable outcome form its lifecycle?
+- Which primary, failure, boundary, and state-transition checks follow from that lifecycle?
 - What does the team call that behavior?
 - Who or what exercises it?
-- Which runner or checklist is the right first shape?
+- Which existing automation adapter can compile the selected QA scenario?
 - Which setup, selector, fixture, or validation gap blocks this from becoming real regression coverage?
 
 If the output only says "make an E2E test" without these answers, it is not ready for the current release bar.

--- a/docs/quickstart-demo.md
+++ b/docs/quickstart-demo.md
@@ -145,10 +145,13 @@ Input
 ```txt
 Output
 - PR comment/checklist draft
+- commit-backed change intent and confidence
+- ordered behavior lifecycle
+- primary, failure, boundary, and state-transition QA scenarios
 - changed domain language
 - candidate user flow
 - manifest evidence when a repo-local flow/check matches
-- recommended runner
+- automation adapter selected after QA design
 - draft file path
 - flow language brief
 - runnable status
@@ -164,9 +167,13 @@ The result should not stop at "selector needed" or "fixture needed." A useful QA
 ```txt
 # QAMap QA Draft
 
+At a Glance
+- Change intent: Submit checkout and persist the confirmed order [high]
+- Behavior lifecycle: trigger: submit checkout -> side-effect: create order -> observable-outcome: show confirmation
+
 Summary
 - Project: Web
-- Recommended runner: Playwright
+- Automation adapter: Playwright
 - Manifest: .qamap/manifest.yaml
 - Stage: almost runnable (3 of 4)
 

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -1,5 +1,19 @@
 # Release Validation
 
+## 0.4.0 - 2026-07-12
+
+Validated as the first intent-first QA design release. The release contract starts with behavior-bearing commits and diff evidence, reconstructs an ordered behavior lifecycle, proposes runner-independent QA scenarios, and only then compiles an optional automation draft:
+
+| Gate | Current result |
+| --- | --- |
+| `pnpm test` | 139/139 passing |
+| `pnpm bench:ci` | 12/12 synthetic PR targets pass; dedicated web and mobile lifecycle targets require commit intent, ordered lifecycle phases, failure/boundary/state QA, observable success text, and commit-backed Behavior Graph evidence |
+| Coverage | Lines 86.80%, branches 83.37%, functions 94.86% |
+| Change Intent coverage | Lines 94.76%, branches 88.57%, functions 98.04% |
+| `npm publish --dry-run --access public` | Passed for `@ivorycanvas/qamap@0.4.0`; 129 files, 813.8 kB packed |
+| Intent-first output | Markdown, JSON, agent output, Behavior Graph, and generated drafts preserve confidence, commit evidence, lifecycle, and QA scenarios before automation-adapter guidance |
+| Read-only safety | Public regression coverage uses synthetic repositories; optional local smoke validation runs from temporary copies and does not modify target repositories |
+
 ## 0.3.5 - 2026-07-11
 
 Validated as a manifest-feedback reliability patch:
@@ -83,7 +97,9 @@ For each target, record:
 
 - command used
 - base/head refs or working-tree mode
-- recommended runner
+- inferred change intent, confidence, commit evidence, and review requirement
+- lifecycle and runner-independent QA scenario quality
+- selected automation adapter
 - generated flow language brief quality
 - draft readiness summary
 - draft self-check status and blockers
@@ -140,7 +156,9 @@ node dist/cli.js e2e draft <package> --workspace-root <repo-root> --base <base> 
 
 The E2E plan should show:
 
-- runner recommendation with clear evidence
+- change intent with commit and diff evidence, confidence, and review requirement
+- ordered behavior lifecycle and concrete primary, failure, boundary, and state-transition QA scenarios
+- automation adapter selection after the runner-independent QA sections
 - execution profile with start command, test command, base URL or app id when discoverable, confidence, and blockers
 - runner setup proposal with install commands, explicit `qamap e2e setup` acceptance command, files to create/update, and next commands when the repo lacks an E2E runner
 - setup output that reports the first generated changed-flow draft file after the accepted runner setup is applied
@@ -151,6 +169,7 @@ The E2E plan should show:
 
 The E2E draft should show:
 
+- intent evidence, lifecycle, and QA scenario comments inside generated artifacts
 - `verification-manifest` as the draft source when a matched manifest flow is strong enough
 - manifest evidence comments inside generated drafts
 - external `--manifest <file>` previews that let teams test generated manifest quality without writing `.qamap/manifest.yaml` into target repos
@@ -170,9 +189,11 @@ The QA draft should show:
 
 - no-write PR comment/checklist output from `qamap qa`
 - no cloud and no LLM token positioning in the output
+- change intent and lifecycle before automation setup
+- primary, failure, boundary, and state-transition QA scenarios when evidence supports them
 - affected flow language with changed files and reviewer question
 - suggested E2E or manual checklist path
-- runner recommendation inherited from the E2E planner
+- automation adapter inherited from the E2E planner
 - missing fixture, selector, assertion, runner, validation, or manifest evidence
 - PR checklist items that can be pasted into a pull request
 - optional manifest repair path when a manifest-backed recommendation is wrong
@@ -198,6 +219,9 @@ The manifest commands should show:
 The public demo must prove the product shape, not only command execution. Before promoting a release, run or update a small demo where a realistic PR diff produces a concrete E2E starting point:
 
 - The output names the affected product feature and user flow in domain language.
+- The output shows the behavior-bearing commit evidence, confidence, and review requirement behind the inferred intent.
+- The output orders trigger, condition, action, state change, side effect, and observable outcome before selecting a runner.
+- The output proposes concrete primary, failure, boundary, and state-transition QA where evidence supports them.
 - The output names the draft file that would be created or previewed.
 - The draft includes route or screen entry, realistic actions, and at least one meaningful assertion.
 - The report explains why the test was recommended from changed files and manifest evidence.
@@ -213,11 +237,12 @@ The matrix below is public, fixture-backed evidence from the repository test sui
 
 | Target | Fixture-backed coverage | Expected output |
 | --- | --- | --- |
+| Commit intent and lifecycle | `change intent clusters related commits into one evidence-backed lifecycle`; `change intent keeps unrelated feature commits separate`; `change intent ignores release-only commit metadata`; `E2E planning promotes commit intent before runner-specific draft generation` | Related feature commits become one evidence-backed intent; unrelated features remain separate; release-only changes do not become product intent; lifecycle and QA scenarios appear before Playwright or Maestro compilation; generic `primary journey` and `smoke flow` titles are suppressed when evidence supports a concrete name. |
 | Manifest-free QA skill entrypoint | `qa command emits a PR comment draft without requiring a manifest` | `qamap qa` works without `.qamap/manifest.yaml`, emits a local-first PR QA draft, names affected flow, changed files, suggested E2E/checklist path, missing evidence, PR checklist, agent handoff, and says manifest is optional upgrade rather than a first-use gate. |
 | Packaged PR QA skill template | `package metadata includes the portable PR QA skill template` | npm package metadata includes `skills`, and `skills/qamap-pr-qa/SKILL.md` contains the local PR QA workflow, `qamap qa` command, and manifest repair guidance. |
 | Verification manifest loop | `manifest init creates a baseline verification manifest`; `manifest init keeps Expo app file domains specific`; `manifest init captures advisory instruction context`; `manifest bootstrap produces concrete PR E2E draft from repo QA memory`; `e2e draft can use an external verification manifest for read-only adoption preview`; `manifest matches explain e2e and verify recommendations`; `manifest validate reports missing and stale manifest policy` | Generated `.qamap/manifest.yaml` includes `$schema`, domains, flows, anchors, checks, runner, source, and confidence; context preview reports repo-local instruction sources, role summaries, validation commands, safety rules, and diagnostics; validator reports missing/stale/duplicate policy; explain output maps branch changes to manifest domains/flows/checks; E2E drafts prefer `verification-manifest` sources with manifest evidence, route entry, detected input/action selectors, required checks, and manifest repair paths; external manifests can be passed with `--manifest` for read-only adoption smoke tests. |
-| Web app with Playwright routes | `generateE2ePlan matches committed core flow definitions`; `generateE2eDraft uses web selectors in Playwright specs`; `generateE2eDraft dry run previews files without writing drafts`; `generateE2eDraft asserts changed HTML success copy in Playwright specs`; `generateE2ePlan captures Playwright execution profile and self-check blockers`; `generateE2ePlan infers Playwright base URLs from dev scripts`; `generateE2eDraft supports Next app router route groups and concrete route hints`; `generateE2ePlan reads React Router object route paths`; `generateE2eDraft fills dynamic route params from concrete route hints`; `generateE2eDraft emits runnable Playwright role and input actions` | `Web` project profile, `playwright` runner, core-flow names such as `Checkout purchase`, route-aware Playwright drafts, dry-run preview status without filesystem writes, stable selector hints, changed HTML success copy assertions, execution profile, dev-script base URL hints, opt-in Playwright setup proposal, Next App Router route groups, React Router object paths, dynamic route params, draft self-check status, action items, and validation gaps. |
-| Expo / React Native mobile app | `generateE2ePlan recommends mobile flows for Expo changes`; `generateE2ePlan detects Maestro app ids from app config files`; `generateE2eDraft scopes entrypoint hints to each domain scenario`; `generateE2eDraft names changed component actions before generic primary journeys` | `Expo / React Native` project profile, `maestro` runner, app id and launch command hints from `app.json` or `app.config.*`, Maestro YAML drafts, `testID`/`accessibilityLabel` selector hints, action-specific scenario names such as `Listing Media Link Submit`, and mobile setup actions. |
+| Web app with Playwright routes | `generateE2ePlan matches committed core flow definitions`; `generateE2eDraft uses web selectors in Playwright specs`; `generateE2eDraft dry run previews files without writing drafts`; `generateE2eDraft asserts changed HTML success copy in Playwright specs`; `generateE2ePlan captures Playwright execution profile and self-check blockers`; `generateE2ePlan infers Playwright base URLs from dev scripts`; `generateE2eDraft supports Next app router route groups and concrete route hints`; `generateE2ePlan reads React Router object route paths`; `generateE2eDraft fills dynamic route params from concrete route hints`; `generateE2eDraft emits runnable Playwright role and input actions` | `Web` project profile, Playwright output adapter, intent-backed or core-flow names, route-aware drafts, dry-run preview status without filesystem writes, stable selector hints, changed HTML success copy assertions, execution profile, dev-script base URL hints, opt-in setup proposal, route groups, object paths, dynamic params, draft self-check status, action items, and validation gaps. |
+| Expo / React Native mobile app | `generateE2ePlan recommends mobile flows for Expo changes`; `generateE2ePlan detects Maestro app ids from app config files`; `generateE2eDraft scopes entrypoint hints to each domain scenario`; `generateE2eDraft names changed component actions before generic primary journeys` | `Expo / React Native` project profile, Maestro output adapter, app id and launch command hints from `app.json` or `app.config.*`, YAML drafts, `testID`/`accessibilityLabel` selector hints, and mobile setup actions after runner-independent QA intent. |
 | API or backend service | `generateE2ePlan detects API service projects and suggests contract checklists`; `generateE2ePlan detects Django service apps from a workspace root`; `generateE2ePlan names versioned API service paths with domain language`; `generateE2ePlan uses matched core flow names for API service contracts` | `API / service` project profile, manual contract checklist, Django/FastAPI-style service signals when present, domain-aware titles such as `Listing API contract`, API consumer actor, endpoint/handler/service-path trigger, service start/test command hints, and contract failure coverage. |
 | CLI package | `generateE2ePlan detects CLI packages and suggests command verification checklists` | `CLI` project profile from `package.json` bin entries, manual command verification checklist, CLI user or maintainer actor language, command invocation trigger, stdout/stderr/generated-file/exit-code success signal, valid and invalid argument coverage, and no required API fixture action unless the changed command path explicitly exposes network or fixture evidence. |
 | Design tokens and data catalogs | `generateE2ePlan detects design token packages and suggests artifact validation`; `generateE2ePlan detects data catalog repositories and suggests catalog verification` | `Design tokens` and `Data catalog` project profiles, manual artifact/catalog checklist, token or catalog actor language, schema/generated output/consumer fixture coverage, fixture readiness marked not needed for API mocks, and validation matrix rows that do not require browser/device selectors. |
@@ -239,7 +264,8 @@ Private repositories may be used as local, read-only diagnostics, but their raw 
 The release candidate must pass the fixture-backed suite, package dry-run, and read-only smoke protocol. Record only public synthetic evidence in this document or in release notes:
 
 - whether the generated flow names match the team's domain language
-- whether the recommended runner is plausible
+- whether commit evidence supports the inferred intent and lifecycle
+- whether the automation adapter is plausible without being mistaken for the product value
 - whether generated drafts identify the right actor, trigger, success signal, and edge cases
 - whether action items are concrete enough for a developer to convert into runnable tests
 - whether false positives are caused by missing manifests, weak selectors, or unsupported project structure

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,6 +2,19 @@
 
 This runbook defines the release process for `qamap`. It is intentionally conservative: the package should be published only when the local release gate, documentation, and representative repository validation all agree.
 
+## Pre-1.0 Version Policy
+
+QAMap keeps major and minor changes deliberately rare during `0.x` development.
+
+- Patch is the default for bug fixes, inference quality, performance, internal architecture, benchmarks, documentation, and additional adapters that preserve the existing CLI, schema, and safety contracts.
+- Minor is reserved for a new product-level capability, an incompatible CLI or manifest contract, or a meaningful change to default execution and safety behavior.
+- Risky minor work should ship through `alpha`, `beta`, and `rc` prereleases before the final minor.
+- Do not pre-allocate a minor version to every roadmap phase. Define the next minor release bar and continue compatible work as patches until that bar is met.
+
+The next minor release is earned when QAMap can complete one supported diff-to-evidence vertical slice: identify affected behavior, compile deterministic QA, execute it explicitly in temporary space, and report normalized evidence without modifying the target repository.
+
+Version `1.0.0` requires a stable public contract and external adoption, not implementation volume alone. CLI commands, exit codes, machine output, manifest migration, adapter compatibility, no-LLM/no-upload guarantees, and release operations must be dependable. Repository stars are useful social proof, but repeated use in unrelated repositories and reported QA value are stronger release evidence.
+
 ## Release Owner Checklist
 
 Before publishing, confirm:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -11,7 +11,7 @@ QAMap keeps major and minor changes deliberately rare during `0.x` development.
 - Risky minor work should ship through `alpha`, `beta`, and `rc` prereleases before the final minor.
 - Do not pre-allocate a minor version to every roadmap phase. Define the next minor release bar and continue compatible work as patches until that bar is met.
 
-The next minor release is earned when QAMap can complete one supported diff-to-evidence vertical slice: identify affected behavior, compile deterministic QA, execute it explicitly in temporary space, and report normalized evidence without modifying the target repository.
+Version `0.4.0` is earned by the first commit-to-intent-to-scenario vertical slice: behavior-bearing commits and diff symbols become an evidence-backed lifecycle and concrete runner-independent QA, then existing Playwright, Maestro, or manual adapters compile the result. The next minor is reserved for explicit temporary execution and normalized evidence without modifying the target repository.
 
 Version `1.0.0` requires a stable public contract and external adoption, not implementation volume alone. CLI commands, exit codes, machine output, manifest migration, adapter compatibility, no-LLM/no-upload guarantees, and release operations must be dependable. Repository stars are useful social proof, but repeated use in unrelated repositories and reported QA value are stronger release evidence.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-QAMap starts as a local CLI for repo-level AI agent readiness. The project can grow in layers without becoming heavy.
+QAMap is a local CLI for evidence-backed PR QA design. The project can grow in layers without becoming a hosted platform or token-dependent agent.
 
 ## North Star
 
@@ -20,33 +20,37 @@ This means QAMap should be judged by whether it identifies the right behavior an
 Before treating the next public release as ready, the golden demo must satisfy these conditions:
 
 - First-run output is concrete, not broad: it names the affected feature, flow, draft file, and checks.
+- Commit evidence becomes an explicit change intent and ordered behavior lifecycle before any runner is recommended.
+- Generic `primary journey` and `smoke flow` names fail the benchmark when commit and diff evidence can support a concrete lifecycle.
 - Manifest authoring burden stays low: `manifest context` and `manifest init` provide a useful baseline before a human edits YAML.
 - Generated E2E draft is a usable starting point: it has route/screen entry, meaningful actions, assertions, and clear TODOs only where repo data is missing.
 - Recommendation evidence is explainable: output shows the changed file, manifest flow/check, and manifest path to repair when wrong.
 - README demo shows the full loop: manifest-free PR QA draft, optional repo context baseline, PR mapping, E2E draft, and remaining validation gaps.
 - One manifest correction should improve future PR recommendations without another LLM prompt.
 
-## Now
+## Now: 0.4.x
 
-- Introduce a stable, framework-neutral Behavior Graph with adapter isolation, deterministic ids, evidence provenance, and direct versus propagated impact. Keep the existing flow inference as a compatibility adapter until source analyzers emit graph fragments directly.
+- Stabilize commit-range Change Intent analysis: related behavior commits, diff symbols, confidence, review requirements, lifecycle stages, and runner-independent QA scenarios.
+- Keep `qamap.change-intent` as a direct Behavior Graph adapter while moving more source observations out of the compatibility adapter.
 - Preserve `qa` as the static, read-only product surface while designing explicit execution behind `verify`; never turn a scan into implicit project-code execution.
 - Treat the committed [benchmark contract](benchmarking.md) as the quality gate for recommendations, not only implementation correctness. Reduce real failures into public fixtures and require `pnpm bench:ci` on every PR.
-- Make `qa` the primary product surface. Its first screen and `--format agent` payload should agree on affected behavior, reviewer question, repository evidence, draft path, and missing trust requirements.
+- Make `qa` the primary product surface. Its first screen and `--format agent` payload must agree on change intent, lifecycle, QA scenarios, affected behavior, repository evidence, draft path, and missing trust requirements.
 - Improve changed-file impact mapping from shared symbols and components to consuming routes, screens, API contracts, and manifest flows.
 - Keep the [release validation checklist](release-validation.md), [manifest guide](manifest.md), public [E2E output examples](e2e-output-examples.md), and README examples aligned with captured output from the public fixtures.
 - Stabilize the manifest feedback loop with `.qamap/manifest.yaml`, `manifest init`, `manifest validate`, `manifest explain`, JSON Schema, and manifest-driven E2E draft shaping.
 - Keep `manifest context` useful as a pre-init sanity check for repo-local QA memory, harness docs, agent instructions, and runbooks.
-- Improve generated drafts until the golden demo feels like a real starting point, not a generic checklist.
+- Improve Playwright and Maestro compilation from intent scenarios while keeping runner choice behind the runner-independent QA contract.
 - Keep `verify`, `e2e`, and `manifest` as deeper layers behind `qa`; freeze new scanner, doctor, eval, domains, flows, and history features until the core QA contract is consistently useful.
 
 ## Next
 
 - Move route, screen, endpoint, selector, fixture, test, and contract discovery into analyzer adapters, starting with TypeScript web stacks and reusing one web behavior model across Next.js, React Router, Vue/Nuxt, and SvelteKit.
-- Compare base and head Behavior Graphs, then select impacted graph paths before compiling deterministic success, validation, failure, empty, loading, auth, and contract scenarios.
+- Compare base and head Behavior Graphs, then select impacted graph paths before refining deterministic success, validation, failure, empty, loading, auth, and contract scenarios.
+- Add policy-controlled temporary execution so selected scenarios can produce normalized pass, fail, blocked, and not-verifiable evidence without modifying the target repository.
 - Add an execution benchmark that injects known regressions and requires QAMap to select and fail the relevant scenario without changing the fixture repository.
 - Add symbol-level anchors for exported components, hooks, API clients, handlers, schemas, and queries after the public import-impact fixture stays stable.
 - Add a manifest correction command that proposes the exact flow/anchor patch and applies it only after human approval, avoiding routine hand-edits to YAML.
-- Add stronger deterministic draft adapters for Playwright and Maestro while keeping `manual` output for API, CLI, token, and catalog repositories.
+- Add stronger deterministic draft adapters for Playwright and Maestro while keeping `manual` output for API, CLI, token, and catalog repositories; runner detection itself is not a product success metric.
 - Expand the public benchmark corpus with package-scoped monorepos, auth/session changes, dynamic routes, API failure fixtures, and non-JavaScript services.
 - Keep the `--format agent` output a stable, versioned contract that skills and MCP wrappers can rely on.
 - Continue expanding agent surface detection across popular coding-agent tools without making the public workflow depend on a single vendor.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,16 +4,16 @@ QAMap starts as a local CLI for repo-level AI agent readiness. The project can g
 
 ## North Star
 
-QAMap should become a local-first QA skill plus optional QA memory layer: it maps PR changes to affected flows, drafts the E2E/checklist work needed before merge, and improves over time through a repository-level verification manifest. The goal is not to replace reviewers or QA. The goal is to remove the repeated blank-page work that makes developers skip good verification.
+QAMap should become a local, zero-LLM, change-aware QA engine. It should map any PR change to affected behavior, select the smallest relevant QA set, and eventually execute that QA with local evidence. A repository-level verification manifest supplies reviewed product intent that static code evidence cannot prove. The goal is not to replace reviewers or QA. The goal is to remove the repeated blank-page and manual verification work that makes developers skip good QA.
 
 The sharp product position is:
 
 ```txt
-Do not re-prompt AI for the same QA context.
-Run a local PR QA draft first, then capture team QA memory in the repo when repeated corrections should improve future recommendations.
+Read the change, find the affected behavior, and produce local QA evidence.
+No source upload. No LLM token. Let reviewed repository memory improve every later PR.
 ```
 
-This means QAMap should be judged less like a generic test recorder and more like a manifest-backed PR verification assistant. A recorder captures what a person just clicked. QAMap should explain what the PR changed, which durable flow/check knowledge applies, and what test artifact should now exist.
+This means QAMap should be judged by whether it identifies the right behavior and catches a seeded regression, not only whether it writes plausible test code. Playwright, Maestro, and other runners are implementation details behind that product contract.
 
 ## Release Bar
 
@@ -28,6 +28,8 @@ Before treating the next public release as ready, the golden demo must satisfy t
 
 ## Now
 
+- Introduce a stable, framework-neutral Behavior Graph with adapter isolation, deterministic ids, evidence provenance, and direct versus propagated impact. Keep the existing flow inference as a compatibility adapter until source analyzers emit graph fragments directly.
+- Preserve `qa` as the static, read-only product surface while designing explicit execution behind `verify`; never turn a scan into implicit project-code execution.
 - Treat the committed [benchmark contract](benchmarking.md) as the quality gate for recommendations, not only implementation correctness. Reduce real failures into public fixtures and require `pnpm bench:ci` on every PR.
 - Make `qa` the primary product surface. Its first screen and `--format agent` payload should agree on affected behavior, reviewer question, repository evidence, draft path, and missing trust requirements.
 - Improve changed-file impact mapping from shared symbols and components to consuming routes, screens, API contracts, and manifest flows.
@@ -39,6 +41,9 @@ Before treating the next public release as ready, the golden demo must satisfy t
 
 ## Next
 
+- Move route, screen, endpoint, selector, fixture, test, and contract discovery into analyzer adapters, starting with TypeScript web stacks and reusing one web behavior model across Next.js, React Router, Vue/Nuxt, and SvelteKit.
+- Compare base and head Behavior Graphs, then select impacted graph paths before compiling deterministic success, validation, failure, empty, loading, auth, and contract scenarios.
+- Add an execution benchmark that injects known regressions and requires QAMap to select and fail the relevant scenario without changing the fixture repository.
 - Add symbol-level anchors for exported components, hooks, API clients, handlers, schemas, and queries after the public import-impact fixture stays stable.
 - Add a manifest correction command that proposes the exact flow/anchor patch and applies it only after human approval, avoiding routine hand-edits to YAML.
 - Add stronger deterministic draft adapters for Playwright and Maestro while keeping `manual` output for API, CLI, token, and catalog repositories.
@@ -55,7 +60,8 @@ Before treating the next public release as ready, the golden demo must satisfy t
 
 ## Non-Goals
 
-- QAMap will not execute untrusted project code.
+- Static commands such as `qa`, `scan`, and planning modes will not execute scanned project code. Future execution requires an explicit command and a visible, policy-controlled execution plan.
+- QAMap will not implement its own browser or device automation engine; it will orchestrate proven local executors behind a framework-neutral QA contract.
 - QAMap will not replace tests, review, branch protection, threat modeling, or security review.
 - QAMap will not become a general-purpose code style linter.
 - QAMap will not become a deep MCP server analysis engine.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ivorycanvas/qamap",
-      "version": "0.3.6",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ivorycanvas/qamap",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.9.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.3.6",
-  "description": "Local zero-LLM QA map that turns PR diffs into affected behavior, missing evidence, and deterministic E2E drafts.",
+  "version": "0.4.0",
+  "description": "Local zero-LLM PR QA designer that turns commit intent and diffs into behavior lifecycles, QA scenarios, and deterministic automation drafts.",
   "type": "module",
   "packageManager": "pnpm@10.32.1",
   "bin": {
@@ -39,6 +39,8 @@
     "mcp",
     "preflight",
     "pull-request",
+    "change-intent",
+    "behavior-graph",
     "e2e",
     "e2e-testing",
     "qa",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ivorycanvas/qamap",
   "version": "0.3.5",
-  "description": "Local-first QA skill that turns PR diffs into affected flows, missing evidence, and E2E drafts with no cloud or LLM token.",
+  "description": "Local zero-LLM QA map that turns PR diffs into affected behavior, missing evidence, and deterministic E2E drafts.",
   "type": "module",
   "packageManager": "pnpm@10.32.1",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Local zero-LLM QA map that turns PR diffs into affected behavior, missing evidence, and deterministic E2E drafts.",
   "type": "module",
   "packageManager": "pnpm@10.32.1",

--- a/schema/qamap-agent.schema.json
+++ b/schema/qamap-agent.schema.json
@@ -45,7 +45,7 @@
     "runner": {
       "type": "string",
       "enum": ["maestro", "playwright", "manual"],
-      "description": "Recommended E2E runner for this repository."
+      "description": "Automation output adapter selected after runner-independent QA intent analysis."
     },
     "manifest": {
       "type": ["string", "null"],

--- a/schema/qamap-agent.schema.json
+++ b/schema/qamap-agent.schema.json
@@ -71,6 +71,47 @@
         "files": { "type": "number", "minimum": 0 }
       }
     },
+    "intents": {
+      "type": "array",
+      "description": "Evidence-backed change intents derived before runner selection (capped).",
+      "items": {
+        "type": "object",
+        "required": ["title", "confidence", "reviewRequired", "evidence", "lifecycle", "scenarios"],
+        "properties": {
+          "title": { "type": "string" },
+          "confidence": { "type": "string", "enum": ["low", "medium", "high"] },
+          "reviewRequired": { "type": "boolean" },
+          "evidence": { "type": "array", "items": { "type": "string" } },
+          "lifecycle": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["phase", "label"],
+              "properties": {
+                "phase": {
+                  "type": "string",
+                  "enum": ["trigger", "condition", "action", "state-change", "side-effect", "observable-outcome"]
+                },
+                "label": { "type": "string" }
+              }
+            }
+          },
+          "scenarios": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["priority", "kind", "title", "assertions"],
+              "properties": {
+                "priority": { "type": "string", "enum": ["critical", "recommended"] },
+                "kind": { "type": "string", "enum": ["primary", "failure", "boundary", "state-transition"] },
+                "title": { "type": "string" },
+                "assertions": { "type": "array", "items": { "type": "string" } }
+              }
+            }
+          }
+        }
+      }
+    },
     "firstDraftCommand": {
       "type": "string",
       "description": "One command that creates the first E2E draft. Only present when the repository has no test suite and the diff reaches a product journey."

--- a/schema/qamap-behavior.schema.json
+++ b/schema/qamap-behavior.schema.json
@@ -1,0 +1,307 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/IvoryCanvas/qamap/main/schema/qamap-behavior.schema.json",
+  "title": "QAMap Behavior Graph",
+  "description": "Framework-neutral, deterministic behavior evidence derived from a repository change.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "schemaVersion", "root", "base", "head", "surface", "adapters", "nodes", "edges", "diagnostics", "summary"],
+  "properties": {
+    "$schema": {
+      "const": "https://raw.githubusercontent.com/IvoryCanvas/qamap/main/schema/qamap-behavior.schema.json"
+    },
+    "schemaVersion": {
+      "const": 1
+    },
+    "root": {
+      "type": "string",
+      "minLength": 1
+    },
+    "workspaceRoot": {
+      "type": "string",
+      "minLength": 1
+    },
+    "base": {
+      "type": "string",
+      "minLength": 1
+    },
+    "head": {
+      "type": "string",
+      "minLength": 1
+    },
+    "surface": {
+      "$ref": "#/$defs/surface"
+    },
+    "adapters": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/adapterRun"
+      }
+    },
+    "nodes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/node"
+      }
+    },
+    "edges": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/edge"
+      }
+    },
+    "diagnostics": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/diagnostic"
+      }
+    },
+    "summary": {
+      "$ref": "#/$defs/summary"
+    }
+  },
+  "$defs": {
+    "confidence": {
+      "type": "string",
+      "enum": ["low", "medium", "high"]
+    },
+    "surface": {
+      "type": "string",
+      "enum": ["web", "mobile", "api", "cli", "artifact", "unknown"]
+    },
+    "nodeKind": {
+      "type": "string",
+      "enum": ["domain", "flow", "surface", "action", "state", "effect", "contract", "assertion", "fixture", "locator", "source"]
+    },
+    "edgeKind": {
+      "type": "string",
+      "enum": ["contains", "enters-at", "precedes", "expects", "uses-fixture", "located-by", "implemented-by", "impacts"]
+    },
+    "evidenceKind": {
+      "type": "string",
+      "enum": ["diff", "source", "manifest", "selector", "fixture", "test", "inference"]
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "value"],
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/evidenceKind"
+        },
+        "value": {
+          "type": "string",
+          "minLength": 1
+        },
+        "file": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "impact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "changedFiles"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["direct", "propagated"]
+        },
+        "changedFiles": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "attributeValue": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "number" },
+        { "type": "boolean" },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "label", "confidence", "evidence"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "$ref": "#/$defs/nodeKind"
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "confidence": {
+          "$ref": "#/$defs/confidence"
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/evidence"
+          }
+        },
+        "attributes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/attributeValue"
+          }
+        },
+        "impact": {
+          "$ref": "#/$defs/impact"
+        }
+      }
+    },
+    "edge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "from", "to", "confidence", "evidence"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "$ref": "#/$defs/edgeKind"
+        },
+        "from": {
+          "type": "string",
+          "minLength": 1
+        },
+        "to": {
+          "type": "string",
+          "minLength": 1
+        },
+        "confidence": {
+          "$ref": "#/$defs/confidence"
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/evidence"
+          }
+        }
+      }
+    },
+    "adapterRun": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version", "status", "detection", "nodeCount", "edgeCount"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "type": "string",
+          "enum": ["used", "skipped", "failed"]
+        },
+        "detection": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["confidence", "reason", "evidence"],
+          "properties": {
+            "confidence": {
+              "type": "string",
+              "enum": ["none", "low", "medium", "high"]
+            },
+            "reason": {
+              "type": "string",
+              "minLength": 1
+            },
+            "evidence": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "nodeCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "edgeCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "diagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["severity", "message"],
+      "properties": {
+        "severity": {
+          "type": "string",
+          "enum": ["info", "warning"]
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "adapterId": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["nodes", "edges", "impactedNodes", "byKind"],
+      "properties": {
+        "nodes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "edges": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "impactedNodes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "byKind": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["domain", "flow", "surface", "action", "state", "effect", "contract", "assertion", "fixture", "locator", "source"],
+          "properties": {
+            "domain": { "type": "integer", "minimum": 0 },
+            "flow": { "type": "integer", "minimum": 0 },
+            "surface": { "type": "integer", "minimum": 0 },
+            "action": { "type": "integer", "minimum": 0 },
+            "state": { "type": "integer", "minimum": 0 },
+            "effect": { "type": "integer", "minimum": 0 },
+            "contract": { "type": "integer", "minimum": 0 },
+            "assertion": { "type": "integer", "minimum": 0 },
+            "fixture": { "type": "integer", "minimum": 0 },
+            "locator": { "type": "integer", "minimum": 0 },
+            "source": { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/qamap-behavior.schema.json
+++ b/schema/qamap-behavior.schema.json
@@ -79,7 +79,7 @@
     },
     "evidenceKind": {
       "type": "string",
-      "enum": ["diff", "source", "manifest", "selector", "fixture", "test", "inference"]
+      "enum": ["commit", "diff", "source", "manifest", "selector", "fixture", "test", "inference"]
     },
     "evidence": {
       "type": "object",

--- a/scripts/bench.mjs
+++ b/scripts/bench.mjs
@@ -94,6 +94,7 @@ function scoreTarget(target, plan, qa, durationMs) {
   const successSignals = qa.flows
     .map((flow) => flow.userJourney?.successSignal)
     .filter(Boolean);
+  const entrypoints = plan.flows.flatMap((flow) => flow.entrypoints.map((entrypoint) => entrypoint.value));
   const mustName = expect.mustNameFlows ?? [];
   const named = mustName.filter((name) => includesTerm(flowTitles, name));
 
@@ -106,6 +107,7 @@ function scoreTarget(target, plan, qa, durationMs) {
     planFlowTitles,
     flowTitles,
     successSignals,
+    entrypoints,
     draftPaths: qa.flows.map((flow) => normalizePath(flow.draftPath)),
     genericTitles: qa.flows.filter((flow) => genericTitlePattern.test(flow.title)).length,
     importPropagatedFlows: plan.flows.filter((flow) => flow.reason.includes("through imports")).length,
@@ -209,6 +211,7 @@ function evaluateContract(expect, result, plan, qa) {
   appendMissingTerms(failures, "step", steps, expect.mustIncludeSteps);
   appendMissingTerms(failures, "selector", selectors, expect.mustFindSelectors);
   appendMissingTerms(failures, "success signal", result.successSignals, expect.mustFindSuccessSignals);
+  appendMissingTerms(failures, "entrypoint", result.entrypoints, expect.mustFindEntrypoints);
   appendMissingTerms(failures, "evidence", evidence, expect.mustFindEvidence);
   appendUnexpectedTerms(failures, "evidence", evidence, expect.mustNotFindEvidence);
   appendMissingTerms(failures, "command", commands, expect.mustRecommendCommands);

--- a/scripts/bench.mjs
+++ b/scripts/bench.mjs
@@ -113,6 +113,13 @@ function scoreTarget(target, plan, qa, durationMs) {
     manifestMatches: plan.verificationManifestMatches.length,
     manifestFlowMatches: plan.verificationManifestMatches.filter((match) => match.kind === "flow").length,
     manifestBackedFlows: qa.flows.filter((flow) => flow.source === "manifest-backed").length,
+    behaviorNodes: plan.behaviorGraph.summary.nodes,
+    behaviorEdges: plan.behaviorGraph.summary.edges,
+    behaviorImpactedNodes: plan.behaviorGraph.summary.impactedNodes,
+    behaviorGraph: `${plan.behaviorGraph.summary.nodes}/${plan.behaviorGraph.summary.impactedNodes}`,
+    behaviorKinds: Object.entries(plan.behaviorGraph.summary.byKind)
+      .filter(([, count]) => count > 0)
+      .map(([kind]) => kind),
     blankActions: allSteps.filter((step) => blankActionPattern.test(step)).length,
     mustReachRecall: mustReach.length > 0 ? `${reached.length}/${mustReach.length}` : null,
     mustReachMissing: mustReach.filter((file) => !flowFiles.has(file)),
@@ -138,6 +145,26 @@ function evaluateContract(expect, result, plan, qa) {
     ...qa.runnerSetup.installCommands,
     ...qa.runnerSetup.nextCommands,
   ].filter(Boolean);
+  const behaviorNodeIds = new Set(plan.behaviorGraph.nodes.map((node) => node.id));
+  const danglingBehaviorEdges = plan.behaviorGraph.edges.filter(
+    (edge) => !behaviorNodeIds.has(edge.from) || !behaviorNodeIds.has(edge.to),
+  );
+
+  if (plan.behaviorGraph.schemaVersion !== 1) {
+    failures.push(`behavior graph schema expected 1, got ${plan.behaviorGraph.schemaVersion}`);
+  }
+  if (plan.behaviorGraph.summary.byKind.flow < plan.flows.length) {
+    failures.push(
+      `behavior graph expected at least ${plan.flows.length} flow node(s), got ${plan.behaviorGraph.summary.byKind.flow}`,
+    );
+  }
+  if (plan.changedFiles.length > 0 && plan.behaviorGraph.summary.impactedNodes === 0) {
+    failures.push("behavior graph has no impacted nodes for a non-empty branch diff");
+  }
+  if (danglingBehaviorEdges.length > 0) {
+    failures.push(`behavior graph has ${danglingBehaviorEdges.length} dangling edge(s)`);
+  }
+  appendMissingTerms(failures, "behavior kind", result.behaviorKinds, expect.mustHaveBehaviorKinds);
 
   if (expect.runner && result.runner !== expect.runner) {
     failures.push(`runner expected ${expect.runner}, got ${result.runner}`);
@@ -294,6 +321,7 @@ function printTable(rows) {
     ["importPropagatedFlows", 10],
     ["diffAnchoredFlows", 10],
     ["manifestFlowMatches", 8],
+    ["behaviorGraph", 9],
     ["blankActions", 6],
     ["genericTitles", 8],
     ["mustReachRecall", 10],
@@ -331,7 +359,7 @@ function printDeltas(baselineRows, currentRows) {
       continue;
     }
     const deltas = [];
-    for (const key of ["flows", "importPropagatedFlows", "diffAnchoredFlows", "manifestFlowMatches", "blankActions", "genericTitles", "agentBytes"]) {
+    for (const key of ["flows", "importPropagatedFlows", "diffAnchoredFlows", "manifestFlowMatches", "behaviorNodes", "behaviorImpactedNodes", "blankActions", "genericTitles", "agentBytes"]) {
       const diff = (current[key] ?? 0) - (before[key] ?? 0);
       if (diff !== 0) {
         deltas.push(`${key} ${diff > 0 ? "+" : ""}${diff}`);
@@ -347,6 +375,7 @@ function shortLabel(key) {
     importPropagatedFlows: "viaImport",
     diffAnchoredFlows: "diffAnchor",
     manifestFlowMatches: "manifest",
+    behaviorGraph: "graph n/i",
     blankActions: "blank",
     genericTitles: "generic",
     mustReachRecall: "reach",

--- a/scripts/bench.mjs
+++ b/scripts/bench.mjs
@@ -116,6 +116,9 @@ function scoreTarget(target, plan, qa, durationMs) {
     behaviorNodes: plan.behaviorGraph.summary.nodes,
     behaviorEdges: plan.behaviorGraph.summary.edges,
     behaviorImpactedNodes: plan.behaviorGraph.summary.impactedNodes,
+    manifestBehaviorNodes: plan.behaviorGraph.nodes.filter((node) =>
+      node.evidence.some((evidence) => evidence.kind === "manifest")
+    ).length,
     behaviorGraph: `${plan.behaviorGraph.summary.nodes}/${plan.behaviorGraph.summary.impactedNodes}`,
     behaviorKinds: Object.entries(plan.behaviorGraph.summary.byKind)
       .filter(([, count]) => count > 0)
@@ -163,6 +166,14 @@ function evaluateContract(expect, result, plan, qa) {
   }
   if (danglingBehaviorEdges.length > 0) {
     failures.push(`behavior graph has ${danglingBehaviorEdges.length} dangling edge(s)`);
+  }
+  if (
+    expect.minManifestBehaviorNodes !== undefined &&
+    result.manifestBehaviorNodes < expect.minManifestBehaviorNodes
+  ) {
+    failures.push(
+      `expected at least ${expect.minManifestBehaviorNodes} manifest behavior node(s), got ${result.manifestBehaviorNodes}`,
+    );
   }
   appendMissingTerms(failures, "behavior kind", result.behaviorKinds, expect.mustHaveBehaviorKinds);
 
@@ -359,7 +370,7 @@ function printDeltas(baselineRows, currentRows) {
       continue;
     }
     const deltas = [];
-    for (const key of ["flows", "importPropagatedFlows", "diffAnchoredFlows", "manifestFlowMatches", "behaviorNodes", "behaviorImpactedNodes", "blankActions", "genericTitles", "agentBytes"]) {
+    for (const key of ["flows", "importPropagatedFlows", "diffAnchoredFlows", "manifestFlowMatches", "behaviorNodes", "behaviorImpactedNodes", "manifestBehaviorNodes", "blankActions", "genericTitles", "agentBytes"]) {
       const diff = (current[key] ?? 0) - (before[key] ?? 0);
       if (diff !== 0) {
         deltas.push(`${key} ${diff > 0 ? "+" : ""}${diff}`);

--- a/scripts/bench.mjs
+++ b/scripts/bench.mjs
@@ -95,6 +95,15 @@ function scoreTarget(target, plan, qa, durationMs) {
     .map((flow) => flow.userJourney?.successSignal)
     .filter(Boolean);
   const entrypoints = plan.flows.flatMap((flow) => flow.entrypoints.map((entrypoint) => entrypoint.value));
+  const intentTitles = plan.changeAnalysis.intents.map((intent) => intent.title);
+  const intentLifecycle = plan.changeAnalysis.intents.flatMap((intent) =>
+    intent.lifecycle.map((stage) => `${stage.kind}: ${stage.label}`)
+  );
+  const intentScenarios = plan.changeAnalysis.intents.flatMap((intent) =>
+    intent.scenarios.map((scenario) =>
+      `${scenario.priority} ${scenario.kind}: ${scenario.title} ${scenario.assertions.join(" ")}`
+    )
+  );
   const mustName = expect.mustNameFlows ?? [];
   const named = mustName.filter((name) => includesTerm(flowTitles, name));
 
@@ -108,6 +117,14 @@ function scoreTarget(target, plan, qa, durationMs) {
     flowTitles,
     successSignals,
     entrypoints,
+    changeIntents: plan.changeAnalysis.intents.length,
+    highConfidenceIntents: plan.changeAnalysis.intents.filter((intent) => intent.confidence === "high").length,
+    intentTitles,
+    intentLifecycle,
+    intentScenarios,
+    intentEvidence: plan.changeAnalysis.intents.flatMap((intent) =>
+      intent.evidence.map((evidence) => evidence.value)
+    ),
     draftPaths: qa.flows.map((flow) => normalizePath(flow.draftPath)),
     genericTitles: qa.flows.filter((flow) => genericTitlePattern.test(flow.title)).length,
     importPropagatedFlows: plan.flows.filter((flow) => flow.reason.includes("through imports")).length,
@@ -120,6 +137,9 @@ function scoreTarget(target, plan, qa, durationMs) {
     behaviorImpactedNodes: plan.behaviorGraph.summary.impactedNodes,
     manifestBehaviorNodes: plan.behaviorGraph.nodes.filter((node) =>
       node.evidence.some((evidence) => evidence.kind === "manifest")
+    ).length,
+    commitBehaviorNodes: plan.behaviorGraph.nodes.filter((node) =>
+      node.evidence.some((evidence) => evidence.kind === "commit")
     ).length,
     behaviorGraph: `${plan.behaviorGraph.summary.nodes}/${plan.behaviorGraph.summary.impactedNodes}`,
     behaviorKinds: Object.entries(plan.behaviorGraph.summary.byKind)
@@ -178,6 +198,27 @@ function evaluateContract(expect, result, plan, qa) {
     );
   }
   appendMissingTerms(failures, "behavior kind", result.behaviorKinds, expect.mustHaveBehaviorKinds);
+  if (expect.minChangeIntents !== undefined && result.changeIntents < expect.minChangeIntents) {
+    failures.push(`expected at least ${expect.minChangeIntents} change intent(s), got ${result.changeIntents}`);
+  }
+  if (
+    expect.minHighConfidenceIntents !== undefined &&
+    result.highConfidenceIntents < expect.minHighConfidenceIntents
+  ) {
+    failures.push(
+      `expected at least ${expect.minHighConfidenceIntents} high-confidence intent(s), got ${result.highConfidenceIntents}`,
+    );
+  }
+  if (expect.minCommitBehaviorNodes !== undefined && result.commitBehaviorNodes < expect.minCommitBehaviorNodes) {
+    failures.push(
+      `expected at least ${expect.minCommitBehaviorNodes} commit-backed behavior node(s), got ${result.commitBehaviorNodes}`,
+    );
+  }
+  appendMissingTerms(failures, "intent title", result.intentTitles, expect.mustNameIntents);
+  appendUnexpectedTerms(failures, "intent title", result.intentTitles, expect.mustNotNameIntents);
+  appendMissingTerms(failures, "intent lifecycle", result.intentLifecycle, expect.mustIncludeLifecycle);
+  appendMissingTerms(failures, "intent QA scenario", result.intentScenarios, expect.mustIncludeQaScenarios);
+  appendMissingTerms(failures, "intent evidence", result.intentEvidence, expect.mustFindIntentEvidence);
 
   if (expect.runner && result.runner !== expect.runner) {
     failures.push(`runner expected ${expect.runner}, got ${result.runner}`);
@@ -289,7 +330,7 @@ async function materializeFixture(target, configDir) {
     await fs.cp(headRoot, repositoryRoot, { recursive: true, force: true });
   }
   await git(repositoryRoot, ["add", "-A"]);
-  await git(repositoryRoot, ["commit", "--allow-empty", "-m", "benchmark change"]);
+  await git(repositoryRoot, ["commit", "--allow-empty", "-m", target.commitMessage ?? "benchmark change"]);
   const prepared = targetPaths(target, repositoryRoot, "main", "HEAD");
   return {
     ...prepared,
@@ -336,6 +377,7 @@ function printTable(rows) {
     ["diffAnchoredFlows", 10],
     ["manifestFlowMatches", 8],
     ["behaviorGraph", 9],
+    ["changeIntents", 7],
     ["blankActions", 6],
     ["genericTitles", 8],
     ["mustReachRecall", 10],
@@ -373,7 +415,7 @@ function printDeltas(baselineRows, currentRows) {
       continue;
     }
     const deltas = [];
-    for (const key of ["flows", "importPropagatedFlows", "diffAnchoredFlows", "manifestFlowMatches", "behaviorNodes", "behaviorImpactedNodes", "manifestBehaviorNodes", "blankActions", "genericTitles", "agentBytes"]) {
+    for (const key of ["flows", "changeIntents", "highConfidenceIntents", "importPropagatedFlows", "diffAnchoredFlows", "manifestFlowMatches", "behaviorNodes", "behaviorImpactedNodes", "manifestBehaviorNodes", "commitBehaviorNodes", "blankActions", "genericTitles", "agentBytes"]) {
       const diff = (current[key] ?? 0) - (before[key] ?? 0);
       if (diff !== 0) {
         deltas.push(`${key} ${diff > 0 ? "+" : ""}${diff}`);
@@ -390,6 +432,7 @@ function shortLabel(key) {
     diffAnchoredFlows: "diffAnchor",
     manifestFlowMatches: "manifest",
     behaviorGraph: "graph n/i",
+    changeIntents: "intents",
     blankActions: "blank",
     genericTitles: "generic",
     mustReachRecall: "reach",

--- a/skills/qamap-pr-qa/SKILL.md
+++ b/skills/qamap-pr-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qamap-pr-qa
-description: Local-first PR QA workflow for AI-assisted code changes. Use when an agent is preparing, updating, or reviewing a pull request and needs to run QAMap to identify affected flows, recommended E2E or manual QA work, missing fixture/selector/assertion/runner evidence, PR checklist items, and optional manifest repair guidance without calling a cloud service or LLM.
+description: Local zero-LLM PR QA workflow. Use when an agent is preparing, updating, or reviewing a pull request and needs to derive commit-backed change intent, behavior lifecycle, runner-independent QA scenarios, affected flows, automation drafts, missing evidence, and optional manifest repair guidance without calling a cloud service or LLM.
 ---
 
 # QAMap PR QA
@@ -33,28 +33,30 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
    pnpm dlx @ivorycanvas/qamap qa <package-path> --workspace-root . --base <base> --head HEAD
    ```
 
-4. If QAMap prints `First E2E Draft Bootstrap`, treat it as an instruction to create the starter draft before writing broad QA notes:
+4. Read and verify intent before generating code. In agent format:
+   - `intents[]` — commit/diff evidence, confidence, `reviewRequired`, ordered lifecycle, and primary/failure/boundary/state-transition scenarios.
+   - If `reviewRequired` is true or the lifecycle conflicts with the PR, ask a human to confirm the intended behavior before promoting a draft.
+   - `flows[]` — affected flows with `draft` path, `runnable` status, entry route, capped steps, and selectors.
+   - `requiredEvidence[]` — evidence that must exist before the PR can be trusted; `recommendedEvidenceCount` for the rest.
+   - `requiredBootstrap[]` — setup steps that block trusting generated drafts.
+   - `prChecklist[]` and `commands[]` — checklist lines and validation commands for the handoff.
+
+5. If the intent is credible and QAMap prints `First E2E Draft Bootstrap`, create the starter draft instead of stopping at broad QA notes:
 
    ```sh
    pnpm exec qamap e2e setup . --runner <runner>
    ```
 
    Use the exact create command from the output when it differs.
-5. Read the output. In agent format (single minified JSON object, `schema.name` = `qamap.qa`):
-   - `flows[]` — affected flows with `draft` path, `runnable` status, `entry` route, capped `steps` and `selectors`.
-   - `requiredEvidence[]` — evidence that must exist before the PR can be trusted; `recommendedEvidenceCount` for the rest.
-   - `requiredBootstrap[]` — setup steps that block trusting generated drafts.
-   - `firstDraftCommand` — present only when the repo has no test suite; run it to create the first starter draft.
-   - `prChecklist[]` and `commands[]` — checklist lines and validation commands for the handoff.
-   In markdown format, start from `At a Glance` (affected flows, the single next command, blocking items), then read the `PR Comment Draft`, `Missing Evidence Before Trusting This PR`, and `PR Checklist` sections.
+   `firstDraftCommand` is present only when the repo has no test suite; run it to create the first starter draft. In markdown format, start from `At a Glance` and `Change Intent Evidence`, then read the PR comment, missing evidence, and checklist sections.
 6. Include the useful parts in the PR body, review note, or handoff summary.
 
 ## Output Rules
 
 - Treat QAMap output as QA planning evidence, not proof that browser, device, API, or manual QA passed.
-- Preserve the affected flow, suggested E2E/checklist path, missing evidence, and validation command in the handoff.
+- Preserve change intent, confidence, lifecycle, QA scenarios, affected flow, suggested E2E/checklist path, missing evidence, and validation command in the handoff.
 - Prefer creating the suggested starter E2E draft over only reporting that a draft is needed.
-- If QAMap recommends Playwright, Maestro, or manual QA, do not force a different runner unless the repository already has stronger runner evidence.
+- Treat Playwright, Maestro, and manual output as adapters after QA design. Do not let runner selection replace review of the inferred intent and scenarios.
 - If the output is `review only` or `near runnable`, explain what blocks it from becoming trusted regression evidence.
 - If `qamap qa` says no manifest was found, do not stop. The first run is allowed to be manifest-free.
 
@@ -74,6 +76,9 @@ Then humans should review `.qamap/manifest.yaml` and keep only durable team QA l
 
 ```txt
 QAMap QA
+- Change intent and confidence:
+- Behavior lifecycle:
+- Required QA scenarios:
 - Affected flow:
 - Suggested E2E/checklist:
 - Missing evidence:

--- a/src/behavior-intent.ts
+++ b/src/behavior-intent.ts
@@ -1,0 +1,227 @@
+import {
+  createBehaviorEdge,
+  createBehaviorNodeId,
+  type BehaviorAnalysisContext,
+  type BehaviorAnalyzerAdapter,
+  type BehaviorConfidence,
+  type BehaviorEvidence,
+  type BehaviorGraphFragment,
+  type BehaviorNode,
+  type BehaviorNodeKind,
+} from "./behavior.js";
+import type {
+  BehaviorLifecycleStage,
+  ChangeIntent,
+  ChangeIntentAnalysis,
+  ChangeIntentEvidence,
+  ChangeIntentConfidence,
+} from "./change-intent.js";
+
+export interface ChangeIntentBehaviorAdapterOptions {
+  analysis: ChangeIntentAnalysis;
+}
+
+export function createChangeIntentBehaviorAdapter(
+  options: ChangeIntentBehaviorAdapterOptions,
+): BehaviorAnalyzerAdapter {
+  return {
+    id: "qamap.change-intent",
+    version: "1",
+    detect: () => ({
+      confidence: detectionConfidence(options.analysis.intents),
+      reason: options.analysis.intents.length > 0
+        ? "Behavior-bearing commit and diff evidence produced runner-independent change intents."
+        : "No behavior-bearing change intent was available.",
+      evidence: options.analysis.intents.slice(0, 8).map((intent) => intent.title),
+    }),
+    analyze: (context) => buildChangeIntentFragment(context, options.analysis.intents),
+  };
+}
+
+function buildChangeIntentFragment(
+  context: BehaviorAnalysisContext,
+  intents: ChangeIntent[],
+): BehaviorGraphFragment {
+  const nodes: BehaviorNode[] = [];
+  const edges = [];
+  const changedFiles = new Set(context.changedFiles.map((file) => file.path));
+
+  for (const intent of intents) {
+    const confidence = behaviorConfidence(intent.confidence);
+    const intentFiles = uniqueStrings(intent.files);
+    const directlyChangedFiles = intentFiles.filter((file) => changedFiles.has(file));
+    const impactFiles = directlyChangedFiles.length > 0
+      ? directlyChangedFiles
+      : context.changedFiles.map((file) => file.path).slice(0, 12);
+    const contractId = createBehaviorNodeId("contract", "change-intent", intent.id);
+    nodes.push({
+      id: contractId,
+      kind: "contract",
+      label: intent.title,
+      confidence,
+      evidence: intent.evidence.map(toBehaviorEvidence),
+      attributes: {
+        contractType: "change-intent",
+        intentId: intent.id,
+        summary: intent.summary,
+        reviewRequired: intent.reviewRequired,
+        commitCount: intent.commits.length,
+      },
+      impact: impactFiles.length > 0
+        ? {
+            kind: directlyChangedFiles.length > 0 ? "direct" : "propagated",
+            changedFiles: uniqueStrings(impactFiles),
+          }
+        : undefined,
+    });
+
+    for (const file of intentFiles) {
+      const sourceId = createBehaviorNodeId("source", file);
+      const direct = changedFiles.has(file);
+      nodes.push({
+        id: sourceId,
+        kind: "source",
+        label: file,
+        confidence: "high",
+        evidence: [{ kind: direct ? "diff" : "source", value: file, file }],
+        attributes: { path: file },
+        impact: direct ? { kind: "direct", changedFiles: [file] } : undefined,
+      });
+      edges.push(
+        direct
+          ? createBehaviorEdge("impacts", sourceId, contractId, "high", [{ kind: "diff", value: file, file }])
+          : createBehaviorEdge("implemented-by", contractId, sourceId, "medium", [{ kind: "source", value: file, file }]),
+      );
+    }
+
+    let previousStageId: string | undefined;
+    intent.lifecycle.forEach((stage, index) => {
+      const stageKind = nodeKindForLifecycle(stage);
+      const stageId = createBehaviorNodeId(stageKind, "change-intent", intent.id, stage.id);
+      const stageFiles = uniqueStrings([
+        ...stage.files,
+        ...stage.evidence.map((item) => item.file).filter((file): file is string => Boolean(file)),
+      ]);
+      nodes.push({
+        id: stageId,
+        kind: stageKind,
+        label: stage.label,
+        confidence: behaviorConfidence(stage.confidence),
+        evidence: stage.evidence.map(toBehaviorEvidence),
+        attributes: {
+          intentId: intent.id,
+          lifecyclePhase: stage.kind,
+          order: index + 1,
+        },
+        impact: stageFiles.length > 0
+          ? { kind: "direct", changedFiles: stageFiles }
+          : impactFiles.length > 0
+            ? { kind: "propagated", changedFiles: uniqueStrings(impactFiles) }
+            : undefined,
+      });
+      edges.push(
+        createBehaviorEdge(
+          stage.kind === "observable-outcome" ? "expects" : "contains",
+          contractId,
+          stageId,
+          behaviorConfidence(stage.confidence),
+          stage.evidence.map(toBehaviorEvidence),
+        ),
+      );
+      if (previousStageId) {
+        edges.push(createBehaviorEdge("precedes", previousStageId, stageId, behaviorConfidence(stage.confidence)));
+      }
+      previousStageId = stageId;
+
+      for (const file of stageFiles) {
+        const sourceId = createBehaviorNodeId("source", file);
+        if (intentFiles.includes(file)) {
+          edges.push(createBehaviorEdge("implemented-by", stageId, sourceId, "high", [
+            { kind: changedFiles.has(file) ? "diff" : "source", value: file, file },
+          ]));
+        }
+      }
+    });
+
+    for (const scenario of intent.scenarios) {
+      for (const [assertionIndex, assertion] of scenario.assertions.entries()) {
+        const assertionId = createBehaviorNodeId(
+          "assertion",
+          "change-intent",
+          intent.id,
+          scenario.id,
+          String(assertionIndex),
+          assertion,
+        );
+        nodes.push({
+          id: assertionId,
+          kind: "assertion",
+          label: assertion,
+          confidence: scenario.priority === "critical" ? confidence : "medium",
+          evidence: scenario.evidence.map(toBehaviorEvidence),
+          attributes: {
+            intentId: intent.id,
+            scenarioId: scenario.id,
+            scenarioKind: scenario.kind,
+            scenarioTitle: scenario.title,
+            priority: scenario.priority,
+          },
+          impact: impactFiles.length > 0
+            ? { kind: "propagated", changedFiles: uniqueStrings(impactFiles) }
+            : undefined,
+        });
+        edges.push(createBehaviorEdge("expects", contractId, assertionId, scenario.priority === "critical" ? confidence : "medium"));
+      }
+    }
+  }
+
+  return { nodes, edges };
+}
+
+function nodeKindForLifecycle(stage: BehaviorLifecycleStage): BehaviorNodeKind {
+  if (stage.kind === "condition" || stage.kind === "state-change") {
+    return "state";
+  }
+  if (stage.kind === "side-effect") {
+    return "effect";
+  }
+  if (stage.kind === "observable-outcome") {
+    return "assertion";
+  }
+  return "action";
+}
+
+function toBehaviorEvidence(evidence: ChangeIntentEvidence): BehaviorEvidence {
+  if (evidence.kind === "commit") {
+    return {
+      kind: "commit",
+      value: evidence.commit ? `${evidence.commit.slice(0, 12)} ${evidence.value}` : evidence.value,
+    };
+  }
+  return {
+    kind: evidence.kind,
+    value: evidence.symbol ? `${evidence.symbol}: ${evidence.value}` : evidence.value,
+    file: evidence.file,
+  };
+}
+
+function detectionConfidence(intents: ChangeIntent[]): "none" | BehaviorConfidence {
+  if (intents.length === 0) {
+    return "none";
+  }
+  if (intents.some((intent) => intent.confidence === "high")) {
+    return "high";
+  }
+  if (intents.some((intent) => intent.confidence === "medium")) {
+    return "medium";
+  }
+  return "low";
+}
+
+function behaviorConfidence(confidence: ChangeIntentConfidence): BehaviorConfidence {
+  return confidence;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}

--- a/src/behavior-manifest.ts
+++ b/src/behavior-manifest.ts
@@ -1,0 +1,270 @@
+import path from "node:path";
+import {
+  createBehaviorEdge,
+  createBehaviorNodeId,
+  type BehaviorAnalysisContext,
+  type BehaviorAnalyzerAdapter,
+  type BehaviorAttributeValue,
+  type BehaviorConfidence,
+  type BehaviorEvidence,
+  type BehaviorGraphFragment,
+  type BehaviorImpact,
+  type BehaviorNode,
+  type BehaviorNodeKind,
+} from "./behavior.js";
+import type { VerificationManifestMatch } from "./manifest.js";
+
+export interface ManifestBehaviorAdapterOptions {
+  matches: VerificationManifestMatch[];
+}
+
+export function createManifestBehaviorAdapter(options: ManifestBehaviorAdapterOptions): BehaviorAnalyzerAdapter {
+  return {
+    id: "qamap.verification-manifest",
+    version: "1",
+    detect: () => ({
+      confidence: manifestDetectionConfidence(options.matches),
+      reason: options.matches.length > 0
+        ? "The repository verification manifest matched this branch and can supply reviewed behavior evidence."
+        : "No verification manifest entries matched this branch.",
+      evidence: uniqueStrings(options.matches.map((match) => match.manifestPath)).slice(0, 12),
+    }),
+    analyze: (context) => buildManifestBehaviorFragment(context, options.matches),
+  };
+}
+
+function buildManifestBehaviorFragment(
+  context: BehaviorAnalysisContext,
+  matches: VerificationManifestMatch[],
+): BehaviorGraphFragment {
+  const nodes: BehaviorNode[] = [];
+  const edges = [];
+  const changedFiles = new Set(context.changedFiles.map((file) => file.path));
+  const flowMatches = new Map(matches.filter((match) => match.kind === "flow").map((match) => [match.id, match]));
+  const domainNodes: Array<{ match: VerificationManifestMatch; nodeId: string; files: string[] }> = [];
+  const flowNodes: Array<{ match: VerificationManifestMatch; nodeId: string; files: string[] }> = [];
+
+  for (const match of [...matches].sort(compareManifestMatches)) {
+    const files = manifestFilesForContext(context, match.matchedFiles);
+    const nodeKind = nodeKindForMatch(match);
+    const nodeId = manifestNodeId(nodeKind, match.id);
+    const impact = manifestImpact(context, files, changedFiles);
+    const evidence = manifestEvidence(match, files);
+    nodes.push({
+      id: nodeId,
+      kind: nodeKind,
+      label: match.name,
+      confidence: match.confidence,
+      evidence,
+      attributes: manifestAttributes(match),
+      impact,
+    });
+
+    if (match.kind === "domain") {
+      domainNodes.push({ match, nodeId, files });
+    } else if (match.kind === "flow") {
+      flowNodes.push({ match, nodeId, files });
+    }
+
+    for (const file of files) {
+      const sourceId = createBehaviorNodeId("source", file);
+      const direct = changedFiles.has(file);
+      nodes.push({
+        id: sourceId,
+        kind: "source",
+        label: file,
+        confidence: "high",
+        evidence: [
+          { kind: direct ? "diff" : "source", value: file, file },
+          { kind: "manifest", value: match.manifestPath, file },
+        ],
+        attributes: { path: file },
+        impact: direct ? { kind: "direct", changedFiles: [file] } : undefined,
+      });
+      edges.push(
+        direct
+          ? createBehaviorEdge("impacts", sourceId, nodeId, "high", [{ kind: "manifest", value: match.manifestPath, file }])
+          : createBehaviorEdge("implemented-by", nodeId, sourceId, match.confidence, [
+              { kind: "manifest", value: match.manifestPath, file },
+            ]),
+      );
+    }
+
+    if (match.kind === "flow" && match.entryRoute) {
+      const surfaceId = createBehaviorNodeId("surface", "manifest-route", match.entryRoute, match.id);
+      nodes.push({
+        id: surfaceId,
+        kind: "surface",
+        label: `route: ${match.entryRoute}`,
+        confidence: match.confidence,
+        evidence: [{ kind: "manifest", value: match.manifestPath }],
+        attributes: { entrypointKind: "route", value: match.entryRoute, surface: "web", source: "manifest" },
+      });
+      edges.push(createBehaviorEdge("enters-at", nodeId, surfaceId, match.confidence, evidence));
+    }
+
+    if (match.kind === "check") {
+      const flowId = parentFlowId(match.id);
+      const parentMatch = flowMatches.get(flowId);
+      const parentNodeId = manifestNodeId("flow", flowId);
+      if (!parentMatch) {
+        nodes.push({
+          id: parentNodeId,
+          kind: "flow",
+          label: flowId,
+          confidence: match.confidence,
+          evidence,
+          attributes: { manifestId: flowId, source: "manifest" },
+          impact,
+        });
+      }
+      edges.push(createBehaviorEdge("expects", parentNodeId, nodeId, match.confidence, evidence));
+
+      if (match.checkSelector) {
+        const locatorId = createBehaviorNodeId("locator", "manifest", match.checkSelector, match.id);
+        nodes.push({
+          id: locatorId,
+          kind: "locator",
+          label: `manifest selector: ${match.checkSelector}`,
+          confidence: match.confidence,
+          evidence: [{ kind: "manifest", value: match.manifestPath }],
+          attributes: { value: match.checkSelector, source: "manifest" },
+        });
+        edges.push(createBehaviorEdge("located-by", nodeId, locatorId, match.confidence, evidence));
+      }
+    }
+  }
+
+  for (const domain of domainNodes) {
+    for (const flow of flowNodes) {
+      if (!filesOverlap(domain.files, flow.files)) {
+        continue;
+      }
+      edges.push(createBehaviorEdge("contains", domain.nodeId, flow.nodeId, weakerConfidence(domain.match.confidence, flow.match.confidence), [
+        { kind: "manifest", value: domain.match.manifestPath },
+        { kind: "manifest", value: flow.match.manifestPath },
+      ]));
+    }
+  }
+
+  return { nodes, edges };
+}
+
+function manifestNodeId(kind: BehaviorNodeKind, id: string): string {
+  return createBehaviorNodeId(kind, "manifest", id);
+}
+
+function nodeKindForMatch(match: VerificationManifestMatch): BehaviorNodeKind {
+  if (match.kind === "domain") {
+    return "domain";
+  }
+  if (match.kind === "flow") {
+    return "flow";
+  }
+  return "assertion";
+}
+
+function manifestDetectionConfidence(matches: VerificationManifestMatch[]): BehaviorConfidence | "none" {
+  if (matches.some((match) => match.kind === "flow" || match.kind === "check")) {
+    return "high";
+  }
+  return matches.length > 0 ? "medium" : "none";
+}
+
+function manifestImpact(
+  context: BehaviorAnalysisContext,
+  matchedFiles: string[],
+  changedFiles: Set<string>,
+): BehaviorImpact | undefined {
+  const directFiles = uniqueStrings(matchedFiles).filter((file) => changedFiles.has(file));
+  if (directFiles.length > 0) {
+    return { kind: "direct", changedFiles: directFiles };
+  }
+  const propagatedFiles = context.changedFiles.map((file) => file.path).slice(0, 12);
+  return propagatedFiles.length > 0 ? { kind: "propagated", changedFiles: propagatedFiles } : undefined;
+}
+
+function manifestEvidence(match: VerificationManifestMatch, files: string[]): BehaviorEvidence[] {
+  return [
+    { kind: "manifest", value: match.manifestPath },
+    ...match.evidenceSources.map((source) => ({ kind: "manifest" as const, value: source })),
+    ...files.slice(0, 12).map((file) => ({ kind: "source" as const, value: file, file })),
+  ];
+}
+
+function manifestFilesForContext(context: BehaviorAnalysisContext, matchedFiles: string[]): string[] {
+  const workspaceRoot = context.workspaceRoot ? path.resolve(context.workspaceRoot) : undefined;
+  const root = path.resolve(context.root);
+  if (!workspaceRoot || workspaceRoot === root) {
+    return uniqueStrings(matchedFiles.map(toPosixPath));
+  }
+  const packagePrefix = toPosixPath(path.relative(workspaceRoot, root)).replace(/^\.\/+|\/+$/g, "");
+  if (!packagePrefix || packagePrefix.startsWith("..")) {
+    return uniqueStrings(matchedFiles.map(toPosixPath));
+  }
+  return uniqueStrings(
+    matchedFiles.map((file) => {
+      const normalized = toPosixPath(file).replace(/^\.\/+/, "");
+      return normalized.startsWith(`${packagePrefix}/`) ? normalized.slice(packagePrefix.length + 1) : normalized;
+    }),
+  );
+}
+
+function manifestAttributes(match: VerificationManifestMatch): Record<string, BehaviorAttributeValue> {
+  const attributes: Record<string, BehaviorAttributeValue> = {
+    manifestId: match.id,
+    matchKind: match.kind,
+    source: "manifest",
+    updatePath: match.updatePath,
+  };
+  if (match.criticality) {
+    attributes.criticality = match.criticality;
+  }
+  if (match.runner) {
+    attributes.runner = match.runner;
+  }
+  if (match.entryRoute) {
+    attributes.entryRoute = match.entryRoute;
+  }
+  if (match.checkType) {
+    attributes.checkType = match.checkType;
+  }
+  if (match.checkSelector) {
+    attributes.checkSelector = match.checkSelector;
+  }
+  if (match.checkValue) {
+    attributes.checkValue = match.checkValue;
+  }
+  if (match.checkSteps && match.checkSteps.length > 0) {
+    attributes.checkSteps = match.checkSteps;
+  }
+  return attributes;
+}
+
+function parentFlowId(checkId: string): string {
+  const parts = checkId.split(".");
+  return parts.length > 1 ? parts.slice(0, -1).join(".") : checkId;
+}
+
+function filesOverlap(left: string[], right: string[]): boolean {
+  const leftFiles = new Set(left);
+  return right.some((file) => leftFiles.has(file));
+}
+
+function weakerConfidence(left: BehaviorConfidence, right: BehaviorConfidence): BehaviorConfidence {
+  const rank: Record<BehaviorConfidence, number> = { low: 1, medium: 2, high: 3 };
+  return rank[left] <= rank[right] ? left : right;
+}
+
+function compareManifestMatches(left: VerificationManifestMatch, right: VerificationManifestMatch): number {
+  const kindRank = { domain: 0, flow: 1, check: 2 };
+  return kindRank[left.kind] - kindRank[right.kind] || left.id.localeCompare(right.id);
+}
+
+function uniqueStrings(items: string[]): string[] {
+  return [...new Set(items.map((item) => item.trim()).filter(Boolean))];
+}
+
+function toPosixPath(value: string): string {
+  return value.split(path.sep).join("/");
+}

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -1,32 +1,41 @@
 import { createHash } from "node:crypto";
 
 export const behaviorGraphSchemaVersion = 1 as const;
+export const behaviorGraphSchemaUrl =
+  "https://raw.githubusercontent.com/IvoryCanvas/qamap/main/schema/qamap-behavior.schema.json";
+
+export const behaviorSurfaceKinds = ["web", "mobile", "api", "cli", "artifact", "unknown"] as const;
+export const behaviorNodeKinds = [
+  "domain",
+  "flow",
+  "surface",
+  "action",
+  "state",
+  "effect",
+  "contract",
+  "assertion",
+  "fixture",
+  "locator",
+  "source",
+] as const;
+export const behaviorEdgeKinds = [
+  "contains",
+  "enters-at",
+  "precedes",
+  "expects",
+  "uses-fixture",
+  "located-by",
+  "implemented-by",
+  "impacts",
+] as const;
+export const behaviorEvidenceKinds = ["diff", "source", "manifest", "selector", "fixture", "test", "inference"] as const;
 
 export type BehaviorConfidence = "low" | "medium" | "high";
 export type BehaviorAdapterConfidence = "none" | BehaviorConfidence;
-export type BehaviorSurfaceKind = "web" | "mobile" | "api" | "cli" | "artifact" | "unknown";
-export type BehaviorNodeKind =
-  | "domain"
-  | "flow"
-  | "surface"
-  | "action"
-  | "state"
-  | "effect"
-  | "contract"
-  | "assertion"
-  | "fixture"
-  | "locator"
-  | "source";
-export type BehaviorEdgeKind =
-  | "contains"
-  | "enters-at"
-  | "precedes"
-  | "expects"
-  | "uses-fixture"
-  | "located-by"
-  | "implemented-by"
-  | "impacts";
-export type BehaviorEvidenceKind = "diff" | "source" | "manifest" | "selector" | "fixture" | "test" | "inference";
+export type BehaviorSurfaceKind = (typeof behaviorSurfaceKinds)[number];
+export type BehaviorNodeKind = (typeof behaviorNodeKinds)[number];
+export type BehaviorEdgeKind = (typeof behaviorEdgeKinds)[number];
+export type BehaviorEvidenceKind = (typeof behaviorEvidenceKinds)[number];
 export type BehaviorImpactKind = "direct" | "propagated";
 export type BehaviorDiagnosticSeverity = "info" | "warning";
 export type BehaviorAttributeValue = string | number | boolean | string[];
@@ -90,6 +99,7 @@ export interface BehaviorGraphSummary {
 }
 
 export interface BehaviorGraph {
+  $schema?: string;
   schemaVersion: typeof behaviorGraphSchemaVersion;
   root: string;
   workspaceRoot?: string;
@@ -248,6 +258,7 @@ export async function analyzeBehaviorGraph(
   const merged = mergeBehaviorGraphFragments(fragments);
   diagnostics.push(...(merged.diagnostics ?? []));
   return {
+    $schema: behaviorGraphSchemaUrl,
     schemaVersion: behaviorGraphSchemaVersion,
     root: context.root,
     workspaceRoot: context.workspaceRoot,

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -1,0 +1,654 @@
+import { createHash } from "node:crypto";
+
+export const behaviorGraphSchemaVersion = 1 as const;
+
+export type BehaviorConfidence = "low" | "medium" | "high";
+export type BehaviorAdapterConfidence = "none" | BehaviorConfidence;
+export type BehaviorSurfaceKind = "web" | "mobile" | "api" | "cli" | "artifact" | "unknown";
+export type BehaviorNodeKind =
+  | "domain"
+  | "flow"
+  | "surface"
+  | "action"
+  | "state"
+  | "effect"
+  | "contract"
+  | "assertion"
+  | "fixture"
+  | "locator"
+  | "source";
+export type BehaviorEdgeKind =
+  | "contains"
+  | "enters-at"
+  | "precedes"
+  | "expects"
+  | "uses-fixture"
+  | "located-by"
+  | "implemented-by"
+  | "impacts";
+export type BehaviorEvidenceKind = "diff" | "source" | "manifest" | "selector" | "fixture" | "test" | "inference";
+export type BehaviorImpactKind = "direct" | "propagated";
+export type BehaviorDiagnosticSeverity = "info" | "warning";
+export type BehaviorAttributeValue = string | number | boolean | string[];
+
+export interface BehaviorEvidence {
+  kind: BehaviorEvidenceKind;
+  value: string;
+  file?: string;
+}
+
+export interface BehaviorImpact {
+  kind: BehaviorImpactKind;
+  changedFiles: string[];
+}
+
+export interface BehaviorNode {
+  id: string;
+  kind: BehaviorNodeKind;
+  label: string;
+  confidence: BehaviorConfidence;
+  evidence: BehaviorEvidence[];
+  attributes?: Record<string, BehaviorAttributeValue>;
+  impact?: BehaviorImpact;
+}
+
+export interface BehaviorEdge {
+  id: string;
+  kind: BehaviorEdgeKind;
+  from: string;
+  to: string;
+  confidence: BehaviorConfidence;
+  evidence: BehaviorEvidence[];
+}
+
+export interface BehaviorDiagnostic {
+  severity: BehaviorDiagnosticSeverity;
+  message: string;
+  adapterId?: string;
+}
+
+export interface BehaviorAdapterDetection {
+  confidence: BehaviorAdapterConfidence;
+  reason: string;
+  evidence: string[];
+}
+
+export interface BehaviorAdapterRun {
+  id: string;
+  version: string;
+  status: "used" | "skipped" | "failed";
+  detection: BehaviorAdapterDetection;
+  nodeCount: number;
+  edgeCount: number;
+}
+
+export interface BehaviorGraphSummary {
+  nodes: number;
+  edges: number;
+  impactedNodes: number;
+  byKind: Record<BehaviorNodeKind, number>;
+}
+
+export interface BehaviorGraph {
+  schemaVersion: typeof behaviorGraphSchemaVersion;
+  root: string;
+  workspaceRoot?: string;
+  base: string;
+  head: string;
+  surface: BehaviorSurfaceKind;
+  adapters: BehaviorAdapterRun[];
+  nodes: BehaviorNode[];
+  edges: BehaviorEdge[];
+  diagnostics: BehaviorDiagnostic[];
+  summary: BehaviorGraphSummary;
+}
+
+export interface BehaviorChangedFile {
+  path: string;
+  status: string;
+  previousPath?: string;
+}
+
+export interface BehaviorAnalysisContext {
+  root: string;
+  workspaceRoot?: string;
+  base: string;
+  head: string;
+  projectType: string;
+  surface: BehaviorSurfaceKind;
+  runner?: string;
+  changedFiles: BehaviorChangedFile[];
+}
+
+export interface BehaviorGraphFragment {
+  nodes: BehaviorNode[];
+  edges: BehaviorEdge[];
+  diagnostics?: BehaviorDiagnostic[];
+}
+
+export interface BehaviorAnalyzerAdapter {
+  id: string;
+  version: string;
+  detect(context: BehaviorAnalysisContext): BehaviorAdapterDetection | Promise<BehaviorAdapterDetection>;
+  analyze(context: BehaviorAnalysisContext): BehaviorGraphFragment | Promise<BehaviorGraphFragment>;
+}
+
+export interface InferredBehaviorEntrypoint {
+  kind: "route" | "screen" | "command";
+  value: string;
+  file: string;
+  confidence: BehaviorConfidence;
+}
+
+export interface InferredBehaviorSelector {
+  kind: string;
+  value: string;
+  file: string;
+  addedInDiff?: boolean;
+}
+
+export interface InferredBehaviorCoverage {
+  title: string;
+  priority: string;
+  reason: string;
+  checks: string[];
+}
+
+export interface InferredBehaviorFlow {
+  kind: string;
+  title: string;
+  reason: string;
+  files: string[];
+  steps: string[];
+  entrypoints: InferredBehaviorEntrypoint[];
+  selectors: InferredBehaviorSelector[];
+  coverage: InferredBehaviorCoverage[];
+  fixtureStatus: string;
+  fixtureFiles: string[];
+}
+
+export interface InferredFlowAdapterOptions {
+  flows: InferredBehaviorFlow[];
+}
+
+const confidenceWeight: Record<BehaviorConfidence, number> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+};
+
+const assertionStepMatcher = /^\s*(?:assert|check|compare|confirm|ensure|expect|record|reject|verify)\b/i;
+
+export async function analyzeBehaviorGraph(
+  context: BehaviorAnalysisContext,
+  adapters: BehaviorAnalyzerAdapter[],
+): Promise<BehaviorGraph> {
+  const adapterRuns: BehaviorAdapterRun[] = [];
+  const fragments: BehaviorGraphFragment[] = [];
+  const diagnostics: BehaviorDiagnostic[] = [];
+
+  for (const adapter of [...adapters].sort((left, right) => left.id.localeCompare(right.id))) {
+    let detection: BehaviorAdapterDetection;
+    try {
+      detection = normalizeDetection(await adapter.detect(context));
+    } catch (error) {
+      const message = errorMessage(error);
+      diagnostics.push({ severity: "warning", adapterId: adapter.id, message: `Adapter detection failed: ${message}` });
+      adapterRuns.push({
+        id: adapter.id,
+        version: adapter.version,
+        status: "failed",
+        detection: { confidence: "none", reason: message, evidence: [] },
+        nodeCount: 0,
+        edgeCount: 0,
+      });
+      continue;
+    }
+
+    if (detection.confidence === "none") {
+      adapterRuns.push({
+        id: adapter.id,
+        version: adapter.version,
+        status: "skipped",
+        detection,
+        nodeCount: 0,
+        edgeCount: 0,
+      });
+      continue;
+    }
+
+    try {
+      const fragment = await adapter.analyze(context);
+      fragments.push({
+        ...fragment,
+        diagnostics: (fragment.diagnostics ?? []).map((item) => ({ ...item, adapterId: item.adapterId ?? adapter.id })),
+      });
+      adapterRuns.push({
+        id: adapter.id,
+        version: adapter.version,
+        status: "used",
+        detection,
+        nodeCount: fragment.nodes.length,
+        edgeCount: fragment.edges.length,
+      });
+    } catch (error) {
+      const message = errorMessage(error);
+      diagnostics.push({ severity: "warning", adapterId: adapter.id, message: `Adapter analysis failed: ${message}` });
+      adapterRuns.push({
+        id: adapter.id,
+        version: adapter.version,
+        status: "failed",
+        detection,
+        nodeCount: 0,
+        edgeCount: 0,
+      });
+    }
+  }
+
+  const merged = mergeBehaviorGraphFragments(fragments);
+  diagnostics.push(...(merged.diagnostics ?? []));
+  return {
+    schemaVersion: behaviorGraphSchemaVersion,
+    root: context.root,
+    workspaceRoot: context.workspaceRoot,
+    base: context.base,
+    head: context.head,
+    surface: context.surface,
+    adapters: adapterRuns,
+    nodes: merged.nodes,
+    edges: merged.edges,
+    diagnostics,
+    summary: summarizeBehaviorGraph(merged.nodes, merged.edges),
+  };
+}
+
+export function mergeBehaviorGraphFragments(fragments: BehaviorGraphFragment[]): BehaviorGraphFragment {
+  const nodes = new Map<string, BehaviorNode>();
+  const edges = new Map<string, BehaviorEdge>();
+  const diagnostics: BehaviorDiagnostic[] = [];
+
+  for (const fragment of fragments) {
+    diagnostics.push(...(fragment.diagnostics ?? []));
+    for (const node of fragment.nodes) {
+      const existing = nodes.get(node.id);
+      if (!existing) {
+        nodes.set(node.id, normalizeNode(node));
+        continue;
+      }
+      if (existing.kind !== node.kind) {
+        diagnostics.push({
+          severity: "warning",
+          message: `Behavior node ${node.id} was emitted with both ${existing.kind} and ${node.kind}; keeping ${existing.kind}.`,
+        });
+        continue;
+      }
+      nodes.set(node.id, mergeNodes(existing, node));
+    }
+    for (const edge of fragment.edges) {
+      const existing = edges.get(edge.id);
+      edges.set(edge.id, existing ? mergeEdges(existing, edge) : normalizeEdge(edge));
+    }
+  }
+
+  for (const [id, edge] of edges) {
+    if (nodes.has(edge.from) && nodes.has(edge.to)) {
+      continue;
+    }
+    edges.delete(id);
+    diagnostics.push({
+      severity: "warning",
+      message: `Dropped behavior edge ${id} because one or both endpoint nodes were missing.`,
+    });
+  }
+
+  return {
+    nodes: [...nodes.values()].sort(compareById),
+    edges: [...edges.values()].sort(compareById),
+    diagnostics,
+  };
+}
+
+export function createInferredFlowBehaviorAdapter(options: InferredFlowAdapterOptions): BehaviorAnalyzerAdapter {
+  return {
+    id: "qamap.inferred-flow-compat",
+    version: "1",
+    detect: () => ({
+      confidence: options.flows.length > 0 ? "high" : "none",
+      reason: options.flows.length > 0
+        ? "QAMap produced deterministic flow observations that can be represented in the behavior graph."
+        : "No inferred flow observations were available.",
+      evidence: options.flows.slice(0, 8).map((flow) => flow.title),
+    }),
+    analyze: (context) => buildInferredFlowFragment(context, options.flows),
+  };
+}
+
+export function createBehaviorNodeId(kind: BehaviorNodeKind, ...parts: string[]): string {
+  const identity = parts.map((part) => part.trim()).join("\u0000");
+  const readable = slugify(parts.find((part) => part.trim().length > 0) ?? kind).slice(0, 40) || kind;
+  return `${kind}:${readable}:${shortHash(`${kind}\u0000${identity}`)}`;
+}
+
+export function createBehaviorEdge(
+  kind: BehaviorEdgeKind,
+  from: string,
+  to: string,
+  confidence: BehaviorConfidence,
+  evidence: BehaviorEvidence[] = [],
+): BehaviorEdge {
+  return {
+    id: `edge:${shortHash(`${kind}\u0000${from}\u0000${to}`)}`,
+    kind,
+    from,
+    to,
+    confidence,
+    evidence: uniqueEvidence(evidence),
+  };
+}
+
+function buildInferredFlowFragment(
+  context: BehaviorAnalysisContext,
+  flows: InferredBehaviorFlow[],
+): BehaviorGraphFragment {
+  const nodes: BehaviorNode[] = [];
+  const edges: BehaviorEdge[] = [];
+  const changedFiles = new Set(context.changedFiles.map((file) => file.path));
+
+  for (const flow of flows) {
+    const files = uniqueStrings(flow.files);
+    const directlyChanged = files.filter((file) => changedFiles.has(file));
+    const impactFiles = directlyChanged.length > 0
+      ? directlyChanged
+      : context.changedFiles.map((file) => file.path).slice(0, 12);
+    const confidence = inferredFlowConfidence(flow);
+    const flowId = createBehaviorNodeId("flow", flow.kind, flow.title, ...files.slice().sort());
+    nodes.push({
+      id: flowId,
+      kind: "flow",
+      label: flow.title,
+      confidence,
+      evidence: uniqueEvidence([
+        { kind: "inference", value: flow.reason },
+        ...files.slice(0, 12).map((file) => ({ kind: "source" as const, value: file, file })),
+      ]),
+      attributes: {
+        flowKind: flow.kind,
+        surface: surfaceForFlow(flow, context.surface),
+        fixtureStatus: flow.fixtureStatus,
+      },
+      impact: impactFiles.length > 0
+        ? { kind: directlyChanged.length > 0 ? "direct" : "propagated", changedFiles: uniqueStrings(impactFiles) }
+        : undefined,
+    });
+
+    for (const file of files) {
+      const sourceId = createBehaviorNodeId("source", file);
+      const direct = changedFiles.has(file);
+      nodes.push({
+        id: sourceId,
+        kind: "source",
+        label: file,
+        confidence: "high",
+        evidence: [{ kind: direct ? "diff" : "source", value: file, file }],
+        attributes: { path: file },
+        impact: direct ? { kind: "direct", changedFiles: [file] } : undefined,
+      });
+      edges.push(
+        direct
+          ? createBehaviorEdge("impacts", sourceId, flowId, "high", [{ kind: "diff", value: file, file }])
+          : createBehaviorEdge("implemented-by", flowId, sourceId, "medium", [{ kind: "source", value: file, file }]),
+      );
+    }
+
+    for (const entrypoint of flow.entrypoints) {
+      const surfaceId = createBehaviorNodeId("surface", entrypoint.kind, entrypoint.value, entrypoint.file);
+      nodes.push({
+        id: surfaceId,
+        kind: "surface",
+        label: `${entrypoint.kind}: ${entrypoint.value}`,
+        confidence: entrypoint.confidence,
+        evidence: [{ kind: "source", value: entrypoint.value, file: entrypoint.file }],
+        attributes: {
+          entrypointKind: entrypoint.kind,
+          value: entrypoint.value,
+          surface: surfaceForEntrypoint(entrypoint.kind),
+        },
+      });
+      edges.push(createBehaviorEdge("enters-at", flowId, surfaceId, entrypoint.confidence, [
+        { kind: "source", value: entrypoint.value, file: entrypoint.file },
+      ]));
+    }
+
+    let previousStepId: string | undefined;
+    flow.steps.forEach((step, index) => {
+      const kind: BehaviorNodeKind = assertionStepMatcher.test(step) ? "assertion" : "action";
+      const stepId = createBehaviorNodeId(kind, flowId, String(index), step);
+      nodes.push({
+        id: stepId,
+        kind,
+        label: step,
+        confidence,
+        evidence: [{ kind: "inference", value: `flow-step:${index + 1}` }],
+        attributes: { order: index + 1 },
+      });
+      edges.push(createBehaviorEdge(kind === "assertion" ? "expects" : "contains", flowId, stepId, confidence));
+      if (previousStepId) {
+        edges.push(createBehaviorEdge("precedes", previousStepId, stepId, confidence));
+      }
+      previousStepId = stepId;
+    });
+
+    flow.coverage.forEach((target, targetIndex) => {
+      const checks = target.checks.length > 0 ? target.checks : [target.title];
+      checks.forEach((check, checkIndex) => {
+        const assertionId = createBehaviorNodeId("assertion", flowId, "coverage", String(targetIndex), String(checkIndex), check);
+        nodes.push({
+          id: assertionId,
+          kind: "assertion",
+          label: check,
+          confidence: confidenceForPriority(target.priority),
+          evidence: [{ kind: "inference", value: target.reason }],
+          attributes: { coverageTarget: target.title, priority: target.priority },
+        });
+        edges.push(createBehaviorEdge("expects", flowId, assertionId, confidenceForPriority(target.priority)));
+      });
+    });
+
+    for (const selector of flow.selectors) {
+      const locatorId = createBehaviorNodeId("locator", selector.kind, selector.value, selector.file);
+      nodes.push({
+        id: locatorId,
+        kind: "locator",
+        label: `${selector.kind}: ${selector.value}`,
+        confidence: selector.addedInDiff ? "high" : "medium",
+        evidence: [{
+          kind: selector.addedInDiff ? "diff" : "selector",
+          value: selector.value,
+          file: selector.file,
+        }],
+        attributes: { selectorKind: selector.kind, value: selector.value, addedInDiff: selector.addedInDiff ?? false },
+      });
+      edges.push(createBehaviorEdge("located-by", flowId, locatorId, selector.addedInDiff ? "high" : "medium"));
+    }
+
+    for (const fixtureFile of uniqueStrings(flow.fixtureFiles)) {
+      const fixtureId = createBehaviorNodeId("fixture", fixtureFile);
+      nodes.push({
+        id: fixtureId,
+        kind: "fixture",
+        label: fixtureFile,
+        confidence: "high",
+        evidence: [{ kind: "fixture", value: fixtureFile, file: fixtureFile }],
+        attributes: { path: fixtureFile },
+      });
+      edges.push(createBehaviorEdge("uses-fixture", flowId, fixtureId, "high"));
+    }
+  }
+
+  return { nodes, edges };
+}
+
+function surfaceForFlow(flow: InferredBehaviorFlow, fallback: BehaviorSurfaceKind): BehaviorSurfaceKind {
+  if (flow.kind === "api") {
+    return "api";
+  }
+  if (flow.kind === "command") {
+    return "cli";
+  }
+  if (flow.kind === "artifact" || flow.kind === "catalog" || flow.kind === "generated-artifact") {
+    return "artifact";
+  }
+  return fallback;
+}
+
+function surfaceForEntrypoint(kind: InferredBehaviorEntrypoint["kind"]): BehaviorSurfaceKind {
+  if (kind === "route") {
+    return "web";
+  }
+  if (kind === "screen") {
+    return "mobile";
+  }
+  return "cli";
+}
+
+function inferredFlowConfidence(flow: InferredBehaviorFlow): BehaviorConfidence {
+  if (flow.entrypoints.some((entrypoint) => entrypoint.confidence === "high") || flow.selectors.some((selector) => selector.addedInDiff)) {
+    return "high";
+  }
+  if (flow.entrypoints.length > 0 || flow.selectors.length > 0 || flow.files.length > 0) {
+    return "medium";
+  }
+  return "low";
+}
+
+function confidenceForPriority(priority: string): BehaviorConfidence {
+  if (priority === "critical") {
+    return "high";
+  }
+  if (priority === "recommended") {
+    return "medium";
+  }
+  return "low";
+}
+
+function normalizeDetection(detection: BehaviorAdapterDetection): BehaviorAdapterDetection {
+  return {
+    confidence: detection.confidence,
+    reason: detection.reason.trim() || "No detection reason was provided.",
+    evidence: uniqueStrings(detection.evidence),
+  };
+}
+
+function mergeNodes(left: BehaviorNode, right: BehaviorNode): BehaviorNode {
+  return {
+    ...left,
+    confidence: strongerConfidence(left.confidence, right.confidence),
+    evidence: uniqueEvidence([...left.evidence, ...right.evidence]),
+    attributes: left.attributes || right.attributes ? { ...(left.attributes ?? {}), ...(right.attributes ?? {}) } : undefined,
+    impact: mergeImpact(left.impact, right.impact),
+  };
+}
+
+function mergeEdges(left: BehaviorEdge, right: BehaviorEdge): BehaviorEdge {
+  return {
+    ...left,
+    confidence: strongerConfidence(left.confidence, right.confidence),
+    evidence: uniqueEvidence([...left.evidence, ...right.evidence]),
+  };
+}
+
+function normalizeNode(node: BehaviorNode): BehaviorNode {
+  return {
+    ...node,
+    evidence: uniqueEvidence(node.evidence),
+    impact: node.impact ? { ...node.impact, changedFiles: uniqueStrings(node.impact.changedFiles) } : undefined,
+  };
+}
+
+function normalizeEdge(edge: BehaviorEdge): BehaviorEdge {
+  return { ...edge, evidence: uniqueEvidence(edge.evidence) };
+}
+
+function mergeImpact(left?: BehaviorImpact, right?: BehaviorImpact): BehaviorImpact | undefined {
+  if (!left) {
+    return right ? { ...right, changedFiles: uniqueStrings(right.changedFiles) } : undefined;
+  }
+  if (!right) {
+    return { ...left, changedFiles: uniqueStrings(left.changedFiles) };
+  }
+  return {
+    kind: left.kind === "direct" || right.kind === "direct" ? "direct" : "propagated",
+    changedFiles: uniqueStrings([...left.changedFiles, ...right.changedFiles]),
+  };
+}
+
+function summarizeBehaviorGraph(nodes: BehaviorNode[], edges: BehaviorEdge[]): BehaviorGraphSummary {
+  const byKind = emptyNodeCounts();
+  for (const node of nodes) {
+    byKind[node.kind] += 1;
+  }
+  return {
+    nodes: nodes.length,
+    edges: edges.length,
+    impactedNodes: nodes.filter((node) => node.impact && node.impact.changedFiles.length > 0).length,
+    byKind,
+  };
+}
+
+function emptyNodeCounts(): Record<BehaviorNodeKind, number> {
+  return {
+    domain: 0,
+    flow: 0,
+    surface: 0,
+    action: 0,
+    state: 0,
+    effect: 0,
+    contract: 0,
+    assertion: 0,
+    fixture: 0,
+    locator: 0,
+    source: 0,
+  };
+}
+
+function strongerConfidence(left: BehaviorConfidence, right: BehaviorConfidence): BehaviorConfidence {
+  return confidenceWeight[left] >= confidenceWeight[right] ? left : right;
+}
+
+function uniqueEvidence(items: BehaviorEvidence[]): BehaviorEvidence[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    const key = `${item.kind}\u0000${item.value}\u0000${item.file ?? ""}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function uniqueStrings(items: string[]): string[] {
+  return [...new Set(items.map((item) => item.trim()).filter(Boolean))];
+}
+
+function compareById(left: { id: string }, right: { id: string }): number {
+  return left.id.localeCompare(right.id);
+}
+
+function shortHash(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
+}
+
+function slugify(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -28,7 +28,7 @@ export const behaviorEdgeKinds = [
   "implemented-by",
   "impacts",
 ] as const;
-export const behaviorEvidenceKinds = ["diff", "source", "manifest", "selector", "fixture", "test", "inference"] as const;
+export const behaviorEvidenceKinds = ["commit", "diff", "source", "manifest", "selector", "fixture", "test", "inference"] as const;
 
 export type BehaviorConfidence = "low" | "medium" | "high";
 export type BehaviorAdapterConfidence = "none" | BehaviorConfidence;

--- a/src/change-intent.ts
+++ b/src/change-intent.ts
@@ -378,12 +378,12 @@ function buildCommitIntent(
 }
 
 function buildDiffOnlyIntent(changedFiles: string[], codeSignals: CodeBehaviorSignal[]): ChangeIntent | undefined {
-  const stageKinds = new Set(codeSignals.map((signal) => signal.kind));
-  if (codeSignals.length < 3 || stageKinds.size < 3) {
+  const lifecycle = lifecycleFromCodeSignals(codeSignals);
+  const stageKinds = new Set(lifecycle.map((stage) => stage.kind));
+  if (lifecycle.length < 3 || stageKinds.size < 3) {
     return undefined;
   }
   const files = uniqueStrings(codeSignals.map((signal) => signal.file)).slice(0, maxIntentFiles);
-  const lifecycle = lifecycleFromCodeSignals(codeSignals);
   const titleSubject = humanizeIdentifier(path.basename(files[0] ?? "working tree change").replace(/\.[^.]+$/, ""));
   const title = `${titleSubject} working-tree behavior`;
   const evidence = uniqueEvidence(codeSignals.slice(0, 12).map((signal) => ({
@@ -434,10 +434,14 @@ function buildLifecycle(commits: ParsedCommit[], signals: CodeBehaviorSignal[]):
       stages.push(createLifecycleStage("trigger", trigger, commit.seed ? "high" : "medium", evidence, []));
     }
     for (const clause of splitIntentClauses(commit.statement)) {
+      const label = sentenceLabel(clause);
+      if (isImplementationOnlyLifecycleStep(label)) {
+        continue;
+      }
       stages.push(
         createLifecycleStage(
           classifyLifecycleClause(clause),
-          sentenceLabel(clause),
+          label,
           commit.seed ? "high" : "medium",
           evidence,
           [],
@@ -450,6 +454,9 @@ function buildLifecycle(commits: ParsedCommit[], signals: CodeBehaviorSignal[]):
   for (const signal of signals) {
     if (stages.length >= maxLifecycleStages) {
       break;
+    }
+    if (isImplementationOnlyLifecycleStep(`${signal.label} ${signal.symbol}`)) {
+      continue;
     }
     const alreadyRepresented = stages.some((stage) =>
       stage.label.toLowerCase().includes(signal.symbol.toLowerCase()) ||
@@ -471,12 +478,14 @@ function buildLifecycle(commits: ParsedCommit[], signals: CodeBehaviorSignal[]):
 }
 
 function lifecycleFromCodeSignals(signals: CodeBehaviorSignal[]): BehaviorLifecycleStage[] {
-  const stages = signals.map((signal) => createLifecycleStage(signal.kind, signal.label, "low", [{
-    kind: "diff",
-    value: signal.label,
-    file: signal.file,
-    symbol: signal.symbol,
-  }], [signal.file]));
+  const stages = signals
+    .filter((signal) => !isImplementationOnlyLifecycleStep(`${signal.label} ${signal.symbol}`))
+    .map((signal) => createLifecycleStage(signal.kind, signal.label, "low", [{
+      kind: "diff",
+      value: signal.label,
+      file: signal.file,
+      symbol: signal.symbol,
+    }], [signal.file]));
   return orderLifecycleStages(uniqueLifecycleStages(stages)).slice(0, maxLifecycleStages);
 }
 
@@ -506,9 +515,7 @@ function buildIntentQaScenarios(
   evidence: ChangeIntentEvidence[],
 ): IntentQaScenario[] {
   const conditions = lifecycle.filter((stage) => stage.kind === "condition").map((stage) => stage.label);
-  const actions = lifecycle
-    .filter((stage) => !["condition", "observable-outcome"].includes(stage.kind))
-    .map((stage) => stage.label);
+  const actions = selectPrimaryLifecycleSteps(lifecycle);
   const outcomes = lifecycle.filter((stage) => stage.kind === "observable-outcome").map((stage) => assertionForStage(stage));
   const sideEffects = lifecycle.filter((stage) => stage.kind === "side-effect").map((stage) => assertionForStage(stage));
   const primary: IntentQaScenario = {
@@ -591,6 +598,33 @@ function buildIntentQaScenarios(
   }
 
   return uniqueScenarios(scenarios).slice(0, 4);
+}
+
+function selectPrimaryLifecycleSteps(lifecycle: BehaviorLifecycleStage[]): string[] {
+  const limits: Partial<Record<BehaviorLifecycleStageKind, number>> = {
+    trigger: 1,
+    action: 1,
+    "state-change": 2,
+    "side-effect": 2,
+  };
+  const counts = new Map<BehaviorLifecycleStageKind, number>();
+  const steps: string[] = [];
+  for (const stage of lifecycle) {
+    const limit = limits[stage.kind] ?? 0;
+    const count = counts.get(stage.kind) ?? 0;
+    if (limit === 0 || count >= limit || isImplementationOnlyLifecycleStep(stage.label)) {
+      continue;
+    }
+    counts.set(stage.kind, count + 1);
+    steps.push(stage.label);
+  }
+  return steps;
+}
+
+function isImplementationOnlyLifecycleStep(label: string): boolean {
+  const implementationNoun = "(?:helpers?|interfaces?|lookups?|modules?|types?|utilities)";
+  return new RegExp(`^(?:add|extract|move|refactor|rename)\\b.*\\b${implementationNoun}\\b`, "i").test(label) ||
+    new RegExp(`^(?:an?|the)\\b.*\\b${implementationNoun}\\.?$`, "i").test(label);
 }
 
 function makeScenario(

--- a/src/change-intent.ts
+++ b/src/change-intent.ts
@@ -1,0 +1,924 @@
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { promisify } from "node:util";
+import type { TestPlanChangedFile } from "./test-plan.js";
+
+const execFileAsync = promisify(execFile);
+
+export type ChangeIntentConfidence = "low" | "medium" | "high";
+export type ChangeIntentEvidenceKind = "commit" | "diff" | "source";
+export type BehaviorLifecycleStageKind =
+  | "trigger"
+  | "condition"
+  | "action"
+  | "state-change"
+  | "side-effect"
+  | "observable-outcome";
+export type IntentQaScenarioKind = "primary" | "failure" | "boundary" | "state-transition";
+export type IntentQaScenarioPriority = "critical" | "recommended";
+
+export interface ChangeIntentEvidence {
+  kind: ChangeIntentEvidenceKind;
+  value: string;
+  commit?: string;
+  file?: string;
+  symbol?: string;
+}
+
+export interface ChangeIntentCommit {
+  sha: string;
+  subject: string;
+  body?: string;
+  conventionalType?: string;
+  scope?: string;
+  statement: string;
+}
+
+export interface BehaviorLifecycleStage {
+  id: string;
+  kind: BehaviorLifecycleStageKind;
+  label: string;
+  confidence: ChangeIntentConfidence;
+  evidence: ChangeIntentEvidence[];
+  files: string[];
+}
+
+export interface IntentQaScenario {
+  id: string;
+  kind: IntentQaScenarioKind;
+  priority: IntentQaScenarioPriority;
+  title: string;
+  rationale: string;
+  setup: string[];
+  steps: string[];
+  assertions: string[];
+  edgeCases: string[];
+  evidence: ChangeIntentEvidence[];
+}
+
+export interface ChangeIntent {
+  id: string;
+  title: string;
+  summary: string;
+  confidence: ChangeIntentConfidence;
+  commits: ChangeIntentCommit[];
+  files: string[];
+  keywords: string[];
+  evidence: ChangeIntentEvidence[];
+  lifecycle: BehaviorLifecycleStage[];
+  scenarios: IntentQaScenario[];
+  reviewRequired: boolean;
+}
+
+export interface ChangeIntentAnalysis {
+  base: string;
+  head: string;
+  source: "commits-and-diff" | "commits" | "diff-only" | "none";
+  commits: ChangeIntentCommit[];
+  intents: ChangeIntent[];
+  diagnostics: string[];
+}
+
+export interface ChangeIntentAnalysisOptions {
+  base: string;
+  head: string;
+  workspaceRoot?: string;
+  includeWorkingTree?: boolean;
+  changedFiles: TestPlanChangedFile[];
+  addedDiffText?: Record<string, string>;
+}
+
+interface ParsedCommit extends ChangeIntentCommit {
+  seed: boolean;
+  supporting: boolean;
+  keywords: string[];
+}
+
+interface CodeBehaviorSignal {
+  kind: BehaviorLifecycleStageKind;
+  label: string;
+  file: string;
+  symbol: string;
+}
+
+const behavioralCommitTypes = new Set(["feat", "feature", "fix", "hotfix", "perf"]);
+const supportingCommitTypes = new Set(["refactor"]);
+const ignoredCommitTypes = new Set(["build", "chore", "ci", "docs", "release", "style", "test"]);
+const maxCommits = 50;
+const maxIntentFiles = 20;
+const maxLifecycleStages = 12;
+const maxSignals = 40;
+
+const stopWords = new Set([
+  "a",
+  "an",
+  "and",
+  "app",
+  "behavior",
+  "change",
+  "create",
+  "export",
+  "for",
+  "from",
+  "implement",
+  "improve",
+  "in",
+  "into",
+  "its",
+  "of",
+  "on",
+  "page",
+  "screen",
+  "service",
+  "support",
+  "the",
+  "to",
+  "update",
+  "user",
+  "using",
+  "with",
+]);
+
+const ignoredCallNames = new Set([
+  "async",
+  "catch",
+  "describe",
+  "expect",
+  "filter",
+  "forEach",
+  "if",
+  "it",
+  "map",
+  "reduce",
+  "return",
+  "switch",
+  "test",
+  "while",
+]);
+
+export async function analyzeChangeIntents(
+  rootInput: string,
+  options: ChangeIntentAnalysisOptions,
+): Promise<ChangeIntentAnalysis> {
+  const root = path.resolve(rootInput);
+  const workspaceRoot = options.workspaceRoot ? path.resolve(options.workspaceRoot) : undefined;
+  const gitRoot = workspaceRoot ?? root;
+  const relativeRoot = workspaceRoot ? toPosixPath(path.relative(workspaceRoot, root)) : "";
+  if (workspaceRoot && (relativeRoot.startsWith("..") || path.isAbsolute(relativeRoot))) {
+    throw new Error(`Change intent path must be inside workspace root: ${root}`);
+  }
+
+  const diagnostics: string[] = [];
+  const commits = await collectCommitEvidence(gitRoot, options.base, options.head, relativeRoot, diagnostics);
+  const parsedCommits = commits.map(parseCommit);
+  const codeSignals = collectCodeBehaviorSignals(options.addedDiffText ?? {});
+  const changedFiles = options.changedFiles.map((file) => file.path);
+  const commitClusters = clusterBehaviorCommits(parsedCommits);
+  const intents = commitClusters.map((cluster, index) =>
+    buildCommitIntent(cluster, index, commitClusters.length, changedFiles, options.addedDiffText ?? {}, codeSignals),
+  );
+
+  if (intents.length === 0 && (options.includeWorkingTree ?? false)) {
+    const diffIntent = buildDiffOnlyIntent(changedFiles, codeSignals);
+    if (diffIntent) {
+      intents.push(diffIntent);
+    }
+  }
+
+  if (intents.length === 0) {
+    diagnostics.push(
+      commits.length === 0
+        ? "No behavior-bearing commit or sufficiently connected working-tree signals were found."
+        : "Commit evidence was available, but it did not contain a behavior-bearing feat, fix, hotfix, or performance intent.",
+    );
+  }
+
+  return {
+    base: options.base,
+    head: options.head,
+    source: changeIntentSource(intents, commits, codeSignals),
+    commits,
+    intents,
+    diagnostics: uniqueStrings(diagnostics),
+  };
+}
+
+async function collectCommitEvidence(
+  root: string,
+  base: string,
+  head: string,
+  relativeRoot: string,
+  diagnostics: string[],
+): Promise<ChangeIntentCommit[]> {
+  const args = [
+    "log",
+    "--reverse",
+    "--no-merges",
+    `--max-count=${maxCommits}`,
+    "--format=%H%x1f%s%x1f%b%x1e",
+    `${base}..${head}`,
+  ];
+  if (relativeRoot) {
+    args.push("--", relativeRoot);
+  }
+  try {
+    const { stdout } = await execFileAsync("git", args, { cwd: root, maxBuffer: 4 * 1024 * 1024 });
+    return stdout
+      .split("\u001e")
+      .map((record) => record.trim())
+      .filter(Boolean)
+      .map(parseCommitRecord)
+      .filter((commit) => !/^merge\b/i.test(commit.subject));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    diagnostics.push(`Could not read commit intent evidence: ${message}`);
+    return [];
+  }
+}
+
+function parseCommitRecord(record: string): ChangeIntentCommit {
+  const [sha = "", subject = "", body = ""] = record.split("\u001f");
+  return {
+    sha: sha.trim(),
+    subject: subject.trim(),
+    body: body.trim() || undefined,
+    statement: subject.trim(),
+  };
+}
+
+function parseCommit(commit: ChangeIntentCommit): ParsedCommit {
+  const match = commit.subject.match(/^([a-z][a-z0-9-]*)(?:\(([^)]+)\))?!?:\s*(.+)$/i);
+  const conventionalType = match?.[1]?.toLowerCase();
+  const scope = match?.[2]?.trim();
+  const statement = (match?.[3] ?? commit.subject).trim();
+  const actionSignals = lifecycleKeywordCount(`${statement} ${commit.body ?? ""}`);
+  const seed = conventionalType
+    ? behavioralCommitTypes.has(conventionalType)
+    : actionSignals >= 2 && !isLowSignalCommitStatement(statement);
+  const supporting = conventionalType
+    ? supportingCommitTypes.has(conventionalType)
+    : actionSignals >= 1 && !isLowSignalCommitStatement(statement);
+  return {
+    ...commit,
+    conventionalType,
+    scope,
+    statement,
+    seed,
+    supporting: supporting && !seed,
+    keywords: extractKeywords(`${scope ?? ""} ${statement} ${commit.body ?? ""}`),
+  };
+}
+
+function clusterBehaviorCommits(commits: ParsedCommit[]): ParsedCommit[][] {
+  const candidates = commits.filter((commit) => {
+    if (commit.conventionalType && ignoredCommitTypes.has(commit.conventionalType)) {
+      return false;
+    }
+    return commit.seed || commit.supporting;
+  });
+  const seedIndexes = candidates
+    .map((commit, index) => (commit.seed ? index : -1))
+    .filter((index) => index >= 0);
+  if (seedIndexes.length === 0) {
+    return [];
+  }
+
+  const parent = candidates.map((_, index) => index);
+  const find = (index: number): number => {
+    if (parent[index] !== index) {
+      parent[index] = find(parent[index]);
+    }
+    return parent[index];
+  };
+  const join = (left: number, right: number): void => {
+    const leftRoot = find(left);
+    const rightRoot = find(right);
+    if (leftRoot !== rightRoot) {
+      parent[rightRoot] = leftRoot;
+    }
+  };
+
+  for (let left = 0; left < candidates.length; left += 1) {
+    for (let right = left + 1; right < candidates.length; right += 1) {
+      if (commitsShareIntent(candidates[left], candidates[right])) {
+        join(left, right);
+      }
+    }
+  }
+
+  const components = new Map<number, ParsedCommit[]>();
+  candidates.forEach((commit, index) => {
+    const root = find(index);
+    const group = components.get(root) ?? [];
+    group.push(commit);
+    components.set(root, group);
+  });
+
+  return [...components.values()]
+    .filter((group) => group.some((commit) => commit.seed))
+    .sort((left, right) => commits.indexOf(left[0]) - commits.indexOf(right[0]));
+}
+
+function commitsShareIntent(left: ParsedCommit, right: ParsedCommit): boolean {
+  if (left.scope && right.scope && normalizeToken(left.scope) === normalizeToken(right.scope)) {
+    return true;
+  }
+  const rightKeywords = new Set(right.keywords);
+  return left.keywords.some((keyword) => rightKeywords.has(keyword) && keyword.length >= 4);
+}
+
+function buildCommitIntent(
+  commits: ParsedCommit[],
+  index: number,
+  clusterCount: number,
+  changedFiles: string[],
+  addedDiffText: Record<string, string>,
+  codeSignals: CodeBehaviorSignal[],
+): ChangeIntent {
+  const keywords = uniqueStrings(commits.flatMap((commit) => commit.keywords));
+  const files = selectIntentFiles(keywords, changedFiles, addedDiffText, clusterCount);
+  const relevantSignals = codeSignals.filter((signal) => files.includes(signal.file));
+  const lifecycle = buildLifecycle(commits, relevantSignals);
+  const confidence = confidenceForIntent(commits, lifecycle, relevantSignals);
+  const title = sentenceTitle(commits.find((commit) => commit.seed)?.statement ?? commits[0].statement);
+  const evidence = uniqueEvidence([
+    ...commits.map((commit) => ({
+      kind: "commit" as const,
+      value: commit.subject,
+      commit: commit.sha,
+    })),
+    ...relevantSignals.slice(0, 12).map((signal) => ({
+      kind: "diff" as const,
+      value: signal.label,
+      file: signal.file,
+      symbol: signal.symbol,
+    })),
+  ]);
+  const id = stableId("intent", `${index}:${commits.map((commit) => commit.sha).join(":")}:${title}`);
+  const summary = commits
+    .map((commit) => stripTerminalPunctuation(commit.statement))
+    .filter(Boolean)
+    .slice(0, 4)
+    .join("; ");
+  const scenarios = buildIntentQaScenarios(id, title, lifecycle, keywords, evidence);
+  return {
+    id,
+    title,
+    summary,
+    confidence,
+    commits: commits.map(stripParsedCommitFields),
+    files,
+    keywords,
+    evidence,
+    lifecycle,
+    scenarios,
+    reviewRequired: confidence !== "high" || lifecycle.some((stage) => stage.confidence === "low"),
+  };
+}
+
+function buildDiffOnlyIntent(changedFiles: string[], codeSignals: CodeBehaviorSignal[]): ChangeIntent | undefined {
+  const stageKinds = new Set(codeSignals.map((signal) => signal.kind));
+  if (codeSignals.length < 3 || stageKinds.size < 3) {
+    return undefined;
+  }
+  const files = uniqueStrings(codeSignals.map((signal) => signal.file)).slice(0, maxIntentFiles);
+  const lifecycle = lifecycleFromCodeSignals(codeSignals);
+  const titleSubject = humanizeIdentifier(path.basename(files[0] ?? "working tree change").replace(/\.[^.]+$/, ""));
+  const title = `${titleSubject} working-tree behavior`;
+  const evidence = uniqueEvidence(codeSignals.slice(0, 12).map((signal) => ({
+    kind: "diff" as const,
+    value: signal.label,
+    file: signal.file,
+    symbol: signal.symbol,
+  })));
+  const id = stableId("intent", `working-tree:${files.join(":")}`);
+  const keywords = extractKeywords(codeSignals.map((signal) => `${signal.symbol} ${signal.label}`).join(" "));
+  return {
+    id,
+    title,
+    summary: "Inferred only from connected working-tree behavior signals; no commit intent was available.",
+    confidence: "low",
+    commits: [],
+    files: files.length > 0 ? files : changedFiles.slice(0, maxIntentFiles),
+    keywords,
+    evidence,
+    lifecycle,
+    scenarios: buildIntentQaScenarios(id, title, lifecycle, keywords, evidence),
+    reviewRequired: true,
+  };
+}
+
+function selectIntentFiles(
+  keywords: string[],
+  changedFiles: string[],
+  addedDiffText: Record<string, string>,
+  clusterCount: number,
+): string[] {
+  const behaviorFiles = changedFiles.filter(isBehaviorBearingFile);
+  if (clusterCount === 1) {
+    return behaviorFiles.slice(0, maxIntentFiles);
+  }
+  const matched = behaviorFiles.filter((file) => {
+    const searchable = `${file} ${addedDiffText[file] ?? ""}`.toLowerCase();
+    return keywords.some((keyword) => searchable.includes(keyword));
+  });
+  return (matched.length > 0 ? matched : behaviorFiles).slice(0, maxIntentFiles);
+}
+
+function buildLifecycle(commits: ParsedCommit[], signals: CodeBehaviorSignal[]): BehaviorLifecycleStage[] {
+  const stages: BehaviorLifecycleStage[] = [];
+  for (const commit of commits) {
+    const evidence: ChangeIntentEvidence[] = [{ kind: "commit", value: commit.subject, commit: commit.sha }];
+    for (const trigger of extractTriggerPhrases(commit.statement)) {
+      stages.push(createLifecycleStage("trigger", trigger, commit.seed ? "high" : "medium", evidence, []));
+    }
+    for (const clause of splitIntentClauses(commit.statement)) {
+      stages.push(
+        createLifecycleStage(
+          classifyLifecycleClause(clause),
+          sentenceLabel(clause),
+          commit.seed ? "high" : "medium",
+          evidence,
+          [],
+        ),
+      );
+    }
+  }
+
+  const existingKinds = new Set(stages.map((stage) => stage.kind));
+  for (const signal of signals) {
+    if (stages.length >= maxLifecycleStages) {
+      break;
+    }
+    const alreadyRepresented = stages.some((stage) =>
+      stage.label.toLowerCase().includes(signal.symbol.toLowerCase()) ||
+      (existingKinds.has(signal.kind) && normalizedWords(stage.label).some((word) => normalizedWords(signal.label).includes(word))),
+    );
+    if (alreadyRepresented) {
+      continue;
+    }
+    stages.push(createLifecycleStage(signal.kind, signal.label, "medium", [{
+      kind: "diff",
+      value: signal.label,
+      file: signal.file,
+      symbol: signal.symbol,
+    }], [signal.file]));
+    existingKinds.add(signal.kind);
+  }
+
+  return orderLifecycleStages(uniqueLifecycleStages(stages)).slice(0, maxLifecycleStages);
+}
+
+function lifecycleFromCodeSignals(signals: CodeBehaviorSignal[]): BehaviorLifecycleStage[] {
+  const stages = signals.map((signal) => createLifecycleStage(signal.kind, signal.label, "low", [{
+    kind: "diff",
+    value: signal.label,
+    file: signal.file,
+    symbol: signal.symbol,
+  }], [signal.file]));
+  return orderLifecycleStages(uniqueLifecycleStages(stages)).slice(0, maxLifecycleStages);
+}
+
+function createLifecycleStage(
+  kind: BehaviorLifecycleStageKind,
+  label: string,
+  confidence: ChangeIntentConfidence,
+  evidence: ChangeIntentEvidence[],
+  files: string[],
+): BehaviorLifecycleStage {
+  const normalizedLabel = sentenceLabel(label);
+  return {
+    id: stableId("stage", `${kind}:${normalizedLabel}:${evidence.map((item) => item.commit ?? item.file ?? item.value).join(":")}`),
+    kind,
+    label: normalizedLabel,
+    confidence,
+    evidence: uniqueEvidence(evidence),
+    files: uniqueStrings(files),
+  };
+}
+
+function buildIntentQaScenarios(
+  intentId: string,
+  title: string,
+  lifecycle: BehaviorLifecycleStage[],
+  keywords: string[],
+  evidence: ChangeIntentEvidence[],
+): IntentQaScenario[] {
+  const conditions = lifecycle.filter((stage) => stage.kind === "condition").map((stage) => stage.label);
+  const actions = lifecycle
+    .filter((stage) => !["condition", "observable-outcome"].includes(stage.kind))
+    .map((stage) => stage.label);
+  const outcomes = lifecycle.filter((stage) => stage.kind === "observable-outcome").map((stage) => assertionForStage(stage));
+  const sideEffects = lifecycle.filter((stage) => stage.kind === "side-effect").map((stage) => assertionForStage(stage));
+  const primary: IntentQaScenario = {
+    id: stableId("scenario", `${intentId}:primary`),
+    kind: "primary",
+    priority: "critical",
+    title,
+    rationale: "Commit and diff evidence describe this changed behavior lifecycle; verify the complete observable path before merge.",
+    setup: conditions.length > 0 ? conditions : ["Prepare representative pre-change and changed-branch state."],
+    steps: actions.length > 0 ? actions : lifecycle.map((stage) => stage.label),
+    assertions: outcomes.length > 0 ? outcomes : sideEffects.slice(0, 2),
+    edgeCases: [],
+    evidence: evidence.slice(0, 8),
+  };
+  if (primary.assertions.length === 0) {
+    primary.assertions.push("Verify the externally observable result matches the commit intent.");
+  }
+
+  const scenarios = [primary];
+  const searchable = `${title} ${keywords.join(" ")} ${lifecycle.map((stage) => stage.label).join(" ")}`.toLowerCase();
+
+  if (/schedul|reminder|notification|calendar|date|time|daily|tomorrow/.test(searchable)) {
+    scenarios.push(makeScenario(intentId, "calendar-boundary", "boundary", "critical", "Scheduling, calendar, and duplicate boundary", [
+      "Prepare records near day, month, and timezone boundaries.",
+    ], [
+      "Repeat the changed scheduling action after its source time or date changes.",
+      "Repeat the action without changing source data to expose duplicate side effects.",
+    ], [
+      "Verify the calculated date and time remain correct across boundaries.",
+      "Verify stale or duplicate schedules are replaced, preserved, or rejected intentionally.",
+    ], ["Timezone change", "Day rollover", "Duplicate invocation"], evidence));
+  }
+
+  if (/toggle|enable|disable|permission|authoriz|auth|guard/.test(searchable)) {
+    scenarios.push(makeScenario(intentId, "guard-state", "state-transition", "critical", "Disabled, denied, and re-enabled state", [
+      "Prepare allowed, disabled, and denied states for the changed condition.",
+    ], [
+      "Run the behavior while the condition is disabled or denied.",
+      "Enable or restore the condition and repeat the behavior.",
+    ], [
+      "Verify no protected side effect occurs while blocked.",
+      "Verify re-enabling produces one correct side effect without stale state.",
+    ], ["Permission denied", "Feature disabled", "State restored"], evidence));
+  }
+
+  if (/tap|open|navigat|redirect|route|deep.?link|payload|destination/.test(searchable)) {
+    scenarios.push(makeScenario(intentId, "entry-routing", "failure", "critical", "Entry payload and destination routing", [
+      "Prepare valid, missing, and stale entry payloads.",
+    ], [
+      "Enter through the changed external or internal trigger.",
+      "Repeat with missing or invalid destination context.",
+    ], [
+      "Verify a valid payload opens the matching destination and state.",
+      "Verify invalid context fails safely without opening unrelated data.",
+    ], ["Missing payload", "Stale identifier", "Repeated entry"], evidence));
+  }
+
+  if (/fetch|request|network|endpoint|api|mutation|response|timeout/.test(searchable)) {
+    scenarios.push(makeScenario(intentId, "network-failure", "failure", "recommended", "Failure, timeout, and retry handling", [
+      "Prepare success, empty, unauthorized, timeout, and server-error responses.",
+    ], [
+      "Run the changed behavior for each reachable response.",
+      "Retry after a transient failure when the product supports retry.",
+    ], [
+      "Verify each response produces the intended visible or persisted state.",
+      "Verify retries do not duplicate requests or side effects.",
+    ], ["Unauthorized", "Timeout", "Server error", "Duplicate retry"], evidence));
+  }
+
+  if (/sync|persist|storage|cache|reload|re.?entry|save|store/.test(searchable)) {
+    scenarios.push(makeScenario(intentId, "state-reentry", "state-transition", "recommended", "Re-entry and stale state recovery", [
+      "Prepare current and stale persisted state.",
+    ], [
+      "Run the changed mutation and leave the affected surface.",
+      "Reload or re-enter through the normal entry point.",
+    ], [
+      "Verify the latest state survives or is invalidated intentionally.",
+      "Verify stale state cannot overwrite the changed result.",
+    ], ["Stale cache", "App restart", "Repeated synchronization"], evidence));
+  }
+
+  return uniqueScenarios(scenarios).slice(0, 4);
+}
+
+function makeScenario(
+  intentId: string,
+  key: string,
+  kind: IntentQaScenarioKind,
+  priority: IntentQaScenarioPriority,
+  title: string,
+  setup: string[],
+  steps: string[],
+  assertions: string[],
+  edgeCases: string[],
+  evidence: ChangeIntentEvidence[],
+): IntentQaScenario {
+  return {
+    id: stableId("scenario", `${intentId}:${key}`),
+    kind,
+    priority,
+    title,
+    rationale: "Deterministic lifecycle patterns indicate this failure or boundary axis is easy to miss in review.",
+    setup,
+    steps,
+    assertions,
+    edgeCases,
+    evidence: evidence.slice(0, 6),
+  };
+}
+
+function collectCodeBehaviorSignals(addedDiffText: Record<string, string>): CodeBehaviorSignal[] {
+  const signals: CodeBehaviorSignal[] = [];
+  for (const [file, text] of Object.entries(addedDiffText)) {
+    if (!isBehaviorBearingFile(file)) {
+      continue;
+    }
+    for (const match of text.matchAll(/\b(on[A-Z][A-Za-z0-9_]*)\b/g)) {
+      const symbol = match[1];
+      signals.push({ kind: "trigger", label: `Handle ${humanizeIdentifier(symbol)}.`, file, symbol });
+    }
+    for (const match of text.matchAll(/\b([A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)?)\s*\(/g)) {
+      const symbol = match[1];
+      const leaf = symbol.split(".").at(-1) ?? symbol;
+      if (ignoredCallNames.has(leaf) || leaf.length < 3) {
+        continue;
+      }
+      const kind = lifecycleKindForIdentifier(symbol);
+      if (!kind) {
+        continue;
+      }
+      signals.push({ kind, label: codeSignalLabel(kind, symbol), file, symbol });
+    }
+  }
+  return uniqueCodeSignals(signals).slice(0, maxSignals);
+}
+
+function lifecycleKindForIdentifier(identifier: string): BehaviorLifecycleStageKind | undefined {
+  const value = identifier.toLowerCase();
+  if (/^(?:on|handle)(?:press|click|submit|change|complete|open|response|message|select|toggle)/.test(value)) {
+    return "trigger";
+  }
+  if (/(?:navigate|redirect|router\.(?:push|replace)|openurl|openlink|show|display|preview|render)/.test(value)) {
+    return "observable-outcome";
+  }
+  if (/(?:schedule|notify|notification|request|fetch|mutate|post|send|emit|track|publish|upload|download)/.test(value)) {
+    return "side-effect";
+  }
+  if (/(?:resync|sync|persist|store|save|update|set[A-Z_]|cache|write|delete|remove|cancel|invalidate)/i.test(identifier)) {
+    return "state-change";
+  }
+  if (/(?:permission|authorized|authenticated|enabled|disabled|validate|guard|can[A-Z_]|should[A-Z_])/i.test(identifier)) {
+    return "condition";
+  }
+  return undefined;
+}
+
+function codeSignalLabel(kind: BehaviorLifecycleStageKind, symbol: string): string {
+  if (kind === "trigger") {
+    return `Trigger ${humanizeIdentifier(symbol)}.`;
+  }
+  if (kind === "condition") {
+    return `Check ${humanizeIdentifier(symbol)}.`;
+  }
+  if (kind === "state-change") {
+    return `Update state through ${symbol}.`;
+  }
+  if (kind === "side-effect") {
+    return `Invoke ${symbol}.`;
+  }
+  if (kind === "observable-outcome") {
+    return `Observe the result of ${symbol}.`;
+  }
+  return `Run ${symbol}.`;
+}
+
+function extractTriggerPhrases(statement: string): string[] {
+  const triggers: string[] = [];
+  for (const match of statement.matchAll(/\b(after|when|once|upon|before)\s+([^,;.]+)/gi)) {
+    const phrase = `${match[1]} ${match[2]}`.trim().split(/\s+/).slice(0, 10).join(" ");
+    triggers.push(sentenceLabel(phrase));
+  }
+  const adjectiveTrigger = statement.match(/\b(?:the\s+)?(tapped|clicked|submitted|completed|received)\s+([a-z0-9-]+)\b/i);
+  if (adjectiveTrigger) {
+    triggers.push(sentenceLabel(`When the ${adjectiveTrigger[2]} is ${adjectiveTrigger[1]}`));
+  } else {
+    const passiveTrigger = statement.match(/\b(?:the\s+)?([a-z0-9-]+)\s+is\s+(tapped|clicked|submitted|completed|received)\b/i);
+    if (passiveTrigger) {
+      triggers.push(sentenceLabel(`When the ${passiveTrigger[1]} is ${passiveTrigger[2]}`));
+    }
+  }
+  return uniqueStrings(triggers);
+}
+
+function splitIntentClauses(statement: string): string[] {
+  const stripped = stripTerminalPunctuation(statement.trim());
+  const clauses = stripped
+    .split(/\s+(?:and then|then|and)\s+/i)
+    .map((clause) => clause.trim())
+    .filter((clause) => clause.length >= 4);
+  return clauses.length > 0 ? clauses : [stripped];
+}
+
+function classifyLifecycleClause(clause: string): BehaviorLifecycleStageKind {
+  const value = clause.toLowerCase();
+  if (/^(?:show|display|render|preview|tease|open|navigate|redirect|surface|return)\b/.test(value)) {
+    return "observable-outcome";
+  }
+  if (/^(?:save|persist|store|update|sync|resync|cache|set|cancel|remove|delete|invalidate|toggle)\b/.test(value)) {
+    return "state-change";
+  }
+  if (/^(?:schedule|fire|send|notify|request|fetch|post|emit|track|publish|export|upload)\b/.test(value)) {
+    return "side-effect";
+  }
+  if (/\b(?:if|only|enabled|disabled|permission|authorized|authenticated|valid|guard)\b/.test(value)) {
+    return "condition";
+  }
+  if (/^(?:tap|click|submit|complete|receive|start|select|press)\b/.test(value)) {
+    return "trigger";
+  }
+  if (/\b(?:show|display|render|preview|tease|open|navigate|redirect|surface|return)\b/.test(value)) {
+    return "observable-outcome";
+  }
+  if (/\b(?:save|persist|store|update|sync|resync|cache|set|cancel|remove|delete|invalidate|toggle)\b/.test(value)) {
+    return "state-change";
+  }
+  if (/\b(?:schedule|fire|send|notify|request|fetch|post|emit|track|publish|export|upload)\b/.test(value)) {
+    return "side-effect";
+  }
+  return "action";
+}
+
+function confidenceForIntent(
+  commits: ParsedCommit[],
+  lifecycle: BehaviorLifecycleStage[],
+  signals: CodeBehaviorSignal[],
+): ChangeIntentConfidence {
+  const seedCount = commits.filter((commit) => commit.seed).length;
+  const phaseCount = new Set(lifecycle.map((stage) => stage.kind)).size;
+  if (
+    phaseCount >= 3 &&
+    (seedCount >= 2 || (seedCount === 1 && phaseCount >= 4 && signals.length >= 2))
+  ) {
+    return "high";
+  }
+  if (seedCount >= 1 && lifecycle.length >= 2) {
+    return "medium";
+  }
+  return "low";
+}
+
+function lifecycleKeywordCount(value: string): number {
+  const matches = value.match(
+    /\b(?:cancel|click|complete|display|emit|enable|fetch|fire|navigate|notify|open|persist|preview|record|redirect|request|resync|save|schedule|send|show|submit|sync|tap|toggle|track|update)\w*/gi,
+  );
+  return new Set((matches ?? []).map((match) => normalizeToken(match))).size;
+}
+
+function isLowSignalCommitStatement(statement: string): boolean {
+  return /^(?:benchmark|prepare|release|version|dependency|format|lint|cleanup|metadata)\b/i.test(statement.trim());
+}
+
+function extractKeywords(value: string): string[] {
+  const words = normalizedWords(value)
+    .map(normalizeToken)
+    .filter((word) => word.length >= 3 && !stopWords.has(word));
+  return uniqueStrings(words).slice(0, 24);
+}
+
+function normalizedWords(value: string): string[] {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .split(/[^a-z0-9가-힣]+/)
+    .filter(Boolean);
+}
+
+function normalizeToken(value: string): string {
+  let token = value.toLowerCase().replace(/[^a-z0-9가-힣]/g, "");
+  if (/^schedul/.test(token)) return "schedule";
+  if (/^(?:notify|notification)/.test(token)) return "notification";
+  if (/^(?:resync|sync)/.test(token)) return "sync";
+  if (/^(?:navigate|navigation|redirect|route)/.test(token)) return "navigation";
+  if (/^(?:remind|reminder)/.test(token)) return "reminder";
+  if (/^(?:persist|storage|store)/.test(token)) return "persistence";
+  if (token.endsWith("ies") && token.length > 5) token = `${token.slice(0, -3)}y`;
+  else if (token.endsWith("ing") && token.length > 6) token = token.slice(0, -3);
+  else if (token.endsWith("ed") && token.length > 5) token = token.slice(0, -2);
+  else if (token.endsWith("s") && !token.endsWith("ss") && token.length > 4) token = token.slice(0, -1);
+  return token;
+}
+
+function isBehaviorBearingFile(file: string): boolean {
+  return !(
+    /(?:^|\/)(?:docs?|test|tests|__tests__|fixtures?|snapshots?|coverage|dist|build)\//i.test(file) ||
+    /(?:^|\/)(?:package-lock\.json|pnpm-lock\.yaml|yarn\.lock|CHANGELOG\.md|README\.md)$/i.test(file) ||
+    /\.(?:md|mdx|snap|map)$/i.test(file)
+  );
+}
+
+function stripParsedCommitFields(commit: ParsedCommit): ChangeIntentCommit {
+  const { seed: _seed, supporting: _supporting, keywords: _keywords, ...result } = commit;
+  return result;
+}
+
+function orderLifecycleStages(stages: BehaviorLifecycleStage[]): BehaviorLifecycleStage[] {
+  const rank: Record<BehaviorLifecycleStageKind, number> = {
+    trigger: 0,
+    condition: 1,
+    action: 2,
+    "state-change": 3,
+    "side-effect": 4,
+    "observable-outcome": 5,
+  };
+  return stages
+    .map((stage, index) => ({ stage, index }))
+    .sort((left, right) => rank[left.stage.kind] - rank[right.stage.kind] || left.index - right.index)
+    .map(({ stage }) => stage);
+}
+
+function uniqueLifecycleStages(stages: BehaviorLifecycleStage[]): BehaviorLifecycleStage[] {
+  const seen = new Set<string>();
+  return stages.filter((stage) => {
+    const key = `${stage.kind}:${stripTerminalPunctuation(stage.label).toLowerCase()}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function uniqueCodeSignals(signals: CodeBehaviorSignal[]): CodeBehaviorSignal[] {
+  const seen = new Set<string>();
+  return signals.filter((signal) => {
+    const key = `${signal.kind}:${signal.file}:${signal.symbol}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function uniqueScenarios(scenarios: IntentQaScenario[]): IntentQaScenario[] {
+  const seen = new Set<string>();
+  return scenarios.filter((scenario) => {
+    const key = scenario.title.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function uniqueEvidence(evidence: ChangeIntentEvidence[]): ChangeIntentEvidence[] {
+  const seen = new Set<string>();
+  return evidence.filter((item) => {
+    const key = `${item.kind}:${item.commit ?? ""}:${item.file ?? ""}:${item.symbol ?? ""}:${item.value}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}
+
+function sentenceTitle(value: string): string {
+  const stripped = stripTerminalPunctuation(value.trim());
+  if (!stripped) return "Changed behavior";
+  return stripped[0].toUpperCase() + stripped.slice(1);
+}
+
+function sentenceLabel(value: string): string {
+  const title = sentenceTitle(value);
+  return /[.!?]$/.test(title) ? title : `${title}.`;
+}
+
+function stripTerminalPunctuation(value: string): string {
+  return value.replace(/[.!?]+$/, "").trim();
+}
+
+function assertionForStage(stage: BehaviorLifecycleStage): string {
+  return `Verify ${lowercaseFirst(stripTerminalPunctuation(stage.label))}.`;
+}
+
+function lowercaseFirst(value: string): string {
+  return value ? value[0].toLowerCase() + value.slice(1) : value;
+}
+
+function humanizeIdentifier(value: string): string {
+  return value
+    .replaceAll(".", " ")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function stableId(prefix: string, value: string): string {
+  return `${prefix}:${createHash("sha256").update(value).digest("hex").slice(0, 12)}`;
+}
+
+function toPosixPath(value: string): string {
+  return value.split(path.sep).join("/");
+}
+
+function changeIntentSource(
+  intents: ChangeIntent[],
+  commits: ChangeIntentCommit[],
+  signals: CodeBehaviorSignal[],
+): ChangeIntentAnalysis["source"] {
+  if (intents.length === 0) return "none";
+  if (commits.length > 0 && signals.length > 0) return "commits-and-diff";
+  if (commits.length > 0) return "commits";
+  return "diff-only";
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -896,13 +896,14 @@ function readValue(args: string[], index: number, flag: string): string {
 }
 
 function printStartHere(): void {
-  console.log(`QAMap ${VERSION} — local-first PR QA for AI-assisted changes.
+  console.log(`QAMap ${VERSION} — local zero-LLM PR QA design from commit intent and code diffs.
 
 Start here, from inside your repository, on the branch you want to check:
 
   qamap qa
-      What should this branch prove before merge? Prints the affected user
-      flow, recommended E2E runner, missing evidence, and a PR checklist.
+      What did this branch intend to change, and what should it prove before
+      merge? Prints behavior lifecycle, QA scenarios, affected flows, missing
+      evidence, and an optional automation adapter.
       The base branch defaults to origin/main (then main); override with
       --base <ref> --head <ref>.
 
@@ -925,7 +926,7 @@ Full command reference: qamap help`);
 function printHelp(): void {
   console.log(`QAMap ${VERSION}
 
-Local-first PR QA drafts and guardrails for AI-assisted changes.
+Local zero-LLM PR QA design, deterministic automation drafts, and repository guardrails.
 
 Usage:
   qamap scan [path] [--format <format>] [--fail-on <severity>] [--max-files <n>]
@@ -1018,7 +1019,7 @@ Examples:
 function printE2eHelp(): void {
   console.log(`QAMap ${VERSION}
 
-E2E planning for AI-assisted changes.
+Intent-first QA planning with optional Playwright, Maestro, or manual adapters.
 
 Usage:
   qamap e2e plan [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--record-history] [--format <format>] [--output <file>]

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -3300,8 +3300,9 @@ async function detectProjectProfile(root: string, workspaceRoot?: string): Promi
     "admin.py",
   ]);
   const projectFilePaths = (await collectProjectFiles(root, 2000)).map((file) => file.path);
-  const hasDesignTokenProject = projectFilePaths.some(isDesignTokenFile);
-  const hasDataCatalogProject = projectFilePaths.some(isCatalogDataFile);
+  const projectProfileArtifactFiles = projectFilePaths.filter((file) => !isTestLikeFile(file));
+  const hasDesignTokenProject = projectProfileArtifactFiles.some(isDesignTokenFile);
+  const hasDataCatalogProject = projectProfileArtifactFiles.some(isCatalogDataFile);
   const hasCliBin = packageJsonHasCliBin(packageJson);
 
   if (hasExpoDependency) {
@@ -3362,14 +3363,14 @@ async function detectProjectProfile(root: string, workspaceRoot?: string): Promi
   if (apiServiceDependency || hasApiServiceConfig || hasDjangoEntrypoint || hasPythonServiceDependency || hasPythonServiceModule) {
     return { type: "api-service", evidence };
   }
+  if (hasCliBin) {
+    return { type: "cli", evidence };
+  }
   if (hasDesignTokenProject) {
     return { type: "design-tokens", evidence };
   }
   if (hasDataCatalogProject) {
     return { type: "data-catalog", evidence };
-  }
-  if (hasCliBin) {
-    return { type: "cli", evidence };
   }
   return {
     type: "unknown",

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -5748,11 +5748,11 @@ function normalizeRouteSegment(segment: string): string | undefined {
   if (!stem || /^\([^)]*\)$/.test(stem) || stem.startsWith("_") || stem.startsWith("@")) {
     return undefined;
   }
-  const routeStem = stem.replace(/^\((?:\.{1,3})\)/, "");
+  const routeStem = stem.replace(/^\+/, "").replace(/^\((?:\.{1,3})\)/, "");
   if (!routeStem) {
     return undefined;
   }
-  if (/^(?:index|page|route|layout|template|loading|error|not-found|404|500)$/i.test(routeStem)) {
+  if (/^(?:index|page|route|server|layout|template|loading|error|not-found|404|500)$/i.test(routeStem)) {
     return undefined;
   }
   const dynamic = dynamicRouteSegmentName(routeStem);

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -1,6 +1,7 @@
 import { promises as fs, type Dirent } from "node:fs";
 import path from "node:path";
 import YAML from "yaml";
+import { analyzeBehaviorGraph, createInferredFlowBehaviorAdapter } from "./behavior.js";
 import { buildDomainLanguageSummary } from "./domain-language.js";
 import { defaultDomainManifestPath, loadDomainManifest, matchDomains } from "./domains.js";
 import { analyzeFixtureSource, insightCoversEndpoint } from "./fixture-insight.js";
@@ -23,6 +24,7 @@ import type { MatchedCoreFlow } from "./flows.js";
 import type { VerificationManifestMatch } from "./manifest.js";
 import type { LocalHistoryReference } from "./history.js";
 import type { CoverageEvidence, TestSuiteInventory, TestSuiteSummary } from "./test-evidence.js";
+import type { BehaviorGraph, BehaviorSurfaceKind, InferredBehaviorFlow } from "./behavior.js";
 import { TOOL_NAME, VERSION } from "./version.js";
 
 export type E2eProjectType =
@@ -35,6 +37,20 @@ export type E2eProjectType =
   | "cli"
   | "unknown";
 export type E2eRunnerName = "maestro" | "playwright" | "manual";
+export type E2eFlowKind =
+  | "ui"
+  | "api"
+  | "state"
+  | "content"
+  | "config"
+  | "test-evidence"
+  | "documentation"
+  | "generated-artifact"
+  | "artifact"
+  | "catalog"
+  | "command"
+  | "domain"
+  | "changed-file";
 export type E2eEntrypointKind = "route" | "screen" | "command";
 export type E2eEntrypointConfidence = "high" | "medium" | "low";
 export type E2eSetupHintKind = "auth" | "network" | "fixture" | "environment" | "payment" | "state";
@@ -132,6 +148,7 @@ export interface E2eFlowLanguageBrief {
 }
 
 export interface E2eFlow {
+  kind?: E2eFlowKind;
   title: string;
   reason: string;
   files: string[];
@@ -249,6 +266,7 @@ export interface E2ePlanResult {
   localHistory?: LocalHistoryReference;
   workspaceTargets: E2eWorkspaceTarget[];
   flows: E2eFlow[];
+  behaviorGraph?: BehaviorGraph;
   validationMatrix: E2eValidationMatrix;
   bootstrap: E2eBootstrapPlan;
   missingTestability: string[];
@@ -484,6 +502,23 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
     domainLanguage,
     addedDiffText,
   );
+  const behaviorGraph = await analyzeBehaviorGraph(
+    {
+      root: testPlan.root,
+      workspaceRoot: testPlan.workspaceRoot,
+      base: testPlan.base,
+      head: testPlan.head,
+      projectType: project.type,
+      surface: behaviorSurfaceForProject(project.type),
+      runner: recommendedRunner.name,
+      changedFiles: testPlan.changedFiles.map((file) => ({
+        path: file.path,
+        status: file.status,
+        previousPath: file.previousPath,
+      })),
+    },
+    [createInferredFlowBehaviorAdapter({ flows: flows.map(toInferredBehaviorFlow) })],
+  );
   const testSuite = summarizeTestSuiteInventory(testSuiteInventory);
   const missingTestability = uniqueStrings([
     ...flows.flatMap((flow) => flow.missingTestability),
@@ -547,10 +582,45 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
     suggestedCommands: testPlan.suggestedCommands,
     workspaceTargets,
     flows,
+    behaviorGraph,
     validationMatrix,
     bootstrap,
     missingTestability,
     setupNotes,
+  };
+}
+
+function behaviorSurfaceForProject(projectType: E2eProjectType): BehaviorSurfaceKind {
+  if (projectType === "web") {
+    return "web";
+  }
+  if (projectType === "expo-react-native" || projectType === "react-native") {
+    return "mobile";
+  }
+  if (projectType === "api-service") {
+    return "api";
+  }
+  if (projectType === "cli") {
+    return "cli";
+  }
+  if (projectType === "design-tokens" || projectType === "data-catalog") {
+    return "artifact";
+  }
+  return "unknown";
+}
+
+function toInferredBehaviorFlow(flow: E2eFlow): InferredBehaviorFlow {
+  return {
+    kind: flow.kind ?? "changed-file",
+    title: flow.title,
+    reason: flow.reason,
+    files: flow.files,
+    steps: flow.steps,
+    entrypoints: flow.entrypoints,
+    selectors: flow.selectors,
+    coverage: flow.coverage,
+    fixtureStatus: flow.fixtureReadiness.status,
+    fixtureFiles: flow.fixtureReadiness.mockInsights?.map((insight) => insight.file) ?? [],
   };
 }
 
@@ -4369,22 +4439,9 @@ function toCoreFlowChangedFiles(
   }));
 }
 
-type E2eFlowKind =
-  | "ui"
-  | "api"
-  | "state"
-  | "content"
-  | "config"
-  | "test-evidence"
-  | "documentation"
-  | "generated-artifact"
-  | "artifact"
-  | "catalog"
-  | "command"
-  | "domain"
-  | "changed-file";
 type FlowCandidate = Omit<
   E2eFlow,
+  | "kind"
   | "languageBrief"
   | "coverage"
   | "coverageEvidence"
@@ -4817,6 +4874,7 @@ async function buildFlow(
     ? await inferFlowSelectors(root, files, runner, addedDiffText)
     : [];
   const flow: Omit<E2eFlow, "languageBrief"> = {
+    kind: candidate.kind,
     title: candidate.title,
     reason: candidate.reason,
     files,
@@ -6620,6 +6678,7 @@ async function buildManifestDraftFlow(
     ...(await inferFlowSetupHints(plan.root, files, "domain")),
   ]);
   const flow: Omit<DraftE2eFlow, "languageBrief"> = {
+    kind: baseFlow?.kind ?? "domain",
     title: match.name,
     reason: match.reason,
     files,
@@ -6786,6 +6845,7 @@ async function buildDomainScenarioDraftFlow(
     checks: refinedSteps,
   };
   const flow: Omit<DraftE2eFlow, "languageBrief"> = {
+    kind: baseFlow?.kind ?? "domain",
     title,
     reason,
     files,
@@ -7265,6 +7325,7 @@ function buildFallbackFlow(plan: E2ePlanResult): E2eFlow {
   const fallback = fallbackFlowDefinition(plan.project.type);
   const coverage = buildCoverageTargets(fallback.kind, [], plan.recommendedRunner.name);
   const flow: Omit<E2eFlow, "languageBrief"> = {
+    kind: fallback.kind,
     title: fallback.title,
     reason: fallback.reason,
     files: [],

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -2,6 +2,7 @@ import { promises as fs, type Dirent } from "node:fs";
 import path from "node:path";
 import YAML from "yaml";
 import { analyzeBehaviorGraph, createInferredFlowBehaviorAdapter } from "./behavior.js";
+import { createManifestBehaviorAdapter } from "./behavior-manifest.js";
 import { buildDomainLanguageSummary } from "./domain-language.js";
 import { defaultDomainManifestPath, loadDomainManifest, matchDomains } from "./domains.js";
 import { analyzeFixtureSource, insightCoversEndpoint } from "./fixture-insight.js";
@@ -517,7 +518,10 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
         previousPath: file.previousPath,
       })),
     },
-    [createInferredFlowBehaviorAdapter({ flows: flows.map(toInferredBehaviorFlow) })],
+    [
+      createInferredFlowBehaviorAdapter({ flows: flows.map(toInferredBehaviorFlow) }),
+      createManifestBehaviorAdapter({ matches: verificationManifestMatches }),
+    ],
   );
   const testSuite = summarizeTestSuiteInventory(testSuiteInventory);
   const missingTestability = uniqueStrings([

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -2,7 +2,9 @@ import { promises as fs, type Dirent } from "node:fs";
 import path from "node:path";
 import YAML from "yaml";
 import { analyzeBehaviorGraph, createInferredFlowBehaviorAdapter } from "./behavior.js";
+import { createChangeIntentBehaviorAdapter } from "./behavior-intent.js";
 import { createManifestBehaviorAdapter } from "./behavior-manifest.js";
+import { analyzeChangeIntents } from "./change-intent.js";
 import { buildDomainLanguageSummary } from "./domain-language.js";
 import { defaultDomainManifestPath, loadDomainManifest, matchDomains } from "./domains.js";
 import { analyzeFixtureSource, insightCoversEndpoint } from "./fixture-insight.js";
@@ -26,6 +28,13 @@ import type { VerificationManifestMatch } from "./manifest.js";
 import type { LocalHistoryReference } from "./history.js";
 import type { CoverageEvidence, TestSuiteInventory, TestSuiteSummary } from "./test-evidence.js";
 import type { BehaviorGraph, BehaviorSurfaceKind, InferredBehaviorFlow } from "./behavior.js";
+import type {
+  BehaviorLifecycleStage,
+  ChangeIntentAnalysis,
+  ChangeIntentConfidence,
+  ChangeIntentEvidence,
+  IntentQaScenario,
+} from "./change-intent.js";
 import { TOOL_NAME, VERSION } from "./version.js";
 
 export type E2eProjectType =
@@ -162,6 +171,11 @@ export interface E2eFlow {
   fixtureReadiness: E2eFixtureReadiness;
   selectors: E2eSelector[];
   missingTestability: string[];
+  intentId?: string;
+  intentConfidence?: ChangeIntentConfidence;
+  intentEvidence?: ChangeIntentEvidence[];
+  lifecycle?: BehaviorLifecycleStage[];
+  qaScenarios?: IntentQaScenario[];
 }
 
 export interface E2eEntrypoint {
@@ -262,6 +276,7 @@ export interface E2ePlanResult {
   verificationManifestPath?: string;
   verificationManifestMatches: VerificationManifestMatch[];
   domainLanguage: DomainLanguageSummary;
+  changeAnalysis: ChangeIntentAnalysis;
   changedFiles: TestPlanChangedFile[];
   suggestedCommands: string[];
   localHistory?: LocalHistoryReference;
@@ -294,7 +309,7 @@ export interface E2eDraftFile {
   flowTitle: string;
   runner: E2eRunnerName;
   status: "created" | "skipped" | "preview";
-  source?: "verification-manifest" | "domain-language" | "core-flow" | "heuristic";
+  source?: "verification-manifest" | "change-intent" | "domain-language" | "core-flow" | "heuristic";
   changedFiles?: string[];
   draftSteps?: string[];
   entrypointHints?: string[];
@@ -322,6 +337,10 @@ export interface E2eDraftFile {
   validationGapCount?: number;
   blockingValidationGapCount?: number;
   reason?: string;
+  intentId?: string;
+  intentConfidence?: ChangeIntentConfidence;
+  lifecycle?: BehaviorLifecycleStage[];
+  qaScenarios?: IntentQaScenario[];
 }
 
 export type E2eDraftActionKind = "assertion" | "fixture" | "manifest" | "runner" | "selector" | "setup" | "validation";
@@ -492,6 +511,14 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
     workspaceRoot: testPlan.workspaceRoot,
     includeWorkingTree: options.includeWorkingTree,
   });
+  const changeAnalysis = await analyzeChangeIntents(root, {
+    base: testPlan.base,
+    head: testPlan.head,
+    workspaceRoot: testPlan.workspaceRoot,
+    includeWorkingTree: options.includeWorkingTree,
+    changedFiles: testPlan.changedFiles,
+    addedDiffText,
+  });
   const domainLanguage = await buildDomainLanguageSummary(root, testPlan.changedFiles, coreFlows, domains, addedDiffText);
   const workspaceTargets = await buildWorkspaceTargets(root, testPlan);
   const flows = await buildFlows(
@@ -502,6 +529,7 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
     testSuiteInventory,
     domainLanguage,
     addedDiffText,
+    changeAnalysis,
   );
   const behaviorGraph = await analyzeBehaviorGraph(
     {
@@ -520,6 +548,7 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
     },
     [
       createInferredFlowBehaviorAdapter({ flows: flows.map(toInferredBehaviorFlow) }),
+      createChangeIntentBehaviorAdapter({ analysis: changeAnalysis }),
       createManifestBehaviorAdapter({ matches: verificationManifestMatches }),
     ],
   );
@@ -582,6 +611,7 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
     verificationManifestPath: verificationManifest.path,
     verificationManifestMatches,
     domainLanguage,
+    changeAnalysis,
     changedFiles: testPlan.changedFiles,
     suggestedCommands: testPlan.suggestedCommands,
     workspaceTargets,
@@ -2087,6 +2117,10 @@ function draftFileDetails(flow: DraftE2eFlow): Pick<
   | "setupHints"
   | "coverageTargets"
   | "manifestUpdatePath"
+  | "intentId"
+  | "intentConfidence"
+  | "lifecycle"
+  | "qaScenarios"
 > {
   return {
     changedFiles: flow.files.slice(0, maxFilesPerFlow),
@@ -2096,6 +2130,10 @@ function draftFileDetails(flow: DraftE2eFlow): Pick<
     setupHints: flow.setupHints.map((hint) => `${hint.title}: ${hint.detail}`).slice(0, 6),
     coverageTargets: flow.coverage.map((target) => `${target.priority}: ${target.title}`).slice(0, 7),
     manifestUpdatePath: flow.manifestMatch?.updatePath,
+    intentId: flow.intentId,
+    intentConfidence: flow.intentConfidence,
+    lifecycle: flow.lifecycle,
+    qaScenarios: flow.qaScenarios,
   };
 }
 
@@ -2536,8 +2574,8 @@ function inferFlowSuccessSignal(flow: Omit<E2eFlow, "languageBrief">): string {
 }
 
 function isVisibleSuccessOutcome(value: string): boolean {
-  return /\b(?:confirmed|saved|refreshed|succeeded|success|completed|created|updated|deleted|sent|approved|accepted)\b/i.test(value) ||
-    /(?:완료|성공|저장(?:됨|됐|되)|등록(?:됨|됐|되)|제출(?:됨|됐|되)|승인(?:됨|됐|되))/.test(value);
+  return /\b(?:confirmed|saved|scheduled|refreshed|succeeded|success|completed|created|updated|deleted|sent|approved|accepted)\b/i.test(value) ||
+    /(?:완료|성공|예약(?:됨|됐|되)|저장(?:됨|됐|되)|등록(?:됨|됐|되)|제출(?:됨|됐|되)|승인(?:됨|됐|되))/.test(value);
 }
 
 function inferFlowReviewQuestion(flow: Omit<E2eFlow, "languageBrief">, successSignal: string): string {
@@ -2649,7 +2687,7 @@ export function formatMarkdownE2ePlan(result: E2ePlanResult): string {
     lines.push("- Includes working tree changes: yes");
   }
   lines.push(`- Project: ${formatProjectType(result.project.type)}`);
-  lines.push(`- Recommended runner: ${formatRunnerName(result.recommendedRunner.name)}`);
+  lines.push(`- Automation adapter: ${formatRunnerName(result.recommendedRunner.name)}`);
   lines.push(
     `- Test suite: ${result.testSuite.hasTestSuite ? `${result.testSuite.testFileCount} test file${result.testSuite.testFileCount === 1 ? "" : "s"}` : "not detected"}`,
   );
@@ -2677,7 +2715,11 @@ export function formatMarkdownE2ePlan(result: E2ePlanResult): string {
   }
   lines.push("");
 
-  lines.push("## Recommendation");
+  appendChangeIntentMarkdown(lines, result.changeAnalysis);
+
+  lines.push("## Automation Adapter");
+  lines.push("");
+  lines.push("QAMap selects an output adapter only after deriving runner-independent change intent and QA scenarios.");
   lines.push("");
   lines.push(result.recommendedRunner.reason);
   if (result.project.evidence.length > 0) {
@@ -2950,6 +2992,55 @@ export function formatMarkdownE2ePlan(result: E2ePlanResult): string {
   return lines.join("\n");
 }
 
+function appendChangeIntentMarkdown(lines: string[], analysis: ChangeIntentAnalysis): void {
+  lines.push("## Change Intent And Behavior Lifecycle");
+  lines.push("");
+  if (analysis.intents.length === 0) {
+    lines.push("No evidence-backed change intent was inferred. QAMap keeps heuristic flow suggestions review-only.");
+    for (const diagnostic of analysis.diagnostics.slice(0, 3)) {
+      lines.push(`- ${escapeMarkdownInline(diagnostic)}`);
+    }
+    lines.push("");
+    return;
+  }
+
+  for (const intent of analysis.intents.slice(0, 3)) {
+    lines.push(`### ${escapeMarkdownInline(intent.title)}`);
+    lines.push("");
+    lines.push(`- Confidence: ${intent.confidence}${intent.reviewRequired ? "; human review required" : ""}`);
+    lines.push(`- Summary: ${escapeMarkdownInline(intent.summary)}`);
+    if (intent.commits.length > 0) {
+      lines.push("- Commit evidence:");
+      for (const commit of intent.commits.slice(0, 6)) {
+        lines.push(`  - \`${commit.sha.slice(0, 12)}\` ${escapeMarkdownInline(commit.subject)}`);
+      }
+    }
+    if (intent.files.length > 0) {
+      lines.push(`- Source scope: ${intent.files.slice(0, 6).map((file) => `\`${escapeMarkdownInline(file)}\``).join(", ")}`);
+    }
+    lines.push("");
+    lines.push("Behavior lifecycle:");
+    intent.lifecycle.slice(0, 12).forEach((stage, index) => {
+      lines.push(`${index + 1}. **${stage.kind}**: ${escapeMarkdownInline(stage.label)} [${stage.confidence}]`);
+    });
+    lines.push("");
+    lines.push("Required QA scenarios:");
+    for (const scenario of intent.scenarios.slice(0, 4)) {
+      lines.push(`- **${scenario.priority} / ${scenario.kind}**: ${escapeMarkdownInline(scenario.title)}`);
+      for (const step of scenario.steps.slice(0, 3)) {
+        lines.push(`  - Step: ${escapeMarkdownInline(step)}`);
+      }
+      for (const assertion of scenario.assertions.slice(0, 3)) {
+        lines.push(`  - Assert: ${escapeMarkdownInline(assertion)}`);
+      }
+      if (scenario.edgeCases.length > 0) {
+        lines.push(`  - Boundaries: ${scenario.edgeCases.slice(0, 4).map(escapeMarkdownInline).join(", ")}`);
+      }
+    }
+    lines.push("");
+  }
+}
+
 function appendVerificationManifestMatchesMarkdown(lines: string[], matches: VerificationManifestMatch[]): void {
   if (matches.length === 0) {
     return;
@@ -3000,7 +3091,7 @@ export function formatMarkdownE2eDraft(result: E2eDraftResult): string {
   lines.push("# QAMap E2E Draft");
   lines.push("");
   lines.push(`- Root: \`${escapeMarkdownInline(result.root)}\``);
-  lines.push(`- Runner: ${formatRunnerName(result.runner)}`);
+  lines.push(`- Automation adapter: ${formatRunnerName(result.runner)}`);
   lines.push(`- Output directory: \`${escapeMarkdownInline(result.outputDirectory)}\``);
   if (result.dryRun) {
     lines.push("- Mode: dry run (no files were written)");
@@ -3039,6 +3130,8 @@ export function formatMarkdownE2eDraft(result: E2eDraftResult): string {
     lines.push(`- Action categories: ${formatDraftActionKindSummary(result.actionSummary.byKind)}`);
   }
   lines.push("");
+
+  appendChangeIntentMarkdown(lines, result.plan.changeAnalysis);
 
   appendVerificationManifestMatchesMarkdown(lines, result.plan.verificationManifestMatches);
 
@@ -4457,8 +4550,9 @@ type FlowCandidate = Omit<
   | "missingTestability"
 > & {
   kind: E2eFlowKind;
+  coverage?: E2eCoverageTarget[];
 };
-type DraftFlowSource = "verification-manifest" | "domain-language" | "core-flow" | "heuristic";
+type DraftFlowSource = "verification-manifest" | "change-intent" | "domain-language" | "core-flow" | "heuristic";
 type DraftE2eFlow = E2eFlow & {
   draftSource?: DraftFlowSource;
   domainScenario?: DomainScenarioSuggestion;
@@ -4475,12 +4569,13 @@ async function buildFlows(
   testSuiteInventory: TestSuiteInventory,
   domainLanguage: DomainLanguageSummary,
   addedDiffText: Record<string, string> = {},
+  changeAnalysis?: ChangeIntentAnalysis,
 ): Promise<E2eFlow[]> {
   const files = changedFiles.map((file) => file.path);
   const importImpacts = await collectImportImpacts(root, files);
   const fixtureContext = await collectFixtureReadinessContext(root, files);
   const flowResults = await Promise.all(
-    buildFlowCandidates(files, runner, projectType, domainLanguage, importImpacts).map((candidate) =>
+    buildFlowCandidates(files, runner, projectType, domainLanguage, importImpacts, changeAnalysis).map((candidate) =>
       buildFlow(root, runner, candidate, testSuiteInventory, fixtureContext, addedDiffText),
     ),
   );
@@ -4546,6 +4641,7 @@ function buildFlowCandidates(
   projectType: E2eProjectType,
   domainLanguage: DomainLanguageSummary,
   importImpacts: ImportImpact[] = [],
+  changeAnalysis?: ChangeIntentAnalysis,
 ): FlowCandidate[] {
   const lowSignalCandidate = importImpacts.length === 0 ? buildLowSignalChangeCandidate(files) : undefined;
   if (lowSignalCandidate) {
@@ -4777,7 +4873,67 @@ function buildFlowCandidates(
     });
   }
 
-  return candidates;
+  return prioritizeChangeIntentCandidates(changeAnalysis, candidates, projectType);
+}
+
+function prioritizeChangeIntentCandidates(
+  analysis: ChangeIntentAnalysis | undefined,
+  heuristicCandidates: FlowCandidate[],
+  projectType: E2eProjectType,
+): FlowCandidate[] {
+  const intentCandidates = (analysis?.intents ?? [])
+    .filter((intent) => intent.confidence !== "low" && intent.files.length > 0)
+    .map((intent): FlowCandidate => {
+      const primaryScenario = intent.scenarios.find((scenario) => scenario.kind === "primary") ?? intent.scenarios[0];
+      const steps = uniqueStrings([
+        ...(primaryScenario?.steps ?? intent.lifecycle.map((stage) => stage.label)),
+        ...(primaryScenario?.assertions ?? []),
+      ]);
+      return {
+        kind: intentFlowKind(intent, projectType),
+        title: intent.title,
+        reason: `Commit and diff evidence support this ${intent.confidence}-confidence change intent. ${intent.summary}`,
+        files: intent.files,
+        steps,
+        coverage: intent.scenarios.map((scenario) => ({
+          title: scenario.title,
+          priority: scenario.priority,
+          reason: scenario.rationale,
+          checks: uniqueStrings([...scenario.assertions, ...scenario.edgeCases.map((edgeCase) => `Exercise ${lowercaseFirst(edgeCase)}.`)]),
+        })),
+        intentId: intent.id,
+        intentConfidence: intent.confidence,
+        intentEvidence: intent.evidence,
+        lifecycle: intent.lifecycle,
+        qaScenarios: intent.scenarios,
+      };
+    });
+  if (intentCandidates.length === 0) {
+    return heuristicCandidates;
+  }
+
+  const intentFiles = new Set(intentCandidates.flatMap((candidate) => candidate.files));
+  const nonOverlapping = heuristicCandidates.filter((candidate) =>
+    candidate.files.every((file) => !intentFiles.has(file)) || isVerificationOnlyKind(candidate.kind),
+  );
+  return [...intentCandidates, ...nonOverlapping].slice(0, 4);
+}
+
+function intentFlowKind(intent: ChangeIntentAnalysis["intents"][number], projectType: E2eProjectType): E2eFlowKind {
+  const searchable = `${intent.title} ${intent.keywords.join(" ")} ${intent.lifecycle.map((stage) => stage.label).join(" ")}`.toLowerCase();
+  if (projectType === "cli") {
+    return "command";
+  }
+  if (/\b(?:endpoint|request|response|api|contract)\b/.test(searchable) && projectType === "api-service") {
+    return "api";
+  }
+  if (/\b(?:state|store|persist|sync|toggle|cache|session|notification|reminder)\b/.test(searchable)) {
+    return "state";
+  }
+  if (intent.lifecycle.some((stage) => stage.kind === "observable-outcome") && projectType !== "api-service") {
+    return "ui";
+  }
+  return "domain";
 }
 
 function cliCommandChecklistTitle(subject: string): string {
@@ -4872,7 +5028,7 @@ async function buildFlow(
   if (files.length === 0) {
     return undefined;
   }
-  const coverage = buildCoverageTargets(candidate.kind, files, runner);
+  const coverage = candidate.coverage ?? buildCoverageTargets(candidate.kind, files, runner);
   const setupHints = await inferFlowSetupHints(root, files, candidate.kind);
   const interactionEvidenceApplies = !isVerificationOnlyKind(candidate.kind);
   const selectors = interactionEvidenceApplies
@@ -4891,6 +5047,11 @@ async function buildFlow(
     fixtureReadiness: await inferFlowFixtureReadiness(root, files, candidate.kind, setupHints, fixtureContext),
     selectors,
     missingTestability: interactionEvidenceApplies ? await findFlowTestabilityGaps(root, files, runner) : [],
+    intentId: candidate.intentId,
+    intentConfidence: candidate.intentConfidence,
+    intentEvidence: candidate.intentEvidence,
+    lifecycle: candidate.lifecycle,
+    qaScenarios: candidate.qaScenarios,
   };
   return {
     ...flow,
@@ -6475,7 +6636,7 @@ async function buildDraftFlows(plan: E2ePlanResult): Promise<DraftE2eFlow[]> {
   if (manifestFlows.length === 0 && scenarioFlows.length === 0) {
     return baseFlows.map((flow) => ({
       ...flow,
-      draftSource: "heuristic",
+      draftSource: flow.intentId ? "change-intent" : "heuristic",
     }));
   }
 
@@ -6516,6 +6677,9 @@ function isImportantBaseDraftFlow(flow: E2eFlow): boolean {
 function shouldUseDomainScenariosForDraft(plan: E2ePlanResult): boolean {
   const files = plan.changedFiles.map((file) => file.path);
   if (isLowSignalVerificationOnlyChange(files) || isConfigurationOnlyChange(files)) {
+    return false;
+  }
+  if (plan.changeAnalysis.intents.some((intent) => intent.confidence !== "low")) {
     return false;
   }
   return !plan.flows.every(isEvidenceVerificationFocusedFlow);
@@ -6582,9 +6746,10 @@ function uniqueManifestCheckMatches(matches: VerificationManifestMatch[]): Verif
 function preferredDraftSource(left: DraftFlowSource | undefined, right: DraftFlowSource | undefined): DraftFlowSource | undefined {
   const ranks: Record<DraftFlowSource, number> = {
     "verification-manifest": 0,
-    "core-flow": 1,
-    "domain-language": 2,
-    heuristic: 3,
+    "change-intent": 1,
+    "core-flow": 2,
+    "domain-language": 3,
+    heuristic: 4,
   };
   if (!left) {
     return right;
@@ -7074,7 +7239,7 @@ function fileOverlapScore(leftFiles: string[], rightFiles: string[]): number {
 
 function draftFlowSource(flow: E2eFlow): DraftFlowSource {
   const draftFlow = flow as DraftE2eFlow;
-  return draftFlow.draftSource ?? "heuristic";
+  return draftFlow.draftSource ?? (flow.intentId ? "change-intent" : "heuristic");
 }
 
 function domainScenarioForFlow(flow: E2eFlow): DomainScenarioSuggestion | undefined {

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -2373,6 +2373,35 @@ function withTerminalPeriod(value: string): string {
 
 function buildFlowLanguageBrief(flow: Omit<E2eFlow, "languageBrief">): E2eFlowLanguageBrief {
   const actor = inferFlowActor(flow);
+  if (flow.intentId && flow.lifecycle && flow.lifecycle.length > 0) {
+    const trigger = flow.lifecycle.find((stage) => stage.kind === "trigger")?.label ?? `Start the changed ${flow.title} behavior.`;
+    const outcomes = flow.lifecycle
+      .filter((stage) => stage.kind === "observable-outcome")
+      .map((stage) => stripTerminalPunctuation(stage.label));
+    const effects = flow.lifecycle
+      .filter((stage) => stage.kind === "side-effect")
+      .map((stage) => stripTerminalPunctuation(stage.label));
+    const lifecycleSuccessSignal = outcomes.length > 0
+      ? outcomes.slice(0, 2).join("; ")
+      : effects.length > 0
+        ? `the intended side effect completes: ${effects.slice(0, 2).join("; ")}`
+        : "the observable result matches the commit intent";
+    const repositorySuccessSignal = inferFlowSuccessSignal(flow);
+    const successSignal = repositorySuccessSignal === "the changed journey reaches a visible, stable success state"
+      ? lifecycleSuccessSignal
+      : repositorySuccessSignal;
+    const scenarioEdges = (flow.qaScenarios ?? [])
+      .filter((scenario) => scenario.kind !== "primary")
+      .flatMap((scenario) => [scenario.title, ...scenario.edgeCases]);
+    return {
+      actor,
+      trigger,
+      goal: `Complete the intended behavior: ${flow.title}.`,
+      successSignal,
+      reviewQuestion: `Does ${flow.title} follow the inferred lifecycle and produce this outcome: ${successSignal}?`,
+      edgeCases: uniqueStrings(scenarioEdges).slice(0, 6),
+    };
+  }
   const trigger = inferFlowTrigger(flow);
   const goal = inferFlowGoal(flow);
   const successSignal = inferFlowSuccessSignal(flow);
@@ -7683,6 +7712,7 @@ function buildMaestroDraft(plan: E2ePlanResult, flow: E2eFlow): string {
   lines.push(`# Base: ${plan.base}`);
   lines.push(`# Head: ${plan.head}`);
   appendDraftBriefComments(lines, flow, "maestro", "#");
+  appendIntentDraftComments(lines, flow, "#");
   appendExecutionProfileComments(lines, plan.executionProfile, "#");
   appendRunnerSetupProposalComments(lines, plan.runnerSetup, "#");
   lines.push("# Replace ${APP_ID} with the app id or export APP_ID before running Maestro.");
@@ -7783,6 +7813,7 @@ function buildPlaywrightDraft(plan: E2ePlanResult, flow: E2eFlow, addedDiffText:
     lines.push(`// Intent: ${scenario.intent}`);
   }
   appendDraftBriefComments(lines, flow, "playwright", "//");
+  appendIntentDraftComments(lines, flow, "//");
   appendExecutionProfileComments(lines, plan.executionProfile, "//");
   appendRunnerSetupProposalComments(lines, plan.runnerSetup, "//");
   lines.push("");
@@ -7901,6 +7932,7 @@ function buildManualDraft(plan: E2ePlanResult, flow: E2eFlow): string {
   lines.push(`- Head: \`${plan.head}\``);
   lines.push("");
   appendManualDraftBrief(lines, flow, "manual");
+  appendManualIntentDraft(lines, flow);
   appendManualExecutionProfile(lines, plan.executionProfile);
   appendManualRunnerSetupProposal(lines, plan.runnerSetup);
   lines.push("");
@@ -8247,6 +8279,55 @@ function appendDraftBriefComments(
   lines.push(`${commentPrefix} - Human fixture inputs:`);
   for (const input of brief.humanFixtureInputs) {
     lines.push(`${commentPrefix}   - ${input}`);
+  }
+}
+
+function appendIntentDraftComments(lines: string[], flow: E2eFlow, commentPrefix: string): void {
+  if (!flow.intentId || !flow.lifecycle || !flow.qaScenarios) {
+    return;
+  }
+  lines.push("");
+  lines.push(`${commentPrefix} Change intent evidence:`);
+  lines.push(`${commentPrefix} - Intent id: ${flow.intentId}`);
+  lines.push(`${commentPrefix} - Confidence: ${flow.intentConfidence ?? "low"}`);
+  for (const evidence of (flow.intentEvidence ?? []).filter((item) => item.kind === "commit").slice(0, 5)) {
+    lines.push(`${commentPrefix} - Commit: ${evidence.value}`);
+  }
+  lines.push(`${commentPrefix} - Behavior lifecycle:`);
+  for (const stage of flow.lifecycle.slice(0, 10)) {
+    lines.push(`${commentPrefix}   - ${stage.kind}: ${stage.label}`);
+  }
+  lines.push(`${commentPrefix} - Runner-independent QA scenarios:`);
+  for (const scenario of flow.qaScenarios.slice(0, 4)) {
+    lines.push(`${commentPrefix}   - [${scenario.priority}] ${scenario.kind}: ${scenario.title}`);
+    for (const assertion of scenario.assertions.slice(0, 2)) {
+      lines.push(`${commentPrefix}     - Assert: ${assertion}`);
+    }
+  }
+}
+
+function appendManualIntentDraft(lines: string[], flow: E2eFlow): void {
+  if (!flow.intentId || !flow.lifecycle || !flow.qaScenarios) {
+    return;
+  }
+  lines.push("");
+  lines.push("## Change Intent Evidence");
+  lines.push("");
+  lines.push(`- Intent id: \`${flow.intentId}\``);
+  lines.push(`- Confidence: ${flow.intentConfidence ?? "low"}`);
+  for (const evidence of (flow.intentEvidence ?? []).filter((item) => item.kind === "commit").slice(0, 5)) {
+    lines.push(`- Commit: ${evidence.value}`);
+  }
+  lines.push("- Behavior lifecycle:");
+  for (const stage of flow.lifecycle.slice(0, 10)) {
+    lines.push(`  - ${stage.kind}: ${stage.label}`);
+  }
+  lines.push("- Runner-independent QA scenarios:");
+  for (const scenario of flow.qaScenarios.slice(0, 4)) {
+    lines.push(`  - [${scenario.priority}] ${scenario.kind}: ${scenario.title}`);
+    for (const assertion of scenario.assertions.slice(0, 2)) {
+      lines.push(`    - Assert: ${assertion}`);
+    }
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
 export { buildAgentQaSection, formatAgentInitReport, initAgentSetup } from "./agent-init.js";
 export {
   analyzeBehaviorGraph,
+  behaviorEdgeKinds,
+  behaviorEvidenceKinds,
   behaviorGraphSchemaVersion,
+  behaviorGraphSchemaUrl,
+  behaviorNodeKinds,
+  behaviorSurfaceKinds,
   createBehaviorEdge,
   createBehaviorNodeId,
   createInferredFlowBehaviorAdapter,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export {
   createInferredFlowBehaviorAdapter,
   mergeBehaviorGraphFragments,
 } from "./behavior.js";
+export { createManifestBehaviorAdapter } from "./behavior-manifest.js";
 export { defaultConfig, loadConfig, writeDefaultConfig } from "./config.js";
 export { detectDlxCommand, generateAgentContext } from "./context.js";
 export { buildDomainLanguageSummary } from "./domain-language.js";
@@ -104,6 +105,7 @@ export type {
   InferredBehaviorSelector,
   InferredFlowAdapterOptions,
 } from "./behavior.js";
+export type { ManifestBehaviorAdapterOptions } from "./behavior-manifest.js";
 export type {
   CoverageEvidence,
   CoverageEvidenceConfidence,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ export {
   mergeBehaviorGraphFragments,
 } from "./behavior.js";
 export { createManifestBehaviorAdapter } from "./behavior-manifest.js";
+export { createChangeIntentBehaviorAdapter } from "./behavior-intent.js";
+export { analyzeChangeIntents } from "./change-intent.js";
 export { defaultConfig, loadConfig, writeDefaultConfig } from "./config.js";
 export { detectDlxCommand, generateAgentContext } from "./context.js";
 export { buildDomainLanguageSummary } from "./domain-language.js";
@@ -111,6 +113,21 @@ export type {
   InferredFlowAdapterOptions,
 } from "./behavior.js";
 export type { ManifestBehaviorAdapterOptions } from "./behavior-manifest.js";
+export type { ChangeIntentBehaviorAdapterOptions } from "./behavior-intent.js";
+export type {
+  BehaviorLifecycleStage,
+  BehaviorLifecycleStageKind,
+  ChangeIntent,
+  ChangeIntentAnalysis,
+  ChangeIntentAnalysisOptions,
+  ChangeIntentCommit,
+  ChangeIntentConfidence,
+  ChangeIntentEvidence,
+  ChangeIntentEvidenceKind,
+  IntentQaScenario,
+  IntentQaScenarioKind,
+  IntentQaScenarioPriority,
+} from "./change-intent.js";
 export type {
   CoverageEvidence,
   CoverageEvidenceConfidence,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,12 @@
 export { buildAgentQaSection, formatAgentInitReport, initAgentSetup } from "./agent-init.js";
+export {
+  analyzeBehaviorGraph,
+  behaviorGraphSchemaVersion,
+  createBehaviorEdge,
+  createBehaviorNodeId,
+  createInferredFlowBehaviorAdapter,
+  mergeBehaviorGraphFragments,
+} from "./behavior.js";
 export { defaultConfig, loadConfig, writeDefaultConfig } from "./config.js";
 export { detectDlxCommand, generateAgentContext } from "./context.js";
 export { buildDomainLanguageSummary } from "./domain-language.js";
@@ -68,6 +76,35 @@ export { collectTestSuiteInventory, evaluateFlowCoverageEvidence, summarizeTestS
 export { formatMarkdownTestPlan, generateTestPlan } from "./test-plan.js";
 export { formatMarkdownVerifyReport, formatVerifyReport, verifyChange } from "./verify.js";
 export type {
+  BehaviorAdapterConfidence,
+  BehaviorAdapterDetection,
+  BehaviorAdapterRun,
+  BehaviorAnalysisContext,
+  BehaviorAnalyzerAdapter,
+  BehaviorAttributeValue,
+  BehaviorChangedFile,
+  BehaviorConfidence,
+  BehaviorDiagnostic,
+  BehaviorDiagnosticSeverity,
+  BehaviorEdge,
+  BehaviorEdgeKind,
+  BehaviorEvidence,
+  BehaviorEvidenceKind,
+  BehaviorGraph,
+  BehaviorGraphFragment,
+  BehaviorGraphSummary,
+  BehaviorImpact,
+  BehaviorImpactKind,
+  BehaviorNode,
+  BehaviorNodeKind,
+  BehaviorSurfaceKind,
+  InferredBehaviorCoverage,
+  InferredBehaviorEntrypoint,
+  InferredBehaviorFlow,
+  InferredBehaviorSelector,
+  InferredFlowAdapterOptions,
+} from "./behavior.js";
+export type {
   CoverageEvidence,
   CoverageEvidenceConfidence,
   CoverageEvidenceStatus,
@@ -103,6 +140,7 @@ export type {
   E2eFixtureReadiness,
   E2eFixtureReadinessStatus,
   E2eFlow,
+  E2eFlowKind,
   E2eSelector,
   E2eSelectorKind,
   E2eSetupHint,

--- a/src/qa.ts
+++ b/src/qa.ts
@@ -187,7 +187,7 @@ export function formatMarkdownQaDraft(result: QaDraftResult): string {
   const primaryIntent = result.changeAnalysis.intents[0];
   if (primaryIntent) {
     lines.push(`- Change intent: ${escapeMarkdownInline(primaryIntent.title)} [${primaryIntent.confidence}]`);
-    const lifecycle = primaryIntent.lifecycle.slice(0, 5).map((stage) => `${stage.kind}: ${stage.label}`).join(" -> ");
+    const lifecycle = summarizeIntentLifecycle(primaryIntent.lifecycle);
     if (lifecycle) {
       lines.push(`- Behavior lifecycle: ${escapeMarkdownInline(lifecycle)}`);
     }
@@ -389,6 +389,15 @@ function appendQaChangeIntentMarkdown(lines: string[], result: QaDraftResult): v
     }
     lines.push("");
   }
+}
+
+function summarizeIntentLifecycle(lifecycle: QaDraftResult["changeAnalysis"]["intents"][number]["lifecycle"]): string {
+  const preferredPhases = ["trigger", "condition", "state-change", "side-effect", "observable-outcome"];
+  const selected = preferredPhases
+    .map((phase) => lifecycle.find((stage) => stage.kind === phase))
+    .filter((stage): stage is NonNullable<typeof stage> => Boolean(stage));
+  const fallback = selected.length > 0 ? selected : lifecycle.slice(0, 5);
+  return fallback.map((stage) => `${stage.kind}: ${stage.label}`).join(" -> ");
 }
 
 function nextStepCommand(result: QaDraftResult): string {

--- a/src/qa.ts
+++ b/src/qa.ts
@@ -31,6 +31,7 @@ export interface QaDraftResult {
   testSuite: E2eDraftResult["plan"]["testSuite"];
   bootstrap: E2eDraftResult["plan"]["bootstrap"];
   runnerSetup: E2eDraftResult["plan"]["runnerSetup"];
+  changeAnalysis: E2eDraftResult["plan"]["changeAnalysis"];
   readiness: E2eDraftReadinessSummary;
   flows: QaDraftFlow[];
   missingEvidence: QaDraftMissingEvidence[];
@@ -94,6 +95,7 @@ export async function generateQaDraft(rootInput: string, options: QaDraftOptions
     testSuite: draft.plan.testSuite,
     bootstrap: draft.plan.bootstrap,
     runnerSetup: draft.plan.runnerSetup,
+    changeAnalysis: draft.plan.changeAnalysis,
     readiness: draft.readinessSummary,
     flows,
     missingEvidence,
@@ -127,6 +129,22 @@ export function formatAgentQaDraft(result: QaDraftResult): string {
     manifest: result.manifestPath ?? null,
     readiness: { score: result.readiness.score, level: result.readiness.level },
     testSuite: { present: result.testSuite.hasTestSuite, files: result.testSuite.testFileCount },
+    intents: result.changeAnalysis.intents.slice(0, 3).map((intent) => ({
+      title: truncateForAgent(intent.title, 100),
+      confidence: intent.confidence,
+      reviewRequired: intent.reviewRequired,
+      evidence: intent.evidence.slice(0, 4).map((item) => truncateForAgent(item.value, 100)),
+      lifecycle: intent.lifecycle.slice(0, 8).map((stage) => ({
+        phase: stage.kind,
+        label: truncateForAgent(stage.label, 120),
+      })),
+      scenarios: intent.scenarios.slice(0, 4).map((scenario) => ({
+        priority: scenario.priority,
+        kind: scenario.kind,
+        title: truncateForAgent(scenario.title, 100),
+        assertions: scenario.assertions.slice(0, 3).map((assertion) => truncateForAgent(assertion, 120)),
+      })),
+    })),
     firstDraftCommand: !result.testSuite.hasTestSuite && needsGeneratedDraft(result)
       ? firstDraftCreateCommand(result)
       : undefined,
@@ -166,6 +184,19 @@ export function formatMarkdownQaDraft(result: QaDraftResult): string {
   lines.push("");
   lines.push("## At a Glance");
   lines.push("");
+  const primaryIntent = result.changeAnalysis.intents[0];
+  if (primaryIntent) {
+    lines.push(`- Change intent: ${escapeMarkdownInline(primaryIntent.title)} [${primaryIntent.confidence}]`);
+    const lifecycle = primaryIntent.lifecycle.slice(0, 5).map((stage) => `${stage.kind}: ${stage.label}`).join(" -> ");
+    if (lifecycle) {
+      lines.push(`- Behavior lifecycle: ${escapeMarkdownInline(lifecycle)}`);
+    }
+    if (primaryIntent.reviewRequired) {
+      lines.push("- Intent confidence: human review is required before treating generated scenarios as regression policy.");
+    }
+  } else {
+    lines.push("- Change intent: not inferred; heuristic flow suggestions remain review-only.");
+  }
   if (result.flows.length === 0) {
     lines.push("- Affected behavior: no changed flow candidate was generated from this diff.");
   } else {
@@ -210,11 +241,13 @@ export function formatMarkdownQaDraft(result: QaDraftResult): string {
   lines.push(`- Base: \`${escapeMarkdownInline(result.base)}\``);
   lines.push(`- Head: \`${escapeMarkdownInline(result.head)}\``);
   lines.push(`- Project: ${formatProjectType(result.project)}`);
-  lines.push(`- Recommended runner: ${formatRunnerName(result.runner)}`);
+  lines.push(`- Automation adapter: ${formatRunnerName(result.runner)}`);
   lines.push(`- Manifest: ${result.manifestPath ? `\`${escapeMarkdownInline(result.manifestPath)}\`` : "not found; using repo signals and PR diff only"}`);
   lines.push(`- Stage: ${formatDraftReadinessStage(result.readiness)}`);
   lines.push(`- Draft flows: ${result.flows.length}`);
   lines.push("");
+
+  appendQaChangeIntentMarkdown(lines, result);
 
   if (!result.testSuite.hasTestSuite && needsGeneratedDraft(result)) {
     lines.push("## First E2E Draft Bootstrap");
@@ -326,6 +359,36 @@ export function formatMarkdownQaDraft(result: QaDraftResult): string {
   lines.push("");
 
   return lines.join("\n");
+}
+
+function appendQaChangeIntentMarkdown(lines: string[], result: QaDraftResult): void {
+  lines.push("## Change Intent Evidence");
+  lines.push("");
+  if (result.changeAnalysis.intents.length === 0) {
+    lines.push("No behavior-bearing commit intent was found. QAMap did not promote inferred names into trusted QA scenarios.");
+    lines.push("");
+    return;
+  }
+  for (const intent of result.changeAnalysis.intents.slice(0, 3)) {
+    lines.push(`### ${escapeMarkdownInline(intent.title)}`);
+    lines.push("");
+    lines.push(`- Confidence: ${intent.confidence}${intent.reviewRequired ? "; review required" : ""}`);
+    for (const commit of intent.commits.slice(0, 5)) {
+      lines.push(`- Evidence: \`${commit.sha.slice(0, 12)}\` ${escapeMarkdownInline(commit.subject)}`);
+    }
+    lines.push("- Lifecycle:");
+    for (const stage of intent.lifecycle.slice(0, 10)) {
+      lines.push(`  - ${stage.kind}: ${escapeMarkdownInline(stage.label)}`);
+    }
+    lines.push("- QA scenarios:");
+    for (const scenario of intent.scenarios.slice(0, 4)) {
+      lines.push(`  - [${scenario.priority}] ${escapeMarkdownInline(scenario.title)}`);
+      for (const assertion of scenario.assertions.slice(0, 2)) {
+        lines.push(`    - Assert: ${escapeMarkdownInline(assertion)}`);
+      }
+    }
+    lines.push("");
+  }
 }
 
 function nextStepCommand(result: QaDraftResult): string {
@@ -582,6 +645,9 @@ function formatDraftSource(source: E2eDraftFile["source"]): string {
   }
   if (source === "domain-language") {
     return "domain-language";
+  }
+  if (source === "change-intent") {
+    return "commit-and-diff-intent";
   }
   if (source === "core-flow") {
     return "core-flow";

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -41,7 +41,7 @@ function colorizeLine(line: string): string {
   }
   let output = line;
   output = output.replace(
-    /^(- (?:Affected|Do next|Blocking(?: \d+)?|Base|Head|Project|Recommended runner|Manifest|Stage|Draft flows)):/,
+    /^(- (?:Affected|Change intent|Behavior lifecycle|Do next|Blocking(?: \d+)?|Base|Head|Project|Automation adapter|Recommended runner|Manifest|Stage|Draft flows)):/,
     `${BOLD}$1${RESET}:`,
   );
   output = output.replace(/\[(required|missing|error)\]/g, `${RED}[$1]${RESET}`);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const TOOL_NAME = "QAMap";
-export const VERSION = "0.3.5";
+export const VERSION = "0.3.6";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const TOOL_NAME = "QAMap";
-export const VERSION = "0.3.6";
+export const VERSION = "0.4.0";

--- a/test/behavior.test.mjs
+++ b/test/behavior.test.mjs
@@ -1,11 +1,16 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import {
   analyzeBehaviorGraph,
+  behaviorEdgeKinds,
+  behaviorEvidenceKinds,
+  behaviorGraphSchemaUrl,
+  behaviorNodeKinds,
+  behaviorSurfaceKinds,
   createBehaviorEdge,
   createBehaviorNodeId,
   createInferredFlowBehaviorAdapter,
@@ -61,6 +66,7 @@ test("behavior graph is deterministic and keeps impact provenance", async () => 
   const second = await analyzeBehaviorGraph(baseContext, [adapter]);
 
   assert.deepEqual(first, second);
+  assert.equal(first.$schema, behaviorGraphSchemaUrl);
   assert.equal(first.schemaVersion, 1);
   assert.equal(first.adapters[0].status, "used");
   assert.equal(first.summary.byKind.flow, 1);
@@ -74,6 +80,19 @@ test("behavior graph is deterministic and keeps impact provenance", async () => 
   assert.deepEqual(source?.impact, { kind: "direct", changedFiles: ["src/pages/checkout.tsx"] });
   const ids = new Set(first.nodes.map((node) => node.id));
   assert.ok(first.edges.every((edge) => ids.has(edge.from) && ids.has(edge.to)));
+});
+
+test("behavior graph JSON schema stays aligned with runtime enums", async () => {
+  const schema = JSON.parse(await readFile(path.join(process.cwd(), "schema/qamap-behavior.schema.json"), "utf8"));
+
+  assert.equal(schema.$id, behaviorGraphSchemaUrl);
+  assert.equal(schema.properties.$schema.const, behaviorGraphSchemaUrl);
+  assert.equal(schema.properties.schemaVersion.const, 1);
+  assert.deepEqual(schema.$defs.surface.enum, behaviorSurfaceKinds);
+  assert.deepEqual(schema.$defs.nodeKind.enum, behaviorNodeKinds);
+  assert.deepEqual(schema.$defs.edgeKind.enum, behaviorEdgeKinds);
+  assert.deepEqual(schema.$defs.evidenceKind.enum, behaviorEvidenceKinds);
+  assert.ok(schema.required.includes("$schema"));
 });
 
 test("behavior adapter failures are isolated and dangling edges are removed", async () => {

--- a/test/behavior.test.mjs
+++ b/test/behavior.test.mjs
@@ -16,6 +16,7 @@ import {
   createInferredFlowBehaviorAdapter,
 } from "../dist/behavior.js";
 import { createManifestBehaviorAdapter } from "../dist/behavior-manifest.js";
+import { createChangeIntentBehaviorAdapter } from "../dist/behavior-intent.js";
 import { generateE2ePlan } from "../dist/e2e.js";
 
 const baseContext = {
@@ -93,6 +94,93 @@ test("behavior graph JSON schema stays aligned with runtime enums", async () => 
   assert.deepEqual(schema.$defs.edgeKind.enum, behaviorEdgeKinds);
   assert.deepEqual(schema.$defs.evidenceKind.enum, behaviorEvidenceKinds);
   assert.ok(schema.required.includes("$schema"));
+});
+
+test("change intent adapter preserves commit lifecycle and QA assertions", async () => {
+  const commitEvidence = {
+    kind: "commit",
+    value: "feat: schedule a digest reminder after report completion",
+    commit: "1234567890abcdef",
+  };
+  const analysis = {
+    base: "main",
+    head: "HEAD",
+    source: "commits-and-diff",
+    commits: [],
+    diagnostics: [],
+    intents: [
+      {
+        id: "intent:digest",
+        title: "Schedule a digest reminder after report completion",
+        summary: "Schedule and open a digest reminder",
+        confidence: "high",
+        commits: [],
+        files: ["src/reminder.ts"],
+        keywords: ["digest", "reminder"],
+        evidence: [commitEvidence],
+        reviewRequired: false,
+        lifecycle: [
+          {
+            id: "stage:trigger",
+            kind: "trigger",
+            label: "After report completion.",
+            confidence: "high",
+            evidence: [commitEvidence],
+            files: [],
+          },
+          {
+            id: "stage:effect",
+            kind: "side-effect",
+            label: "Schedule a digest reminder.",
+            confidence: "high",
+            evidence: [commitEvidence],
+            files: ["src/reminder.ts"],
+          },
+          {
+            id: "stage:outcome",
+            kind: "observable-outcome",
+            label: "Open the linked digest.",
+            confidence: "high",
+            evidence: [commitEvidence],
+            files: ["src/reminder.ts"],
+          },
+        ],
+        scenarios: [
+          {
+            id: "scenario:primary",
+            kind: "primary",
+            priority: "critical",
+            title: "Schedule a digest reminder",
+            rationale: "Commit evidence",
+            setup: [],
+            steps: ["Complete a report."],
+            assertions: ["Verify the linked digest opens."],
+            edgeCases: [],
+            evidence: [commitEvidence],
+          },
+        ],
+      },
+    ],
+  };
+
+  const graph = await analyzeBehaviorGraph(
+    {
+      ...baseContext,
+      changedFiles: [{ status: "M", path: "src/reminder.ts" }],
+    },
+    [createChangeIntentBehaviorAdapter({ analysis })],
+  );
+
+  assert.deepEqual(graph.adapters.map((adapter) => [adapter.id, adapter.status]), [["qamap.change-intent", "used"]]);
+  assert.equal(graph.summary.byKind.contract, 1);
+  assert.ok(graph.summary.byKind.action >= 1);
+  assert.ok(graph.summary.byKind.effect >= 1);
+  assert.ok(graph.summary.byKind.assertion >= 2);
+  assert.ok(graph.nodes.some((node) => node.evidence.some((evidence) => evidence.kind === "commit")));
+  assert.ok(graph.edges.some((edge) => edge.kind === "precedes"));
+  assert.ok(graph.edges.some((edge) => edge.kind === "expects"));
+  const ids = new Set(graph.nodes.map((node) => node.id));
+  assert.ok(graph.edges.every((edge) => ids.has(edge.from) && ids.has(edge.to)));
 });
 
 test("behavior adapter failures are isolated and dangling edges are removed", async () => {

--- a/test/behavior.test.mjs
+++ b/test/behavior.test.mjs
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  analyzeBehaviorGraph,
+  createBehaviorEdge,
+  createBehaviorNodeId,
+  createInferredFlowBehaviorAdapter,
+} from "../dist/behavior.js";
+import { generateE2ePlan } from "../dist/e2e.js";
+
+const baseContext = {
+  root: "/tmp/qamap-behavior-fixture",
+  base: "main",
+  head: "HEAD",
+  projectType: "web",
+  surface: "web",
+  runner: "playwright",
+  changedFiles: [{ status: "M", path: "src/pages/checkout.tsx" }],
+};
+
+test("behavior graph is deterministic and keeps impact provenance", async () => {
+  const adapter = createInferredFlowBehaviorAdapter({
+    flows: [
+      {
+        kind: "ui",
+        title: "Checkout submit flow",
+        reason: "The changed page owns the visible submit action.",
+        files: ["src/pages/checkout.tsx", "src/components/SubmitButton.tsx"],
+        steps: ["Open the checkout page.", "Submit the form.", "Verify the confirmation is visible."],
+        entrypoints: [
+          { kind: "route", value: "/checkout", file: "src/pages/checkout.tsx", confidence: "high" },
+        ],
+        selectors: [
+          {
+            kind: "web-test-id",
+            value: "checkout-submit",
+            file: "src/pages/checkout.tsx",
+            addedInDiff: true,
+          },
+        ],
+        coverage: [
+          {
+            title: "Primary success path",
+            priority: "critical",
+            reason: "A visible completion signal is required.",
+            checks: ["Verify the confirmation is visible."],
+          },
+        ],
+        fixtureStatus: "ready",
+        fixtureFiles: ["src/mocks/handlers.ts"],
+      },
+    ],
+  });
+
+  const first = await analyzeBehaviorGraph(baseContext, [adapter]);
+  const second = await analyzeBehaviorGraph(baseContext, [adapter]);
+
+  assert.deepEqual(first, second);
+  assert.equal(first.schemaVersion, 1);
+  assert.equal(first.adapters[0].status, "used");
+  assert.equal(first.summary.byKind.flow, 1);
+  assert.equal(first.summary.byKind.surface, 1);
+  assert.equal(first.summary.byKind.fixture, 1);
+  assert.equal(first.summary.byKind.locator, 1);
+  assert.ok(first.summary.byKind.action >= 2);
+  assert.ok(first.summary.byKind.assertion >= 1);
+
+  const source = first.nodes.find((node) => node.kind === "source" && node.label === "src/pages/checkout.tsx");
+  assert.deepEqual(source?.impact, { kind: "direct", changedFiles: ["src/pages/checkout.tsx"] });
+  const ids = new Set(first.nodes.map((node) => node.id));
+  assert.ok(first.edges.every((edge) => ids.has(edge.from) && ids.has(edge.to)));
+});
+
+test("behavior adapter failures are isolated and dangling edges are removed", async () => {
+  const sourceId = createBehaviorNodeId("source", "src/index.ts");
+  const healthyAdapter = {
+    id: "adapter.healthy",
+    version: "1",
+    detect: () => ({ confidence: "high", reason: "fixture", evidence: ["src/index.ts"] }),
+    analyze: () => ({
+      nodes: [
+        {
+          id: sourceId,
+          kind: "source",
+          label: "src/index.ts",
+          confidence: "high",
+          evidence: [{ kind: "source", value: "src/index.ts", file: "src/index.ts" }],
+        },
+      ],
+      edges: [createBehaviorEdge("impacts", sourceId, "flow:missing", "high")],
+      diagnostics: [{ severity: "info", message: "synthetic adapter note" }],
+    }),
+  };
+  const failingAdapter = {
+    id: "adapter.failing",
+    version: "1",
+    detect: () => ({ confidence: "medium", reason: "fixture", evidence: [] }),
+    analyze: () => {
+      throw new Error("synthetic analyzer failure");
+    },
+  };
+  const skippedAdapter = {
+    id: "adapter.skipped",
+    version: "1",
+    detect: () => ({ confidence: "none", reason: "not applicable", evidence: [] }),
+    analyze: () => ({ nodes: [], edges: [] }),
+  };
+
+  const graph = await analyzeBehaviorGraph(baseContext, [skippedAdapter, healthyAdapter, failingAdapter]);
+
+  assert.deepEqual(
+    graph.adapters.map((adapter) => [adapter.id, adapter.status]),
+    [
+      ["adapter.failing", "failed"],
+      ["adapter.healthy", "used"],
+      ["adapter.skipped", "skipped"],
+    ],
+  );
+  assert.equal(graph.nodes.length, 1);
+  assert.equal(graph.edges.length, 0);
+  assert.ok(graph.diagnostics.some((diagnostic) => /synthetic analyzer failure/.test(diagnostic.message)));
+  assert.ok(
+    graph.diagnostics.some(
+      (diagnostic) => diagnostic.adapterId === "adapter.healthy" && diagnostic.message === "synthetic adapter note",
+    ),
+  );
+  assert.ok(graph.diagnostics.some((diagnostic) => /endpoint nodes were missing/.test(diagnostic.message)));
+});
+
+test("E2E planning exposes a behavior graph for a real branch diff", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "qamap-behavior-integration-"));
+  try {
+    await mkdir(path.join(root, "src", "pages"), { recursive: true });
+    await writeFile(
+      path.join(root, "package.json"),
+      JSON.stringify({
+        scripts: { dev: "next dev", test: "node --test" },
+        dependencies: { next: "15.0.0", react: "19.0.0" },
+      }),
+    );
+    await writeFile(
+      path.join(root, "src", "pages", "checkout.tsx"),
+      "export default function Checkout() { return <button>Submit</button>; }\n",
+    );
+    git(root, "init", "-b", "main");
+    git(root, "config", "user.email", "qamap@example.test");
+    git(root, "config", "user.name", "QAMap Test");
+    git(root, "add", ".");
+    git(root, "commit", "-m", "base");
+    git(root, "switch", "-c", "feat/checkout-submit");
+    await writeFile(
+      path.join(root, "src", "pages", "checkout.tsx"),
+      "export default function Checkout() { return <button data-testid=\"checkout-submit\">Submit</button>; }\n",
+    );
+    git(root, "add", ".");
+    git(root, "commit", "-m", "change checkout submit");
+
+    const first = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+    const second = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+
+    assert.ok(first.flows.length > 0);
+    assert.ok(first.flows.every((flow) => typeof flow.kind === "string"));
+    assert.equal(first.behaviorGraph.surface, "web");
+    assert.equal(first.behaviorGraph.summary.byKind.flow, first.flows.length);
+    assert.ok(first.behaviorGraph.summary.byKind.surface >= 1);
+    assert.ok(first.behaviorGraph.summary.byKind.locator >= 1);
+    assert.ok(
+      first.behaviorGraph.nodes.some(
+        (node) => node.kind === "source" && node.label === "src/pages/checkout.tsx" && node.impact?.kind === "direct",
+      ),
+    );
+    assert.deepEqual(
+      first.behaviorGraph.nodes.map((node) => node.id),
+      second.behaviorGraph.nodes.map((node) => node.id),
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+function git(cwd, ...args) {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}

--- a/test/behavior.test.mjs
+++ b/test/behavior.test.mjs
@@ -10,6 +10,7 @@ import {
   createBehaviorNodeId,
   createInferredFlowBehaviorAdapter,
 } from "../dist/behavior.js";
+import { createManifestBehaviorAdapter } from "../dist/behavior-manifest.js";
 import { generateE2ePlan } from "../dist/e2e.js";
 
 const baseContext = {
@@ -129,6 +130,113 @@ test("behavior adapter failures are isolated and dangling edges are removed", as
     ),
   );
   assert.ok(graph.diagnostics.some((diagnostic) => /endpoint nodes were missing/.test(diagnostic.message)));
+});
+
+test("manifest adapter connects reviewed domains, flows, checks, routes, and selectors", async () => {
+  const manifestPath = ".qamap/manifest.yaml";
+  const matches = [
+    {
+      kind: "domain",
+      id: "checkout",
+      name: "Checkout",
+      manifestPath: `${manifestPath} > domains.checkout.paths`,
+      updatePath: `${manifestPath} > domains.checkout.paths`,
+      reason: "Changed files match the Checkout domain.",
+      evidenceSources: ["human-reviewed"],
+      nextActions: [],
+      repairHints: [],
+      matchedFiles: ["src/pages/checkout.tsx"],
+      confidence: "high",
+      criticality: "high",
+    },
+    {
+      kind: "flow",
+      id: "checkout-submit",
+      name: "Checkout Submit",
+      manifestPath: `${manifestPath} > flows.checkout-submit.anchors`,
+      updatePath: `${manifestPath} > flows.checkout-submit.anchors`,
+      reason: "Changed files match the Checkout Submit flow.",
+      evidenceSources: ["human-reviewed"],
+      nextActions: [],
+      repairHints: [],
+      matchedFiles: ["src/pages/checkout.tsx"],
+      confidence: "high",
+      criticality: "high",
+      runner: "playwright",
+      entryRoute: "/checkout",
+      checks: ["Show confirmation after submit"],
+    },
+    {
+      kind: "check",
+      id: "checkout-submit.confirmation",
+      name: "Show confirmation after submit",
+      manifestPath: `${manifestPath} > flows.checkout-submit.checks.confirmation`,
+      updatePath: `${manifestPath} > flows.checkout-submit.checks`,
+      reason: "The flow declares this success check.",
+      evidenceSources: ["human-reviewed"],
+      nextActions: [],
+      repairHints: [],
+      matchedFiles: ["src/pages/checkout.tsx"],
+      confidence: "high",
+      runner: "playwright",
+      entryRoute: "/checkout",
+      checks: ["Show confirmation after submit"],
+      checkType: "success",
+      checkSelector: "[data-testid=checkout-confirmation]",
+      checkSteps: ["Submit checkout", "Verify confirmation"],
+    },
+  ];
+
+  const graph = await analyzeBehaviorGraph(baseContext, [createManifestBehaviorAdapter({ matches })]);
+
+  assert.deepEqual(graph.adapters.map((adapter) => [adapter.id, adapter.status]), [
+    ["qamap.verification-manifest", "used"],
+  ]);
+  assert.equal(graph.summary.byKind.domain, 1);
+  assert.equal(graph.summary.byKind.flow, 1);
+  assert.equal(graph.summary.byKind.assertion, 1);
+  assert.equal(graph.summary.byKind.surface, 1);
+  assert.equal(graph.summary.byKind.locator, 1);
+  assert.equal(graph.summary.byKind.source, 1);
+  assert.ok(graph.nodes.every((node) => node.impact?.kind === "direct" || node.kind === "surface" || node.kind === "locator"));
+  assert.ok(graph.nodes.some((node) => node.kind === "assertion" && node.evidence.some((item) => item.kind === "manifest")));
+  assert.ok(graph.edges.some((edge) => edge.kind === "contains"));
+  assert.ok(graph.edges.some((edge) => edge.kind === "expects"));
+  assert.ok(graph.edges.some((edge) => edge.kind === "located-by"));
+});
+
+test("manifest adapter normalizes workspace paths for package-scoped impact", async () => {
+  const context = {
+    ...baseContext,
+    root: "/repo/packages/web-app",
+    workspaceRoot: "/repo",
+    changedFiles: [{ status: "M", path: "src/pages/checkout.tsx" }],
+  };
+  const matches = [
+    {
+      kind: "flow",
+      id: "checkout-submit",
+      name: "Checkout Submit",
+      manifestPath: ".qamap/manifest.yaml > flows.checkout-submit.anchors",
+      updatePath: ".qamap/manifest.yaml > flows.checkout-submit.anchors",
+      reason: "Workspace manifest flow matched.",
+      evidenceSources: ["human-reviewed"],
+      nextActions: [],
+      repairHints: [],
+      matchedFiles: ["packages/web-app/src/pages/checkout.tsx"],
+      confidence: "high",
+      runner: "playwright",
+      entryRoute: "/checkout",
+      checks: [],
+    },
+  ];
+
+  const graph = await analyzeBehaviorGraph(context, [createManifestBehaviorAdapter({ matches })]);
+
+  const source = graph.nodes.find((node) => node.kind === "source");
+  assert.equal(source?.label, "src/pages/checkout.tsx");
+  assert.deepEqual(source?.impact, { kind: "direct", changedFiles: ["src/pages/checkout.tsx"] });
+  assert.equal(graph.nodes.some((node) => node.label.startsWith("packages/web-app/")), false);
 });
 
 test("E2E planning exposes a behavior graph for a real branch diff", async () => {

--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -8,4 +8,6 @@ Each directory represents one reduced pull request:
 
 Fixtures must stay small, synthetic, and safe to publish. The benchmark runner only reads the materialized repositories. It does not install dependencies, start services, run package scripts, or execute generated tests.
 
+The committed matrix includes React/Next.js, Vue, SvelteKit, Expo/React Native, API, artifact, shared-component, configuration-only, and test-only changes. Framework fixtures protect observable behavior contracts rather than framework branding alone: route discovery, changed selectors, success signals, draft paths, and Behavior Graph evidence must agree.
+
 Add a fixture when a real failure can be reduced to a reusable project shape. Prefer one clear regression per fixture over a large imitation of a production repository.

--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -3,11 +3,11 @@
 Each directory represents one reduced pull request:
 
 - `base/` is committed on a temporary `main` branch.
-- `head/` is copied over the baseline and committed on `benchmark/change`.
+- `head/` is copied over the baseline and committed on `benchmark/change`; intent fixtures provide a neutral synthetic `commitMessage`.
 - `bench.config.json` declares the human expectation for the resulting QA draft.
 
 Fixtures must stay small, synthetic, and safe to publish. The benchmark runner only reads the materialized repositories. It does not install dependencies, start services, run package scripts, or execute generated tests.
 
-The committed matrix includes React/Next.js, Vue, SvelteKit, Expo/React Native, API, artifact, shared-component, configuration-only, and test-only changes. Framework fixtures protect observable behavior contracts rather than framework branding alone: route discovery, changed selectors, success signals, draft paths, and Behavior Graph evidence must agree.
+The committed matrix includes React/Next.js, Vue, SvelteKit, Expo/React Native, API, artifact, shared-component, configuration-only, and test-only changes. Dedicated web preferences and mobile reminder fixtures protect commit intent, lifecycle ordering, failure and boundary QA, generic-title suppression, and commit-backed Behavior Graph evidence. Framework fixtures also protect route discovery, changed selectors, success signals, and draft paths rather than framework branding alone.
 
 Add a fixture when a real failure can be reduced to a reusable project shape. Prefer one clear regression per fixture over a large imitation of a production repository.

--- a/test/benchmarks/mobile-reminder-lifecycle/base/app.json
+++ b/test/benchmarks/mobile-reminder-lifecycle/base/app.json
@@ -1,0 +1,12 @@
+{
+  "expo": {
+    "name": "Summary Fixture",
+    "slug": "summary-fixture",
+    "ios": {
+      "bundleIdentifier": "com.example.summaryfixture"
+    },
+    "android": {
+      "package": "com.example.summaryfixture"
+    }
+  }
+}

--- a/test/benchmarks/mobile-reminder-lifecycle/base/package.json
+++ b/test/benchmarks/mobile-reminder-lifecycle/base/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "benchmark-mobile-reminder-lifecycle",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "ios": "expo run:ios"
+  },
+  "dependencies": {
+    "expo": "55.0.0",
+    "expo-notifications": "0.32.0",
+    "react-native": "0.83.0"
+  }
+}

--- a/test/benchmarks/mobile-reminder-lifecycle/base/src/screens/SettingsScreen.tsx
+++ b/test/benchmarks/mobile-reminder-lifecycle/base/src/screens/SettingsScreen.tsx
@@ -1,0 +1,9 @@
+import { Switch, View } from "react-native";
+
+export function SettingsScreen() {
+  return (
+    <View>
+      <Switch value={false} />
+    </View>
+  );
+}

--- a/test/benchmarks/mobile-reminder-lifecycle/base/src/screens/SummaryScreen.tsx
+++ b/test/benchmarks/mobile-reminder-lifecycle/base/src/screens/SummaryScreen.tsx
@@ -1,0 +1,5 @@
+import { Text } from "react-native";
+
+export function SummaryScreen() {
+  return <Text>Summary</Text>;
+}

--- a/test/benchmarks/mobile-reminder-lifecycle/base/src/screens/SurveyCompleteScreen.tsx
+++ b/test/benchmarks/mobile-reminder-lifecycle/base/src/screens/SurveyCompleteScreen.tsx
@@ -1,0 +1,9 @@
+import { Text, View } from "react-native";
+
+export function SurveyCompleteScreen() {
+  return (
+    <View>
+      <Text>Survey complete</Text>
+    </View>
+  );
+}

--- a/test/benchmarks/mobile-reminder-lifecycle/base/src/services/summaryReminder.ts
+++ b/test/benchmarks/mobile-reminder-lifecycle/base/src/services/summaryReminder.ts
@@ -1,0 +1,3 @@
+export function clearSummaryReminder() {
+  return undefined;
+}

--- a/test/benchmarks/mobile-reminder-lifecycle/head/src/screens/SettingsScreen.tsx
+++ b/test/benchmarks/mobile-reminder-lifecycle/head/src/screens/SettingsScreen.tsx
@@ -1,0 +1,9 @@
+import { Switch, View } from "react-native";
+
+export function SettingsScreen() {
+  return (
+    <View>
+      <Switch accessibilityLabel="Summary reminder" testID="summary-reminder-toggle" value />
+    </View>
+  );
+}

--- a/test/benchmarks/mobile-reminder-lifecycle/head/src/screens/SummaryScreen.tsx
+++ b/test/benchmarks/mobile-reminder-lifecycle/head/src/screens/SummaryScreen.tsx
@@ -1,0 +1,5 @@
+import { Text } from "react-native";
+
+export function SummaryScreen() {
+  return <Text testID="linked-summary">Linked summary</Text>;
+}

--- a/test/benchmarks/mobile-reminder-lifecycle/head/src/screens/SurveyCompleteScreen.tsx
+++ b/test/benchmarks/mobile-reminder-lifecycle/head/src/screens/SurveyCompleteScreen.tsx
@@ -1,0 +1,10 @@
+import { Text, View } from "react-native";
+
+export function SurveyCompleteScreen() {
+  return (
+    <View>
+      <Text>Survey complete</Text>
+      <Text testID="summary-reminder-preview">Summary reminder scheduled</Text>
+    </View>
+  );
+}

--- a/test/benchmarks/mobile-reminder-lifecycle/head/src/services/summaryReminder.ts
+++ b/test/benchmarks/mobile-reminder-lifecycle/head/src/services/summaryReminder.ts
@@ -1,0 +1,21 @@
+import * as Notifications from "expo-notifications";
+
+export async function scheduleSummaryReminder(surveyId: string, scheduledAt: Date) {
+  return Notifications.scheduleNotificationAsync({
+    content: {
+      title: "Summary ready",
+      data: { surveyId },
+    },
+    trigger: { date: scheduledAt },
+  });
+}
+
+export async function resyncSummaryReminder(surveyId: string, scheduledAt: Date) {
+  await Notifications.cancelAllScheduledNotificationsAsync();
+  return scheduleSummaryReminder(surveyId, scheduledAt);
+}
+
+export function openLinkedSummary(response: Notifications.NotificationResponse) {
+  const surveyId = response.notification.request.content.data.surveyId;
+  return `/summaries/${surveyId}`;
+}

--- a/test/benchmarks/web-preferences-lifecycle/base/package.json
+++ b/test/benchmarks/web-preferences-lifecycle/base/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "benchmark-web-preferences-lifecycle",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "@playwright/test": "1.56.0",
+    "react": "19.0.0",
+    "vite": "7.0.0"
+  }
+}

--- a/test/benchmarks/web-preferences-lifecycle/base/src/pages/preferences.tsx
+++ b/test/benchmarks/web-preferences-lifecycle/base/src/pages/preferences.tsx
@@ -1,0 +1,3 @@
+export function PreferencesPage() {
+  return <button>Review preferences</button>;
+}

--- a/test/benchmarks/web-preferences-lifecycle/head/src/pages/preferences.tsx
+++ b/test/benchmarks/web-preferences-lifecycle/head/src/pages/preferences.tsx
@@ -1,0 +1,23 @@
+import { useState } from "react";
+
+export function PreferencesPage() {
+  const [saved, setSaved] = useState(false);
+
+  async function onSubmitPreferences() {
+    await fetch("/api/preferences", { method: "POST" });
+    setSaved(true);
+  }
+
+  return (
+    <main>
+      <label>
+        Timezone
+        <input aria-label="Timezone" defaultValue="UTC" />
+      </label>
+      <button data-testid="preferences-save" onClick={onSubmitPreferences} type="button">
+        Save preferences
+      </button>
+      {saved ? <p>Preferences saved</p> : null}
+    </main>
+  );
+}

--- a/test/benchmarks/web-sveltekit-settings/base/package.json
+++ b/test/benchmarks/web-sveltekit-settings/base/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "benchmark-sveltekit-settings",
+  "private": true,
+  "scripts": {
+    "dev": "vite dev"
+  },
+  "dependencies": {
+    "@sveltejs/kit": "2.0.0",
+    "svelte": "5.0.0",
+    "vite": "7.0.0"
+  }
+}

--- a/test/benchmarks/web-sveltekit-settings/base/src/routes/settings/+page.svelte
+++ b/test/benchmarks/web-sveltekit-settings/base/src/routes/settings/+page.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  let displayName = "";
+</script>
+
+<main>
+  <h1>Settings</h1>
+  <input aria-label="Display name" bind:value={displayName} />
+  <button type="button">Review settings</button>
+</main>

--- a/test/benchmarks/web-sveltekit-settings/base/svelte.config.js
+++ b/test/benchmarks/web-sveltekit-settings/base/svelte.config.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/benchmarks/web-sveltekit-settings/head/src/routes/settings/+page.svelte
+++ b/test/benchmarks/web-sveltekit-settings/head/src/routes/settings/+page.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  let displayName = "";
+  let saved = false;
+
+  function saveSettings() {
+    saved = true;
+  }
+</script>
+
+<main>
+  <h1>Settings</h1>
+  <input aria-label="Display name" bind:value={displayName} />
+  <button data-testid="settings-save" type="button" on:click={saveSettings}>Save settings</button>
+  {#if saved}<p>Settings saved</p>{/if}
+</main>

--- a/test/benchmarks/web-vue-account/base/package.json
+++ b/test/benchmarks/web-vue-account/base/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "benchmark-vue-account",
+  "private": true,
+  "scripts": {
+    "dev": "vite"
+  },
+  "dependencies": {
+    "vue": "3.5.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "6.0.0",
+    "vite": "7.0.0"
+  }
+}

--- a/test/benchmarks/web-vue-account/base/src/pages/account.vue
+++ b/test/benchmarks/web-vue-account/base/src/pages/account.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { ref } from "vue";
+
+const email = ref("");
+</script>
+
+<template>
+  <main>
+    <h1>Account</h1>
+    <input v-model="email" aria-label="Email" />
+    <button type="button">Review account</button>
+  </main>
+</template>

--- a/test/benchmarks/web-vue-account/base/vite.config.ts
+++ b/test/benchmarks/web-vue-account/base/vite.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+
+export default defineConfig({ plugins: [vue()] });

--- a/test/benchmarks/web-vue-account/head/src/pages/account.vue
+++ b/test/benchmarks/web-vue-account/head/src/pages/account.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { ref } from "vue";
+
+const email = ref("");
+const saved = ref(false);
+
+function saveAccount() {
+  saved.value = true;
+}
+</script>
+
+<template>
+  <main>
+    <h1>Account</h1>
+    <input v-model="email" aria-label="Email" />
+    <button data-testid="account-save" type="button" @click="saveAccount">Save account</button>
+    <p v-if="saved">Account saved</p>
+  </main>
+</template>

--- a/test/change-intent.test.mjs
+++ b/test/change-intent.test.mjs
@@ -1,0 +1,231 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { analyzeChangeIntents } from "../dist/change-intent.js";
+import { generateE2eDraft, generateE2ePlan } from "../dist/e2e.js";
+import { formatAgentQaDraft, generateQaDraft } from "../dist/qa.js";
+import { collectAddedDiffText } from "../dist/test-plan.js";
+
+test("change intent clusters related commits into one evidence-backed lifecycle", async (t) => {
+  const root = await makeRepo(t);
+  await write(root, "src/reminder.ts", "export const reminder = false;\n");
+  commit(root, "benchmark baseline");
+  branch(root, "feat/digest-reminder");
+
+  await write(
+    root,
+    "src/reminder.ts",
+    "export function scheduleDigestReminder() { return notifications.schedule(); }\n",
+  );
+  commit(root, "feat: schedule a digest reminder after report completion");
+
+  await write(
+    root,
+    "src/reminder.ts",
+    "export function resyncReminder() { setScheduledTime(); return notifications.schedule(); }\n",
+  );
+  commit(root, "feat: resync the reminder when the report time changes");
+
+  await write(
+    root,
+    "src/reminder.ts",
+    "export function openLinkedReport() { return router.push('/reports/current'); }\n",
+  );
+  commit(root, "feat: open the linked report when the reminder is tapped");
+
+  const analysis = await analyze(root, ["src/reminder.ts"]);
+
+  assert.equal(analysis.source, "commits-and-diff");
+  assert.equal(analysis.intents.length, 1);
+  const intent = analysis.intents[0];
+  assert.equal(intent.confidence, "high");
+  assert.match(intent.title, /Schedule a digest reminder after report completion/i);
+  assert.equal(intent.commits.length, 3);
+  assert.ok(intent.lifecycle.some((stage) => stage.kind === "trigger" && /after report completion/i.test(stage.label)));
+  assert.ok(intent.lifecycle.some((stage) => stage.kind === "trigger" && /when the reminder is tapped/i.test(stage.label)));
+  assert.ok(intent.lifecycle.some((stage) => stage.kind === "state-change" && /resync/i.test(stage.label)));
+  assert.ok(intent.lifecycle.some((stage) => stage.kind === "side-effect" && /schedule/i.test(stage.label)));
+  assert.ok(intent.lifecycle.some((stage) => stage.kind === "observable-outcome" && /open the linked report/i.test(stage.label)));
+  assert.ok(intent.scenarios.some((scenario) => /calendar.*duplicate/i.test(scenario.title)));
+  assert.ok(intent.scenarios.some((scenario) => /destination routing/i.test(scenario.title)));
+  assert.ok(intent.evidence.some((item) => item.kind === "commit" && item.commit));
+});
+
+test("change intent keeps unrelated feature commits separate", async (t) => {
+  const root = await makeRepo(t);
+  await write(root, "src/profile.ts", "export const profile = {};\n");
+  await write(root, "src/archive.ts", "export const archive = {};\n");
+  commit(root, "benchmark baseline");
+  branch(root, "feat/mixed-work");
+
+  await write(root, "src/profile.ts", "export function submitProfileForm() { return saveProfile(); }\n");
+  commit(root, "feat(profile): submit profile form");
+  await write(root, "src/archive.ts", "export function exportAuditArchive() { return downloadArchive(); }\n");
+  commit(root, "feat(export): export audit archive");
+
+  const analysis = await analyze(root, ["src/profile.ts", "src/archive.ts"]);
+
+  assert.equal(analysis.intents.length, 2);
+  assert.ok(analysis.intents.some((intent) => /Submit profile form/i.test(intent.title)));
+  assert.ok(analysis.intents.some((intent) => /Export audit archive/i.test(intent.title)));
+  assert.ok(analysis.intents.every((intent) => intent.files.length === 1));
+});
+
+test("change intent ignores release-only commit metadata", async (t) => {
+  const root = await makeRepo(t);
+  await write(root, "package.json", '{"name":"fixture","version":"1.0.0"}\n');
+  commit(root, "benchmark baseline");
+  branch(root, "chore/release");
+  await write(root, "package.json", '{"name":"fixture","version":"1.0.1"}\n');
+  commit(root, "chore: prepare release metadata");
+
+  const analysis = await analyze(root, ["package.json"]);
+
+  assert.equal(analysis.intents.length, 0);
+  assert.equal(analysis.source, "none");
+  assert.ok(analysis.diagnostics.some((diagnostic) => /did not contain a behavior-bearing/i.test(diagnostic)));
+});
+
+test("change intent marks connected working-tree signals as review-required diff evidence", async (t) => {
+  const root = await makeRepo(t);
+  await write(root, "src/form.tsx", "export function Form() { return null; }\n");
+  commit(root, "benchmark baseline");
+
+  const analysis = await analyzeChangeIntents(root, {
+    base: "main",
+    head: "HEAD",
+    includeWorkingTree: true,
+    changedFiles: [{ status: "M", path: "src/form.tsx" }],
+    addedDiffText: {
+      "src/form.tsx": [
+        "const run = async () => {",
+        "function onSubmitProfile() {",
+        "  setSavedProfile();",
+        "  fetchProfile();",
+        "  router.push('/profile');",
+        "}",
+      ].join("\n"),
+    },
+  });
+
+  assert.equal(analysis.source, "diff-only");
+  assert.equal(analysis.intents.length, 1);
+  assert.equal(analysis.intents[0].confidence, "low");
+  assert.equal(analysis.intents[0].reviewRequired, true);
+  assert.equal(analysis.intents[0].commits.length, 0);
+  assert.ok(analysis.intents[0].evidence.every((item) => item.kind === "diff"));
+  assert.equal(analysis.intents[0].evidence.some((item) => item.symbol === "async"), false);
+});
+
+test("E2E planning promotes commit intent before runner-specific draft generation", async (t) => {
+  const root = await makeRepo(t);
+  await write(
+    root,
+    "package.json",
+    JSON.stringify({
+      scripts: { dev: "vite", "test:e2e": "playwright test" },
+      dependencies: { react: "19.0.0", vite: "7.0.0", "@playwright/test": "1.56.0" },
+    }),
+  );
+  await write(
+    root,
+    "src/pages/preferences.tsx",
+    "export function Preferences() { return <button>Review preferences</button>; }\n",
+  );
+  commit(root, "benchmark baseline");
+  branch(root, "feat/preferences-save");
+
+  await write(
+    root,
+    "src/pages/preferences.tsx",
+    [
+      "export function Preferences() {",
+      "  async function onSubmitPreferences() {",
+      "    await fetch('/api/preferences', { method: 'POST' });",
+      "    setSavedTimezone('UTC');",
+      "  }",
+      "  return <button data-testid=\"preferences-save\" onClick={onSubmitPreferences}>Save preferences</button>;",
+      "}",
+    ].join("\n"),
+  );
+  commit(root, "feat: submit account preferences and persist the selected timezone");
+
+  await write(
+    root,
+    "src/pages/preferences.tsx",
+    [
+      "export function Preferences() {",
+      "  async function onSubmitPreferences() {",
+      "    await fetch('/api/preferences', { method: 'POST' });",
+      "    setSavedTimezone('UTC');",
+      "  }",
+      "  return <main>",
+      "    <button data-testid=\"preferences-save\" onClick={onSubmitPreferences}>Save preferences</button>",
+      "    <p>Preferences saved</p>",
+      "  </main>;",
+      "}",
+    ].join("\n"),
+  );
+  commit(root, "fix: show saved preferences after the request completes");
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const draft = await generateE2eDraft(root, { base: "main", head: "HEAD", dryRun: true });
+  const qa = await generateQaDraft(root, { base: "main", head: "HEAD" });
+  const agentSummary = JSON.parse(formatAgentQaDraft(qa));
+
+  assert.equal(plan.changeAnalysis.intents.length, 1);
+  assert.match(plan.changeAnalysis.intents[0].title, /Submit account preferences/i);
+  assert.equal(plan.flows[0].intentId, plan.changeAnalysis.intents[0].id);
+  assert.match(plan.flows[0].title, /Submit account preferences/i);
+  assert.doesNotMatch(plan.flows[0].title, /primary journey|smoke flow/i);
+  assert.ok(plan.flows[0].steps.some((step) => /persist the selected timezone/i.test(step)));
+  assert.ok(plan.flows[0].steps.some((step) => /show saved preferences/i.test(step)));
+  assert.ok(plan.behaviorGraph.nodes.some((node) => node.kind === "contract" && node.label === plan.flows[0].title));
+  assert.ok(plan.behaviorGraph.nodes.some((node) => node.evidence.some((item) => item.kind === "commit")));
+  assert.equal(draft.files[0].source, "change-intent");
+  assert.equal(draft.files[0].intentConfidence, "high");
+  assert.ok(draft.files[0].qaScenarios.some((scenario) => /failure, timeout, and retry/i.test(scenario.title)));
+  assert.match(agentSummary.intents[0].title, /Submit account preferences/i);
+  assert.ok(agentSummary.intents[0].lifecycle.some((stage) => stage.phase === "state-change"));
+  assert.ok(agentSummary.intents[0].scenarios.some((scenario) => /retry handling/i.test(scenario.title)));
+});
+
+async function analyze(root, files) {
+  const addedDiffText = await collectAddedDiffText(root, { base: "main", head: "HEAD" });
+  return analyzeChangeIntents(root, {
+    base: "main",
+    head: "HEAD",
+    changedFiles: files.map((file) => ({ status: "M", path: file })),
+    addedDiffText,
+  });
+}
+
+async function makeRepo(t) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "qamap-change-intent-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  git(root, "init", "-b", "main");
+  git(root, "config", "user.email", "qamap@example.test");
+  git(root, "config", "user.name", "QAMap Test");
+  return root;
+}
+
+async function write(root, file, content) {
+  await mkdir(path.dirname(path.join(root, file)), { recursive: true });
+  await writeFile(path.join(root, file), content);
+}
+
+function commit(root, message) {
+  git(root, "add", "-A");
+  git(root, "commit", "-m", message);
+}
+
+function branch(root, name) {
+  git(root, "switch", "-c", name);
+}
+
+function git(root, ...args) {
+  execFileSync("git", args, { cwd: root, stdio: "ignore" });
+}

--- a/test/change-intent.test.mjs
+++ b/test/change-intent.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -32,6 +32,13 @@ test("change intent clusters related commits into one evidence-backed lifecycle"
   await write(
     root,
     "src/reminder.ts",
+    "function reminderKey() { return 'digest'; }\nexport function resyncReminder() { setScheduledTime(); return notifications.schedule(); }\n",
+  );
+  commit(root, "refactor: extract digest reminder helper");
+
+  await write(
+    root,
+    "src/reminder.ts",
     "export function openLinkedReport() { return router.push('/reports/current'); }\n",
   );
   commit(root, "feat: open the linked report when the reminder is tapped");
@@ -43,12 +50,13 @@ test("change intent clusters related commits into one evidence-backed lifecycle"
   const intent = analysis.intents[0];
   assert.equal(intent.confidence, "high");
   assert.match(intent.title, /Schedule a digest reminder after report completion/i);
-  assert.equal(intent.commits.length, 3);
+  assert.equal(intent.commits.length, 4);
   assert.ok(intent.lifecycle.some((stage) => stage.kind === "trigger" && /after report completion/i.test(stage.label)));
   assert.ok(intent.lifecycle.some((stage) => stage.kind === "trigger" && /when the reminder is tapped/i.test(stage.label)));
   assert.ok(intent.lifecycle.some((stage) => stage.kind === "state-change" && /resync/i.test(stage.label)));
   assert.ok(intent.lifecycle.some((stage) => stage.kind === "side-effect" && /schedule/i.test(stage.label)));
   assert.ok(intent.lifecycle.some((stage) => stage.kind === "observable-outcome" && /open the linked report/i.test(stage.label)));
+  assert.equal(intent.lifecycle.some((stage) => /helper/i.test(stage.label)), false);
   assert.ok(intent.scenarios.some((scenario) => /calendar.*duplicate/i.test(scenario.title)));
   assert.ok(intent.scenarios.some((scenario) => /destination routing/i.test(scenario.title)));
   assert.ok(intent.evidence.some((item) => item.kind === "commit" && item.commit));
@@ -175,6 +183,12 @@ test("E2E planning promotes commit intent before runner-specific draft generatio
   const draft = await generateE2eDraft(root, { base: "main", head: "HEAD", dryRun: true });
   const qa = await generateQaDraft(root, { base: "main", head: "HEAD" });
   const agentSummary = JSON.parse(formatAgentQaDraft(qa));
+  const writtenDraft = await generateE2eDraft(root, {
+    base: "main",
+    head: "HEAD",
+    output: ".generated-e2e",
+  });
+  const spec = await readFile(path.join(root, writtenDraft.files[0].path), "utf8");
 
   assert.equal(plan.changeAnalysis.intents.length, 1);
   assert.match(plan.changeAnalysis.intents[0].title, /Submit account preferences/i);
@@ -183,6 +197,7 @@ test("E2E planning promotes commit intent before runner-specific draft generatio
   assert.doesNotMatch(plan.flows[0].title, /primary journey|smoke flow/i);
   assert.ok(plan.flows[0].steps.some((step) => /persist the selected timezone/i.test(step)));
   assert.ok(plan.flows[0].steps.some((step) => /show saved preferences/i.test(step)));
+  assert.match(plan.flows[0].languageBrief.successSignal, /Preferences saved/i);
   assert.ok(plan.behaviorGraph.nodes.some((node) => node.kind === "contract" && node.label === plan.flows[0].title));
   assert.ok(plan.behaviorGraph.nodes.some((node) => node.evidence.some((item) => item.kind === "commit")));
   assert.equal(draft.files[0].source, "change-intent");
@@ -191,6 +206,9 @@ test("E2E planning promotes commit intent before runner-specific draft generatio
   assert.match(agentSummary.intents[0].title, /Submit account preferences/i);
   assert.ok(agentSummary.intents[0].lifecycle.some((stage) => stage.phase === "state-change"));
   assert.ok(agentSummary.intents[0].scenarios.some((scenario) => /retry handling/i.test(scenario.title)));
+  assert.match(spec, /Change intent evidence:/);
+  assert.match(spec, /Behavior lifecycle:/);
+  assert.match(spec, /Failure, timeout, and retry handling/);
 });
 
 async function analyze(root, files) {

--- a/test/manifest-feedback.test.mjs
+++ b/test/manifest-feedback.test.mjs
@@ -122,6 +122,13 @@ test("domain-only manifest matches preserve manifest provenance in QA drafts", a
   assert.equal(plan.verificationManifestMatches.filter((match) => match.kind === "domain").length, 1);
   assert.equal(plan.verificationManifestMatches.filter((match) => match.kind === "flow").length, 0);
   assert.ok(plan.flows.length >= 2);
+  assert.ok(plan.behaviorGraph.adapters.some((adapter) => adapter.id === "qamap.verification-manifest" && adapter.status === "used"));
+  assert.equal(plan.behaviorGraph.summary.byKind.domain, 1);
+  assert.ok(
+    plan.behaviorGraph.nodes.some(
+      (node) => node.kind === "domain" && node.evidence.some((evidence) => evidence.kind === "manifest"),
+    ),
+  );
 
   const qa = await generateQaDraft(root, options);
   assert.equal(qa.flows.length, plan.flows.length);

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -796,6 +796,7 @@ test("generateE2ePlan detects CLI packages and suggests command verification che
   const root = await makeTempRepo();
   await initGitRepo(root);
   await mkdir(path.join(root, "src"), { recursive: true });
+  await mkdir(path.join(root, "test/benchmarks/token-fixture/tokens"), { recursive: true });
   await writeFile(
     path.join(root, "package.json"),
     JSON.stringify({
@@ -820,6 +821,10 @@ test("generateE2ePlan detects CLI packages and suggests command verification che
       "  return 'ok';",
       "}",
     ].join("\n"),
+  );
+  await writeFile(
+    path.join(root, "test/benchmarks/token-fixture/tokens/color.json"),
+    JSON.stringify({ color: { primary: "#0055ff" } }),
   );
   await git(root, ["add", "."]);
   await git(root, ["commit", "-m", "base"]);
@@ -847,6 +852,7 @@ test("generateE2ePlan detects CLI packages and suggests command verification che
 
   assert.equal(plan.project.type, "cli");
   assert.ok(plan.project.evidence.some((item) => item === "package.json bin entry found"));
+  assert.equal(plan.project.evidence.some((item) => item === "Design token files found"), false);
   assert.equal(plan.recommendedRunner.name, "manual");
   assert.match(plan.recommendedRunner.reason, /CLI command verification checklist/);
   assert.ok(plan.bootstrap.steps.some((step) => step.title === "Start with CLI command validation"));

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -636,7 +636,8 @@ test("generateE2ePlan recommends mobile flows for Expo changes", async () => {
   assert.ok(plan.missingTestability.some((gap) => /\.maestro/.test(gap)));
   assert.deepEqual(plan.suggestedCommands, ["pnpm run lint"]);
   assert.match(markdown, /# QAMap E2E Plan/);
-  assert.match(markdown, /Recommended runner: Maestro/);
+  assert.match(markdown, /Automation adapter: Maestro/);
+  assert.match(markdown, /selects an output adapter only after deriving runner-independent change intent/i);
   assert.match(markdown, /## Execution Profile/);
   assert.match(markdown, /App id: `Fixture`/);
   assert.match(markdown, /Coverage targets:/);


### PR DESCRIPTION
## Intent

Prepare the first intent-first QAMap release. The product contract is no longer "recommend a runner from changed files." It is:

```txt
behavior-bearing commits + diff
  -> change intent with confidence and evidence
  -> ordered behavior lifecycle
  -> runner-independent primary / failure / boundary / state-transition QA
  -> optional Playwright / Maestro / manual adapter
```

## Changes

- Add a framework-neutral Behavior Graph with stable ids, evidence provenance, impact propagation, isolated adapters, and a published JSON Schema.
- Add deterministic Change Intent analysis that groups related behavior commits, connects them to added diff symbols, and exposes confidence plus `reviewRequired`.
- Reconstruct trigger, condition, action, state-change, side-effect, and observable-outcome lifecycle stages.
- Derive concrete runner-independent QA scenarios before automation setup or runner selection.
- Preserve commit evidence, lifecycle, and QA scenarios in Markdown, JSON, agent output, Behavior Graph nodes, dry runs, and generated automation drafts.
- Keep visible success text from the repository as the primary assertion signal and remove implementation-only helper, lookup, type, and utility language from behavior steps.
- Add Vue and SvelteKit structural contracts plus synthetic web and mobile lifecycle benchmarks. The public matrix now contains 12 reduced PR targets.
- Reposition README, CLI help, architecture, roadmap, packaged agent skill, and release docs around local zero-LLM PR QA design.
- Prepare package metadata for `0.4.0`.

## Confidence And Safety

- One rich squash commit or multiple connected commits can reach high confidence; ambiguous or working-tree-only inference stays review-required.
- Release, docs, CI, style, and test-only commits do not become product intent.
- `qamap qa` remains static and read-only. It does not install dependencies, execute target project code, upload source, or call an LLM.
- All committed regression repositories are minimized synthetic fixtures. No external repository names, source, or domain data are included.
- Existing plan fields remain compatible; Change Intent and Behavior Graph data are additive.

## Validation

- `pnpm run release:check`: passed
- Tests: 139/139 passed
- Public benchmark contracts: 12/12 passed
- Coverage: lines 86.80%, branches 83.37%, functions 94.86%
- Change Intent coverage: lines 94.76%, branches 88.57%, functions 98.04%
- QAMap self-scan: 0 findings
- `npm publish --dry-run --access public`: passed for `@ivorycanvas/qamap@0.4.0`
- Package preview: 129 files, 813.8 kB packed

## Release State

This PR intentionally remains Draft. Do not merge, tag, or publish until final review and explicit release approval.