### PR TITLE
Fix: enforce vX.Y.Z release naming

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -20,6 +20,7 @@ Version `1.0.0` requires a stable public contract and external adoption, not imp
 Before publishing, confirm:
 
 - `package.json` version matches the intended npm version.
+- The canonical release identifier is `vX.Y.Z` (for example, `v0.4.0`). The Git tag and GitHub Release title must match this identifier exactly.
 - `CHANGELOG.md` has a dated section for the version being published.
 - `README.md`, [adoption](adoption.md), [E2E examples](e2e-output-examples.md), and [release validation](release-validation.md) describe the current CLI behavior.
 - `pnpm run release:check` passes from a clean checkout.
@@ -93,11 +94,20 @@ Use a fresh shell or temporary directory for the smoke check when possible.
 After npm publish succeeds:
 
 ```sh
-git tag "v$VERSION"
-git push origin "v$VERSION"
+TAG="v$VERSION"
+git tag -a "$TAG" -m "$TAG"
+git push origin "$TAG"
 ```
 
-Create a GitHub Release for the tag with:
+Create a GitHub Release whose display title is exactly the tag:
+
+```sh
+gh release create "$TAG" --title "$TAG" --notes-file <release-notes.md>
+```
+
+Do not prefix the title with `QAMap` or `CodeWard`, and do not add a descriptive subtitle. Product positioning and highlights belong in the release notes body so the release list remains consistently sortable as `vX.Y.Z`.
+
+The release notes body should contain:
 
 - a concise release summary
 - the current `CHANGELOG.md` section


### PR DESCRIPTION
## Intent

Keep the GitHub Release list consistent with the repository tag convention.

## Changes

- Define `vX.Y.Z` as the canonical stable release identifier.
- Require the Git tag and GitHub Release display title to match exactly.
- Add the canonical annotated-tag and `gh release create --title` commands to the runbook.
- Keep product names, positioning, and descriptive subtitles in the release notes body only.

## Metadata Cleanup

All existing releases from `v0.1.0` through `v0.4.0` have already been normalized so their display names exactly match their tags.

## Validation

- Remote Git tags all match `vX.Y.Z`.
- GitHub Release names all match their corresponding tag names.
- `git diff --check`: passed.