### PR TITLE
Feat: enforce automation draft readiness contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+## 0.4.2 - 2026-07-13
+
+### Added
+
+- Added benchmark contracts for draft readiness, runnable candidates, self-check passes, review-only files, TODO markers, and execution blockers. Public fixtures can now fail CI when QAMap finds the right flow but produces an unusable automation draft.
+- Added deterministic Playwright failure-path compilation when repository evidence exposes a mockable endpoint, a stable action control, and an observable failure message. Generated drafts replace the success route with a 4xx/5xx response, repeat the user action, and assert the failure UI instead of falling back to a body-visible smoke check.
+
+### Changed
+
+- Draft execution readiness now measures whether a generated file can be tried locally from runner, entrypoint, selector, fixture, and self-check evidence. Missing pre-existing validation coverage remains required PR guidance, but no longer falsely claims that the new file cannot execute.
+- A partial fixture match can qualify as a runnable candidate when QAMap generated executable mock scaffolding and every other execution check passes. It still remains a review item before the draft becomes trusted regression evidence.
+- Playwright self-checks now report body-only smoke assertions as domain-assertion warnings. Such files remain tryable, but cannot be called runnable candidates until they assert an observable product outcome.
+
+### Fixed
+
+- Draft reports no longer tell users to replace TODO locators when the generated files contain no TODO markers.
+
 ## 0.4.1 - 2026-07-13
 
 ### Added

--- a/bench.config.json
+++ b/bench.config.json
@@ -18,6 +18,11 @@
         "mustRecommendCommands": ["playwright"],
         "maxBlankActions": 0,
         "maxGenericTitles": 0,
+        "minTryableDrafts": 1,
+        "maxSelfCheckFail": 0,
+        "maxReviewOnlyFiles": 0,
+        "maxTodos": 0,
+        "maxExecutionBlockers": 2,
         "maxAgentBytes": 4096
       }
     },
@@ -37,6 +42,15 @@
         "mustFindEvidence": ["/api/orders"],
         "maxBlankActions": 0,
         "maxGenericTitles": 0,
+        "minReadinessScore": 70,
+        "allowedReadinessLevels": ["near-runnable", "ready"],
+        "minTryableDrafts": 1,
+        "minRunnableCandidates": 1,
+        "minSelfCheckPass": 1,
+        "maxSelfCheckFail": 0,
+        "maxReviewOnlyFiles": 0,
+        "maxTodos": 0,
+        "maxExecutionBlockers": 0,
         "maxAgentBytes": 4096
       }
     },
@@ -211,6 +225,11 @@
         "mustFindSelectors": ["checkout-submit"],
         "maxBlankActions": 0,
         "maxGenericTitles": 0,
+        "minTryableDrafts": 1,
+        "maxSelfCheckFail": 0,
+        "maxReviewOnlyFiles": 0,
+        "maxTodos": 0,
+        "maxExecutionBlockers": 2,
         "maxAgentBytes": 4096
       }
     },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,4 +128,4 @@ Playwright, Maestro, and other tools are executor implementations. They are not 
 5. Add explicit, temporary execution and normalized evidence.
 6. Add manifest accept, reject, and repair commands so reviewed outcomes improve later analysis.
 
-Version `0.4.0` establishes the commit-to-intent-to-scenario slice for synthetic web and mobile lifecycle changes. The next minor is reserved for a policy-controlled scenario execution and normalized evidence slice; compatible analyzer and adapter improvements remain patch releases during `0.x` development.
+Version `0.4.0` establishes the commit-to-intent-to-scenario slice for synthetic web and mobile lifecycle changes. The next minor is unscheduled and reserved for a policy-controlled scenario execution and normalized evidence slice that has been proven across unrelated repositories; compatible analyzer and adapter improvements remain `0.4.x` patch releases until that bar is met.

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -64,6 +64,15 @@ Each target can declare:
 | `maxBlankActions` | Maximum malformed or empty draft steps; public fixtures keep this at zero. |
 | `maxGenericTitles` | Maximum titles ending in generic `primary journey` or `smoke flow` wording. |
 | `maxAgentBytes` | Maximum UTF-8 payload size for `qa --format agent`. Production output also has a global 8KB ceiling and discloses omitted intent/flow counts. |
+| `minReadinessScore` | Minimum aggregate draft-readiness score after self-check, TODO, required-action, and execution-blocker penalties. |
+| `allowedReadinessLevels` | Accepted aggregate levels: `ready`, `near-runnable`, `needs-work`, or `blocked`. Use this to prevent a semantically plausible but unusable draft from satisfying the contract. |
+| `minTryableDrafts` | Minimum files classified as `runnable-candidate` or `near-runnable`. |
+| `minRunnableCandidates` | Minimum files classified as `runnable-candidate` with no known execution blockers. |
+| `minSelfCheckPass` | Minimum generated files whose static draft self-check passes. This does not claim that the target application was executed. |
+| `maxSelfCheckFail` | Maximum generated files whose static draft self-check fails. Warnings may remain for honest setup or domain-assertion gaps. |
+| `maxReviewOnlyFiles` | Maximum generated files that remain reference-only instead of tryable automation. |
+| `maxTodos` | Maximum unresolved TODO markers across generated drafts. |
+| `maxExecutionBlockers` | Maximum unresolved execution blockers across generated drafts. Contract failures name the most common blocker. |
 
 Set `manifestBaseline: true` on a committed fixture to generate its manifest from the base snapshot into the benchmark temp directory, then pass that external manifest to analysis of the head commit. The fixture repository is never modified by this step. This protects the feedback loop itself: a baseline must affect the next PR, not merely serialize valid YAML.
 
@@ -79,7 +88,7 @@ node scripts/bench.mjs --baseline bench-results/<file>.json
 
 When both files exist, `pnpm bench` prefers the gitignored local config. CI always passes `--config bench.config.json --assert`, so private paths cannot affect the public quality gate.
 
-Saved results include intent titles, lifecycle and scenario terms, scenario trace coverage, flow titles, draft paths, recall gaps, readiness, agent payload size, and timing. Use a saved baseline to see heuristic movement, but treat the committed expectation contract as the merge gate.
+Saved results include intent titles, lifecycle and scenario terms, scenario trace coverage, flow titles, draft paths, recall gaps, raw readiness counts, self-check outcomes, TODOs, execution blockers, agent payload size, and timing. The table reports draft status as `runnable/near-runnable/review-only`. Use a saved baseline to see heuristic movement, but treat the committed expectation contract as the merge gate.
 
 Every benchmark target also enforces the Behavior Graph base contract: graph schema version 1, at least one graph flow for every planned flow, at least one impacted node for a non-empty diff, and no edge whose endpoint is missing. The table reports `graph n/i` as total nodes versus impacted nodes. These checks keep the graph connected to real PR analysis while framework-specific adapters are introduced incrementally.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -223,6 +223,10 @@ The draft result is meant to be useful as a PR artifact, not only as generated f
 - `actionSummary`: total required/recommended action counts, ready file count, and the most common action categories
 - `readinessSummary`: an overall 0-100 score, readiness level, self-check counts, starter-code gaps, execution blocker counts, and top blockers
 
+`runnable-candidate` means QAMap found no known blocker to trying the generated file with the detected local command. It is not a claim that the scenario is complete or that the PR is safe to merge. Missing failure coverage, unconfirmed fixture values, and other proof gaps remain visible as required or recommended action items and in the validation matrix. `near-runnable` means the file still has a concrete setup or execution gap; `review-only` means it should be used as design guidance rather than executed as automation.
+
+Playwright self-checks also reject false confidence from `body`-only smoke assertions. When static evidence includes a mockable endpoint, a stable action selector, and visible failure copy, QAMap emits a deterministic 4xx/5xx route, repeats the action, and asserts the failure outcome. When any of those facts are missing, the draft keeps a domain-assertion warning rather than inventing behavior.
+
 See [docs/e2e-output-examples.md](e2e-output-examples.md) for compact examples of web, mobile, API/service, CLI, test-light, and monorepo output.
 
 Generated Playwright drafts use the flow language as `test.step()` names so the file reads like the user journey it protects:

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -1,5 +1,22 @@
 # Release Validation
 
+## 0.4.2 - 2026-07-13
+
+Validated as an automation-readiness honesty patch. Benchmark contracts now fail when QAMap finds a plausible flow but emits a draft that cannot be tried, and generated Playwright failure paths require a repository-observed endpoint, stable action, and visible failure outcome before QAMap writes executable steps:
+
+| Gate | Current result |
+| --- | --- |
+| `pnpm release:check` | Passed end to end |
+| `pnpm test` | 146/146 passing |
+| `pnpm scan` | 0 findings |
+| `pnpm bench:ci` | 12/12 synthetic PR targets pass; readiness, runnable-candidate, self-check, TODO, review-only, and execution-blocker contracts are enforced |
+| Coverage | Lines 87.53%, branches 84.18%, functions 95.22% |
+| Existing Playwright golden | Improved from `needs-work 67` with one blocker to `near-runnable 97`, one runnable candidate, and zero execution blockers |
+| Honest weak-draft handling | Testless checkout and shared-component fixtures remain `needs-work 48` because missing execution facts and body-only assertions are not promoted to runnable evidence |
+| Package preview | `pnpm pack --dry-run` and `npm publish --dry-run --access public` pass for `@ivorycanvas/qamap@0.4.2`; 129 files, 828.8 kB packed |
+
+This patch does not claim that all generated E2E files are green in their target applications. It makes that gap measurable: repository validation guidance no longer masquerades as a generated-file execution blocker, body-only smoke assertions remain warnings, and only evidence-backed failure flows compile into Playwright actions and assertions.
+
 ## 0.4.1 - 2026-07-13
 
 Validated as an evidence-first QA patch. A proposed scenario now exposes the commit or exact base/head diff file, line, symbol, hunk, and direct/supporting/contextual relation that caused it. Removed guards remain visible as base-side critical evidence, contextual-only scenarios cannot become critical, and runner adoption remains an explicit step after review:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -10,8 +10,9 @@ QAMap keeps major and minor changes deliberately rare during `0.x` development.
 - Minor is reserved for a new product-level capability, an incompatible CLI or manifest contract, or a meaningful change to default execution and safety behavior.
 - Risky minor work should ship through `alpha`, `beta`, and `rc` prereleases before the final minor.
 - Do not pre-allocate a minor version to every roadmap phase. Define the next minor release bar and continue compatible work as patches until that bar is met.
+- Do not schedule `0.5.x` by date or implementation count. Continue `0.4.x` patches until external repository evidence shows that static QA design and automation drafts are dependable enough to support a new execution contract.
 
-Version `0.4.0` is earned by the first commit-to-intent-to-scenario vertical slice: behavior-bearing commits and diff symbols become an evidence-backed lifecycle and concrete runner-independent QA, then existing Playwright, Maestro, or manual adapters compile the result. The next minor is reserved for explicit temporary execution and normalized evidence without modifying the target repository.
+Version `0.4.0` is earned by the first commit-to-intent-to-scenario vertical slice: behavior-bearing commits and diff symbols become an evidence-backed lifecycle and concrete runner-independent QA, then existing Playwright, Maestro, or manual adapters compile the result. The next minor remains unscheduled and is reserved for explicit temporary execution and normalized evidence without modifying the target repository. That capability must be proven across unrelated repositories before a `0.5.0` candidate is cut.
 
 Version `1.0.0` requires a stable public contract and external adoption, not implementation volume alone. CLI commands, exit codes, machine output, manifest migration, adapter compatibility, no-LLM/no-upload guarantees, and release operations must be dependable. Repository stars are useful social proof, but repeated use in unrelated repositories and reported QA value are stronger release evidence.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,16 +24,20 @@ Before treating the next public release as ready, the golden demo must satisfy t
 - Generic `primary journey` and `smoke flow` names fail the benchmark when commit and diff evidence can support a concrete lifecycle.
 - Manifest authoring burden stays low: `manifest context` and `manifest init` provide a useful baseline before a human edits YAML.
 - Generated E2E draft is a usable starting point: it has route/screen entry, meaningful actions, assertions, and clear TODOs only where repo data is missing.
+- The public benchmark distinguishes a tryable file from complete PR evidence: golden automation fixtures contract on self-checks, TODOs, execution blockers, and runnable status instead of passing on flow naming alone.
 - Recommendation evidence is explainable: output shows the changed file, manifest flow/check, and manifest path to repair when wrong.
 - README demo shows the full loop: manifest-free PR QA draft, optional repo context baseline, PR mapping, E2E draft, and remaining validation gaps.
 - One manifest correction should improve future PR recommendations without another LLM prompt.
 
 ## Now: 0.4.x
 
+There is no fixed end date or patch count for `0.4.x`. QAMap will remain on compatible patch releases while real repositories still expose material gaps in change intent, affected-flow selection, scenario evidence, or automation-draft quality. `0.5.x` is not the next scheduled milestone; it is a release bar that must be earned by a stable, explicitly approved execution contract and evidence from repeated use outside the maintainer's repositories.
+
 - Stabilize commit-range Change Intent analysis: related behavior commits, diff symbols, confidence, review requirements, lifecycle stages, and runner-independent QA scenarios.
 - Keep `qamap.change-intent` as a direct Behavior Graph adapter while moving more source observations out of the compatibility adapter.
 - Preserve `qa` as the static, read-only product surface while designing explicit execution behind `verify`; never turn a scan into implicit project-code execution.
 - Treat the committed [benchmark contract](benchmarking.md) as the quality gate for recommendations, not only implementation correctness. Reduce real failures into public fixtures and require `pnpm bench:ci` on every PR.
+- Keep execution readiness separate from validation completeness. A draft may be locally runnable while still requiring failure coverage, fixture confirmation, or reviewer approval before it becomes trusted PR evidence.
 - Make `qa` the primary product surface. Its first screen and `--format agent` payload must agree on change intent, lifecycle, QA scenarios, affected behavior, repository evidence, draft path, and missing trust requirements.
 - Improve changed-file impact mapping from shared symbols and components to consuming routes, screens, API contracts, and manifest flows.
 - Keep the [release validation checklist](release-validation.md), [manifest guide](manifest.md), public [E2E output examples](e2e-output-examples.md), and README examples aligned with captured output from the public fixtures.
@@ -42,18 +46,21 @@ Before treating the next public release as ready, the golden demo must satisfy t
 - Improve Playwright and Maestro compilation from intent scenarios while keeping runner choice behind the runner-independent QA contract.
 - Keep `verify`, `e2e`, and `manifest` as deeper layers behind `qa`; freeze new scanner, doctor, eval, domains, flows, and history features until the core QA contract is consistently useful.
 
-## Next
+## Longer-Term Release Bar (No Scheduled 0.5.x Date)
 
 - Move route, screen, endpoint, selector, fixture, test, and contract discovery into analyzer adapters, starting with TypeScript web stacks and reusing one web behavior model across Next.js, React Router, Vue/Nuxt, and SvelteKit.
 - Compare base and head Behavior Graphs, then select impacted graph paths before refining deterministic success, validation, failure, empty, loading, auth, and contract scenarios.
 - Add policy-controlled temporary execution so selected scenarios can produce normalized pass, fail, blocked, and not-verifiable evidence without modifying the target repository.
 - Add an execution benchmark that injects known regressions and requires QAMap to select and fail the relevant scenario without changing the fixture repository.
+- Compile critical success and failure scenarios into concrete runner actions before execution, so a green smoke assertion cannot satisfy a lifecycle or coverage contract by itself.
 - Add symbol-level anchors for exported components, hooks, API clients, handlers, schemas, and queries after the public import-impact fixture stays stable.
 - Add a manifest correction command that proposes the exact flow/anchor patch and applies it only after human approval, avoiding routine hand-edits to YAML.
 - Add stronger deterministic draft adapters for Playwright and Maestro while keeping `manual` output for API, CLI, token, and catalog repositories; runner detection itself is not a product success metric.
 - Expand the public benchmark corpus with package-scoped monorepos, auth/session changes, dynamic routes, API failure fixtures, and non-JavaScript services.
 - Keep the `--format agent` output a stable, versioned contract that skills and MCP wrappers can rely on.
 - Continue expanding agent surface detection across popular coding-agent tools without making the public workflow depend on a single vendor.
+
+These items do not imply that the next completed item triggers a minor release. Analyzer improvements, new deterministic scenarios, stronger adapters, and additional benchmark fixtures continue as `0.4.x` patches when they preserve the public CLI, schema, and safety contracts. A `0.5.0` candidate should be considered only when policy-controlled execution is useful across unrelated repositories, the target repository remains unmodified by default, and normalized evidence is stable enough to document as a new public capability.
 
 ## Later
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ivorycanvas/qamap",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Local zero-LLM PR QA designer that maps commit intent and diffs to traceable behavior lifecycles, QA scenarios, and optional automation drafts.",
   "type": "module",
   "packageManager": "pnpm@10.32.1",

--- a/scripts/bench.mjs
+++ b/scripts/bench.mjs
@@ -174,6 +174,19 @@ function scoreTarget(target, plan, qa, durationMs) {
     mustNameRecall: mustName.length > 0 ? `${named.length}/${mustName.length}` : null,
     mustNameMissing: mustName.filter((name) => !named.includes(name)),
     readiness: `${qa.readiness.level} (${qa.readiness.score})`,
+    readinessLevel: qa.readiness.level,
+    readinessScore: qa.readiness.score,
+    runnableCandidates: qa.readiness.runnableCandidates,
+    nearRunnableFiles: qa.readiness.nearRunnable,
+    reviewOnlyFiles: qa.readiness.reviewOnly,
+    tryableDrafts: qa.readiness.runnableCandidates + qa.readiness.nearRunnable,
+    draftStatuses: qa.flows.map((flow) => flow.runnableStatus ?? "unknown"),
+    selfCheckPass: qa.readiness.selfCheckPass,
+    selfCheckWarning: qa.readiness.selfCheckWarning,
+    selfCheckFail: qa.readiness.selfCheckFail,
+    totalTodos: qa.readiness.totalTodos,
+    totalExecutionBlockers: qa.readiness.totalExecutionBlockers,
+    topBlockers: qa.readiness.topBlockers,
     agentBytes: Buffer.byteLength(formatAgentQaDraft(qa)),
     durationMs,
   };
@@ -301,6 +314,49 @@ function evaluateContract(expect, result, plan, qa) {
   if (expect.maxAgentBytes !== undefined && result.agentBytes > expect.maxAgentBytes) {
     failures.push(`agent payload ${result.agentBytes} bytes exceeds ${expect.maxAgentBytes}`);
   }
+  if (expect.minReadinessScore !== undefined && result.readinessScore < expect.minReadinessScore) {
+    failures.push(`readiness score ${result.readinessScore} is below ${expect.minReadinessScore}`);
+  }
+  if (
+    Array.isArray(expect.allowedReadinessLevels) &&
+    !expect.allowedReadinessLevels.includes(result.readinessLevel)
+  ) {
+    failures.push(
+      `readiness level ${result.readinessLevel} is not one of ${expect.allowedReadinessLevels.join(", ")}`,
+    );
+  }
+  if (expect.minTryableDrafts !== undefined && result.tryableDrafts < expect.minTryableDrafts) {
+    failures.push(`expected at least ${expect.minTryableDrafts} tryable draft(s), got ${result.tryableDrafts}`);
+  }
+  if (
+    expect.minRunnableCandidates !== undefined &&
+    result.runnableCandidates < expect.minRunnableCandidates
+  ) {
+    failures.push(
+      `expected at least ${expect.minRunnableCandidates} runnable candidate(s), got ${result.runnableCandidates}`,
+    );
+  }
+  if (expect.minSelfCheckPass !== undefined && result.selfCheckPass < expect.minSelfCheckPass) {
+    failures.push(`expected at least ${expect.minSelfCheckPass} passing draft self-check(s), got ${result.selfCheckPass}`);
+  }
+  if (expect.maxSelfCheckFail !== undefined && result.selfCheckFail > expect.maxSelfCheckFail) {
+    failures.push(`failed draft self-checks ${result.selfCheckFail} exceed ${expect.maxSelfCheckFail}`);
+  }
+  if (expect.maxReviewOnlyFiles !== undefined && result.reviewOnlyFiles > expect.maxReviewOnlyFiles) {
+    failures.push(`review-only drafts ${result.reviewOnlyFiles} exceed ${expect.maxReviewOnlyFiles}`);
+  }
+  if (expect.maxTodos !== undefined && result.totalTodos > expect.maxTodos) {
+    failures.push(`draft TODO markers ${result.totalTodos} exceed ${expect.maxTodos}`);
+  }
+  if (
+    expect.maxExecutionBlockers !== undefined &&
+    result.totalExecutionBlockers > expect.maxExecutionBlockers
+  ) {
+    const topBlocker = result.topBlockers[0] ? ` Top blocker: ${result.topBlockers[0]}` : "";
+    failures.push(
+      `draft execution blockers ${result.totalExecutionBlockers} exceed ${expect.maxExecutionBlockers}.${topBlocker}`,
+    );
+  }
   return failures;
 }
 
@@ -415,6 +471,8 @@ function printTable(rows) {
     ["genericTitles", 8],
     ["mustReachRecall", 10],
     ["readiness", 18],
+    ["draftReadiness", 11],
+    ["totalExecutionBlockers", 8],
     ["agentBytes", 10],
     ["durationMs", 10],
   ];
@@ -437,6 +495,9 @@ function displayValue(row, key) {
   if (key === "contractPassed") {
     return row.contractPassed ? "PASS" : "FAIL";
   }
+  if (key === "draftReadiness") {
+    return `${row.runnableCandidates ?? 0}/${row.nearRunnableFiles ?? 0}/${row.reviewOnlyFiles ?? 0}`;
+  }
   return row[key] ?? "-";
 }
 
@@ -448,7 +509,7 @@ function printDeltas(baselineRows, currentRows) {
       continue;
     }
     const deltas = [];
-    for (const key of ["flows", "changeIntents", "highConfidenceIntents", "importPropagatedFlows", "diffAnchoredFlows", "manifestFlowMatches", "behaviorNodes", "behaviorImpactedNodes", "manifestBehaviorNodes", "commitBehaviorNodes", "blankActions", "genericTitles", "agentBytes"]) {
+    for (const key of ["flows", "changeIntents", "highConfidenceIntents", "importPropagatedFlows", "diffAnchoredFlows", "manifestFlowMatches", "behaviorNodes", "behaviorImpactedNodes", "manifestBehaviorNodes", "commitBehaviorNodes", "blankActions", "genericTitles", "readinessScore", "tryableDrafts", "totalTodos", "totalExecutionBlockers", "agentBytes"]) {
       const diff = (current[key] ?? 0) - (before[key] ?? 0);
       if (diff !== 0) {
         deltas.push(`${key} ${diff > 0 ? "+" : ""}${diff}`);
@@ -470,6 +531,8 @@ function shortLabel(key) {
     blankActions: "blank",
     genericTitles: "generic",
     mustReachRecall: "reach",
+    draftReadiness: "draft r/n/o",
+    totalExecutionBlockers: "blockers",
     durationMs: "ms",
   };
   return labels[key] ?? key;

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -696,8 +696,8 @@ export async function generateE2eDraft(rootInput: string, options: E2eDraftOptio
     const todoCount = countTodos(content);
     const selfCheck = evaluateDraftSelfCheck(plan, flow, runner, content, todoCount);
     const actionItems = buildDraftActionItems(plan, flow, runner, validationSummary, promotionGuidance, selfCheck);
-    const executionBlockers = draftExecutionBlockers(plan, flow, runner, validationSummary, selfCheck);
-    const runnableStatus = draftRunnableStatus(plan, flow, runner, validationSummary, executionBlockers, selfCheck);
+    const executionBlockers = draftExecutionBlockers(plan, flow, runner, selfCheck);
+    const runnableStatus = draftRunnableStatus(plan, flow, runner, executionBlockers, selfCheck);
     const fileDetails = draftFileDetails(flow);
     if (dryRun) {
       files.push({
@@ -805,7 +805,7 @@ export async function generateE2eDraft(rootInput: string, options: E2eDraftOptio
     files,
     actionSummary,
     readinessSummary: summarizeDraftReadiness(files, actionSummary),
-    nextSteps: buildDraftNextSteps(plan, runner),
+    nextSteps: buildDraftNextSteps(plan, runner, files),
   };
 }
 
@@ -2159,7 +2159,8 @@ function draftNeedsAssertionWork(selfCheck?: E2eDraftSelfCheck): boolean {
   return selfCheck.checks.some(
     (check) =>
       (check.name === "Unresolved placeholders" && check.status !== "pass") ||
-      (check.name === "TODO comments" && check.status !== "pass"),
+      (check.name === "TODO comments" && check.status !== "pass") ||
+      (check.name === "Domain assertions" && check.status !== "pass"),
   );
 }
 
@@ -7304,7 +7305,6 @@ function draftExecutionBlockers(
   plan: E2ePlanResult,
   flow: E2eFlow,
   runner: E2eRunnerName,
-  validationSummary: ReturnType<typeof summarizeDraftValidation>,
   selfCheck?: E2eDraftSelfCheck,
 ): string[] {
   const verificationOnly = isVerificationOnlyFlow(flow);
@@ -7318,13 +7318,8 @@ function draftExecutionBlockers(
   if (!verificationOnly && flow.fixtureReadiness.status === "missing") {
     blockers.push(flow.fixtureReadiness.nextActions[0] ?? flow.fixtureReadiness.reason);
   }
-  if (validationSummary.blockingGapCount > 0) {
-    blockers.push(
-      `${validationSummary.blockingGapCount} blocking validation gap${validationSummary.blockingGapCount === 1 ? "" : "s"} ${
-        validationSummary.blockingGapCount === 1 ? "remains" : "remain"
-      }.`,
-    );
-  }
+  // Missing validation evidence describes the repository before this draft exists.
+  // Keep it as PR guidance, but do not treat it as proof that the generated file cannot execute.
   if (selfCheck?.status === "fail") {
     blockers.push(...selfCheck.blockers);
   }
@@ -7335,7 +7330,6 @@ function draftRunnableStatus(
   plan: E2ePlanResult,
   flow: E2eFlow,
   runner: E2eRunnerName,
-  validationSummary: ReturnType<typeof summarizeDraftValidation>,
   executionBlockers: string[],
   selfCheck?: E2eDraftSelfCheck,
 ): "runnable-candidate" | "near-runnable" | "review-only" {
@@ -7347,9 +7341,8 @@ function draftRunnableStatus(
   }
   if (
     executionBlockers.length === 0 &&
-    validationSummary.blockingGapCount === 0 &&
     flow.missingTestability.length === 0 &&
-    (flow.fixtureReadiness.status === "ready" || flow.fixtureReadiness.status === "not-needed") &&
+    flow.fixtureReadiness.status !== "missing" &&
     selfCheck?.status === "pass"
   ) {
     return "runnable-candidate";
@@ -7430,6 +7423,14 @@ function evaluatePlaywrightDraftSelfCheck(
     todoCount === 0
       ? "No TODO comments remain in the generated draft."
       : `${todoCount} TODO marker${todoCount === 1 ? "" : "s"} remain for reviewer follow-up.`,
+  ));
+  const weakSmokeAssertions = content.match(/expect\(page\.locator\(["']body["']\)\)\.toBeVisible\(\)/g)?.length ?? 0;
+  checks.push(draftSelfCheckItem(
+    "Domain assertions",
+    weakSmokeAssertions === 0 ? "pass" : "warning",
+    weakSmokeAssertions === 0
+      ? "The draft does not rely on body-only smoke assertions."
+      : `${weakSmokeAssertions} body-only smoke assertion${weakSmokeAssertions === 1 ? "" : "s"} must be replaced with observable domain outcomes.`,
   ));
   checks.push(draftSelfCheckItem(
     "Execution profile",
@@ -7856,8 +7857,10 @@ function buildPlaywrightDraft(plan: E2ePlanResult, flow: E2eFlow, addedDiffText:
   for (const step of draftExecutableSteps(flow, "playwright")) {
     const manifestCheck = manifestCheckForDraftStep(flow, step);
     const manifestBody = manifestCheck ? playwrightActionForManifestCheck(manifestCheck, step) : undefined;
-    const selector = manifestBody ? undefined : takeSelectorForStep(selectorQueue, step);
+    const failureBody = manifestBody ? undefined : playwrightFailureActionForStep(flow, step);
+    const selector = manifestBody || failureBody ? undefined : takeSelectorForStep(selectorQueue, step);
     const body = manifestBody ??
+      failureBody ??
       (selector
         ? playwrightActionForStep(selector, playwrightLocator(selector), step)
         : playwrightFallbackActionForStep(step));
@@ -8938,18 +8941,23 @@ function formatDraftActionKindSummary(summary: E2eDraftActionKindSummary[]): str
     .join(", ");
 }
 
-function buildDraftNextSteps(plan: E2ePlanResult, runner: E2eRunnerName): string[] {
+function buildDraftNextSteps(plan: E2ePlanResult, runner: E2eRunnerName, files: E2eDraftFile[]): string[] {
   const steps: string[] = [];
+  const hasTodos = files.some((file) => (file.todoCount ?? 0) > 0);
   if (runner === "maestro") {
     steps.push(plan.executionProfile.appId
       ? `Use app id ${plan.executionProfile.appId} or export APP_ID before running Maestro.`
       : "Replace ${APP_ID} or export APP_ID before running Maestro.");
-    steps.push("Replace TODO text selectors with visible copy, testID, or accessibilityLabel selectors.");
+    if (hasTodos) {
+      steps.push("Replace TODO text selectors with visible copy, testID, or accessibilityLabel selectors.");
+    }
     steps.push(plan.executionProfile.startCommand
       ? `Launch the app with \`${plan.executionProfile.startCommand}\`, then run \`${plan.executionProfile.testCommand ?? "maestro test .maestro"}\`.`
       : `Run the app with the launch command that matches your simulator or device, then run \`${plan.executionProfile.testCommand ?? "maestro test .maestro"}\`.`);
   } else if (runner === "playwright") {
-    steps.push("Replace TODO locators with role, text, or data-testid locators from the app.");
+    if (hasTodos) {
+      steps.push("Replace TODO locators with role, text, or data-testid locators from the app.");
+    }
     if (plan.executionProfile.blockers.some((blocker) => /No Playwright config/i.test(blocker))) {
       steps.push(playwrightConfigGuidance(plan.executionProfile));
     }
@@ -9263,6 +9271,65 @@ function playwrightActionForStep(selector: E2eSelector, locator: string, step: s
   }
   body.push(`await ${locator}.click();`);
   return body;
+}
+
+function playwrightFailureActionForStep(flow: E2eFlow, step: string): string[] | undefined {
+  if (!isFailurePathStep(step)) {
+    return undefined;
+  }
+  const endpoint = playwrightFailureMockEndpoint(flow);
+  const actionSelector = flow.selectors.find(
+    (selector) => !isInputSelector(selector) && selectorCanDriveInteraction(selector),
+  );
+  const outcomeSelector = flow.selectors.find(
+    (selector) => selectorCanSupportAssertion(selector) && isFailureOutcomeText(selector.value),
+  );
+  if (!endpoint || !actionSelector || !outcomeSelector) {
+    return undefined;
+  }
+
+  const routePattern = playwrightMockRoutePattern(endpoint);
+  const status = failureResponseStatus(step);
+  return [
+    `// Step intent: ${step}`,
+    `await page.unroute("${quoteJs(routePattern)}");`,
+    `await page.route("${quoteJs(routePattern)}", async (route) => {`,
+    "  await route.fulfill({",
+    `    status: ${status},`,
+    '    contentType: "application/json",',
+    '    body: JSON.stringify({ error: "QAMap simulated failure" }),',
+    "  });",
+    "});",
+    `await ${playwrightLocator(actionSelector)}.click();`,
+    `await expect(${playwrightLocator(outcomeSelector)}).toBeVisible();`,
+  ];
+}
+
+function playwrightFailureMockEndpoint(flow: E2eFlow): string | undefined {
+  const observedEndpoints = observedEndpointsForFlow(flow);
+  return flow.fixtureReadiness.apiEndpoints.find(
+    (endpoint) => !endpointMatchesAny(endpoint, observedEndpoints),
+  );
+}
+
+function isFailurePathStep(step: string): boolean {
+  return /\b(?:blocked|declined|denied|empty|error|failed|failure|invalid|rejected|timeout|unauthori[sz]ed)\b/i.test(step) ||
+    /(?:오류|실패|거절|권한|잘못|할 수 없)/.test(step);
+}
+
+function isFailureOutcomeText(value: string): boolean {
+  return /\b(?:cannot|could not|declined|denied|error|failed|failure|invalid|rejected|try again|unauthori[sz]ed|unavailable)\b/i.test(value) ||
+    /(?:오류|실패|거절|권한|잘못|할 수 없)/.test(value);
+}
+
+function failureResponseStatus(step: string): number {
+  if (/\b(?:denied|unauthori[sz]ed)\b/i.test(step) || /권한/.test(step)) {
+    return 401;
+  }
+  if (/\b(?:invalid|validation)\b/i.test(step) || /잘못/.test(step)) {
+    return 422;
+  }
+  return 500;
 }
 
 interface ManifestSelectorHint {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const TOOL_NAME = "QAMap";
-export const VERSION = "0.4.1";
+export const VERSION = "0.4.2";

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -2624,12 +2624,21 @@ test("fixture guidance names the mock handler file to extend and shapes mock pay
   await writeFile(
     path.join(root, "src/pages/billing/BillingPage.tsx"),
     [
+      'import { useState } from "react";',
       "export async function loadBilling() {",
-      "  const invoices = await fetch('/api/invoices');",
-      "  const summary = await fetch('/api/payments/summary');",
-      "  return { invoices: await invoices.json(), summary: await summary.json() };",
+      "  return Promise.all([fetch('/api/invoices'), fetch('/api/payments/summary')]);",
       "}",
-      "export function BillingPage() { return <button data-testid=\"open-billing\">Open billing</button>; }",
+      "export function BillingPage() {",
+      '  const [status, setStatus] = useState("");',
+      "  async function openBilling() {",
+      "    const [invoices, summary] = await loadBilling();",
+      '    setStatus(invoices.ok && summary.ok ? "Billing loaded" : "Could not load billing");',
+      "  }",
+      "  return <main>",
+      '    <button data-testid="open-billing" onClick={openBilling}>Open billing</button>',
+      "    <p role=\"status\">{status}</p>",
+      "  </main>;",
+      "}",
     ].join("\n"),
   );
   await git(root, ["add", "."]);
@@ -2665,6 +2674,14 @@ test("fixture guidance names the mock handler file to extend and shapes mock pay
   assert.match(spec, /total: "qamap-total"/);
   assert.match(spec, /Response shape keys reuse src\/mocks\/handlers\.ts/);
   assert.doesNotMatch(spec, /source: "qamap-draft"/);
+  assert.match(spec, /page\.unroute\("\*\*\/api\/(?:invoices|payments\/summary)"\)/);
+  assert.match(spec, /status: 500/);
+  assert.match(spec, /expect\(page\.getByText\("Could not load billing"\)\)\.toBeVisible\(\)/);
+  assert.doesNotMatch(spec, /page\.locator\("body"\)/);
+  assert.equal(
+    draftFile.selfCheck?.checks.find((check) => check.name === "Domain assertions")?.status,
+    "pass",
+  );
 });
 
 test("generateE2ePlan builds a bootstrap plan for projects without tests", async () => {
@@ -3038,13 +3055,21 @@ test("generateE2ePlan captures Playwright execution profile and self-check block
   assert.match(markdown, /Start command: `pnpm run dev`/);
   assert.match(markdown, /Base URL: `http:\/\/127\.0\.0\.1:4173`/);
   assert.equal(draftFile.runnableStatus, "near-runnable");
-  assert.equal(draftFile.selfCheck?.status, "pass");
+  assert.equal(draftFile.selfCheck?.status, "warning");
+  assert.equal(
+    draftFile.selfCheck?.checks.find((check) => check.name === "Domain assertions")?.status,
+    "warning",
+  );
   assert.equal(draftFile.selfCheck?.blockers.some((blocker) => /Unresolved placeholders/.test(blocker)), false);
   assert.equal(draft.readinessSummary.nearRunnable > 0, true);
-  assert.equal(draft.readinessSummary.selfCheckPass > 0, true);
+  assert.equal(draft.readinessSummary.selfCheckWarning > 0, true);
   assert.equal(draft.readinessSummary.topBlockers.some((blocker) => /Unresolved placeholders/.test(blocker)), false);
   assert.deepEqual(draftFile.executionBlockers?.filter((blocker) => /Playwright|baseURL|start command/i.test(blocker)), []);
-  assert.match(formatMarkdownE2eDraft(draft), /near-runnable/);
+  assert.equal((draftFile.blockingValidationGapCount ?? 0) > 0, true);
+  assert.deepEqual(draftFile.executionBlockers?.filter((blocker) => /validation gap/i.test(blocker)), []);
+  assert.match(formatMarkdownE2eDraft(draft), /Near-runnable files: 1/);
+  assert.match(formatMarkdownE2eDraft(draft), /Replace starter smoke assertions with domain assertions/);
+  assert.doesNotMatch(formatMarkdownE2eDraft(draft), /Replace TODO locators/);
   assert.match(formatMarkdownE2eDraft(draft), /## Draft Self Checks/);
   assert.match(formatMarkdownE2eDraft(draft), /Stage: [a-z ]+ \(\d of 4\) — readiness \d+\/100/);
   assert.match(spec, /Execution profile:/);
@@ -3378,7 +3403,8 @@ test("generateE2eDraft emits runnable Playwright role and input actions", async 
   assert.match(spec, /role-link: View history/);
   assert.equal(draftFile.selfCheck?.status, "pass");
   assert.equal(draftFile.selfCheck?.summary, "Playwright draft passed static runner checks.");
-  assert.equal(draft.readinessSummary.nearRunnable, 1);
+  assert.equal(draftFile.runnableStatus, "runnable-candidate");
+  assert.equal(draft.readinessSummary.runnableCandidates, 1);
   assert.equal(draft.readinessSummary.selfCheckPass, 1);
   assert.equal(draft.readinessSummary.totalTodos, 0);
   assert.match(formatMarkdownE2eDraft(draft), /Draft Self Checks/);


### PR DESCRIPTION
## Intent

Make automation readiness a measurable release contract instead of treating every generated draft as equally usable. The benchmark now records readiness levels, runnable candidates, self-check results, TODOs, review-only files, and execution blockers. Playwright failure paths compile only when the repository exposes a mockable endpoint, a stable action, and an observable failure outcome.

This PR also prepares `0.4.2` and clarifies that `0.5.x` remains an unscheduled release bar rather than the next automatic milestone.

## Agent / Review Risk

The change touches Playwright draft generation and readiness scoring. The compiler remains conservative: it does not mock changed backend endpoints, invent selectors, or promote body-only smoke assertions to runnable evidence. Existing machine schemas and static-command safety behavior are unchanged.

## Validation Evidence

- [x] `pnpm test`
- [x] `pnpm scan`
- [x] Relevant `qamap verify`, `qamap test-plan`, or `qamap e2e plan/draft` output reviewed.

`pnpm release:check` passed end to end: 146/146 tests, 0 scan findings, 12/12 benchmark contracts, lines 87.53%, branches 84.18%, functions 95.22%, and package preview success. `npm publish --dry-run --access public` also passed for `@ivorycanvas/qamap@0.4.2` with 129 files (828.8 kB).

## E2E / Manual Coverage

- Existing Playwright orders fixture: `needs-work 67` with one blocker -> `near-runnable 97`, one runnable candidate, zero execution blockers.
- Testless checkout and shared-component fixtures remain honestly classified as `needs-work 48` when execution facts or observable outcomes are missing.
- All 12 synthetic PR fixtures pass the expanded readiness contract.

## Maintainer Notes

This is a compatible patch release. It improves deterministic analysis, draft compilation, benchmarks, and documentation without adding a new public execution contract.

## Collaboration Checklist

- [x] The branch uses an allowed prefix and contains no coding-agent product name.
- [x] The PR title follows `Type: imperative summary`.
- [x] `@ivory-code` is assigned, or assignment is left for a maintainer when permissions do not allow it.
- [x] Exactly one `type:` label and only relevant `area:` labels are applied.
- [x] The PR is intended to be squash-merged after required checks pass.