### PR TITLE
Fix: stop Dependabot PRs for synthetic benchmarks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,21 @@
 version: 2
 updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    # Root package security updates stay enabled, but version-update PRs are manual.
+    open-pull-requests-limit: 0
+    # These manifests are static analyzer inputs and are never installed.
+    exclude-paths:
+      - test/benchmarks/**
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 5
+      interval: monthly
+    open-pull-requests-limit: 1
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -8,6 +8,8 @@ Each directory represents one reduced pull request:
 
 Fixtures must stay small, synthetic, and safe to publish. The benchmark runner only reads the materialized repositories. It does not install dependencies, start services, run package scripts, or execute generated tests.
 
+Fixture manifests exist only to exercise static framework and runner detection. They are excluded from Dependabot updates because their packages are never installed; changing a fixture version does not remediate a runtime dependency in QAMap.
+
 The committed matrix includes React/Next.js, Vue, SvelteKit, Expo/React Native, API, artifact, shared-component, configuration-only, and test-only changes. Dedicated web preferences and mobile reminder fixtures protect commit intent, lifecycle ordering, failure and boundary QA, generic-title suppression, and commit-backed Behavior Graph evidence. Framework fixtures also protect route discovery, changed selectors, success signals, and draft paths rather than framework branding alone.
 
 Add a fixture when a real failure can be reduced to a reusable project shape. Prefer one clear regression per fixture over a large imitation of a production repository.


### PR DESCRIPTION
## Intent

Stop Dependabot from treating static benchmark manifests as installed QAMap dependencies while preserving security updates for the real root package.

## Changes

- Add an npm Dependabot policy for the repository root.
- Keep root security updates enabled while setting routine npm version-update PRs to zero.
- Exclude `test/benchmarks/**` because those manifests are static analyzer inputs and their packages are never installed.
- Reduce GitHub Actions updates to a monthly, single grouped PR with an open limit of one.
- Document the fixture dependency policy next to the benchmark contract.

## Why

The open bot PRs only change versions inside synthetic `base/package.json` fixtures. Updating those versions does not remediate a runtime dependency in QAMap and causes a new PR whenever a fixture introduces an intentionally minimal framework manifest.

## Validation

- Dependabot YAML parsed successfully and policy assertions passed.
- `pnpm test`: 139/139 passed.
- `pnpm scan`: 0 findings.
- `git diff --check`: passed.

GitHub documents `exclude-paths` for test assets and `open-pull-requests-limit: 0` as a way to stop version updates while retaining security updates.