### PR TITLE
Fix: ground first-run QA in changed behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+## 0.4.4 - 2026-07-15
+
+### Added
+
+- Added conservative diff-only change intent for committed branches whose commit text does not express a usable behavior intent. Connected trigger, state, side-effect, and observable outcome evidence remains review-required instead of being discarded.
+- Added framework-neutral conditional-state extraction for React and Vue changes, including changed actions, conditional outcomes, destination parameters, and Unicode selector terms.
+- Added public React and Vue conditional-state benchmarks plus a presentation-only negative control. Benchmark contracts can now reject QA scenarios that must not be inferred.
+- Added a tested `skills` CLI installation path for the packaged `qamap-pr-qa` project skill.
+
+### Changed
+
+- Agent output now stays below 4KB and preserves at least the highest-priority intent, routed scenarios, affected flow, source, and omitted counts when compacted.
+- Low-confidence diff-only scenarios remain recommendations until stronger intent evidence promotes them; they no longer become required automation blockers merely because a diff hunk has a location.
+- One-off skill commands use an explicit npm execution environment so they do not invoke Corepack or rewrite a target repository's package-manager metadata.
+- Selector fallback now prefers diff-added, step-related controls and observable copy. Generic exploratory checks remain coverage guidance instead of executable happy-path steps.
+
+### Fixed
+
+- Generated drafts no longer pass by asserting only the document body or by reusing the clicked control as proof of success. Missing outcomes produce an explicit review-only `test.fixme` marker.
+- Generic UI copy such as `Request access`, `Open billing`, or an existing `subscription` symbol no longer fabricates network, external-entry, or payment setup without supporting diff evidence.
+- Vue templates, computed labels, React handlers, multiline visible text, and exact token overlap now produce more stable action and outcome selectors.
+- Risk-specific scenarios are ranked ahead of generic conditional-state suggestions, so calendar, routing, and network failure checks are not silently dropped by the scenario cap.
+
 ## 0.4.3 - 2026-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **A local, zero-LLM PR QA designer. QAMap turns commit intent and code diffs into evidence-backed behavior lifecycles, missing QA, and deterministic automation drafts. No cloud. No source upload. No token.**
 
-QAMap reads commit subjects and bodies, git changes, project structure, selectors, existing tests, and optional repo QA memory, then answers the question every reviewer asks: *"What behavior did this PR intend to change, how does that behavior move through the product, and what should we verify before merge?"* Playwright, Maestro, and manual checklists are output adapters after that judgment, not the product recommendation itself.
+QAMap reads commit subjects and bodies, git changes, project structure, selectors, existing tests, and optional repo QA memory, then answers the question every reviewer asks: *"What behavior did this PR intend to change, how does that behavior move through the product, and what should we verify before merge?"* When commit text is not descriptive, connected diff evidence can still produce a conservative, review-required intent. Playwright, Maestro, and manual checklists are output adapters after that judgment, not the product recommendation itself.
 
 ```txt
 PR commits + diff
@@ -25,7 +25,7 @@ Optional team memory (.qamap/manifest.yaml)
 Run one read-only command on a branch. A manifest and test runner are not required:
 
 ```sh
-pnpm dlx @ivorycanvas/qamap qa . --base origin/main --head HEAD
+npx --yes @ivorycanvas/qamap@latest qa . --base origin/main --head HEAD
 ```
 
 The report starts with the inferred behavior and keeps each proposed scenario connected to the commit or exact base/head diff line that caused it. Removed guards and validation remain visible as base-side evidence; each source is labeled `direct`, `supporting`, or `contextual`. QAMap then shows two separate receipts: why the scenario was routed as `required`, `recommended`, or `review-only`, and whether the E2E adapter compiled it fully, partially, or not at all (trimmed from the committed lifecycle benchmark):
@@ -59,9 +59,9 @@ Optional automation:
 Requires Node.js 20 or newer. Inside a repository whose default branch is `origin/main` (or `main`), the base is inferred automatically:
 
 ```sh
-pnpm dlx @ivorycanvas/qamap qa            # what should this branch prove before merge?
-pnpm dlx @ivorycanvas/qamap qa --format agent   # compact evidence for a coding agent or PR workflow
-pnpm dlx @ivorycanvas/qamap manifest init # optional: save reviewed team QA memory for sharper future runs
+npx --yes @ivorycanvas/qamap@latest qa            # what should this branch prove before merge?
+npx --yes @ivorycanvas/qamap@latest qa --format agent   # compact evidence for a coding agent or PR workflow
+npx --yes @ivorycanvas/qamap@latest manifest init # optional: save reviewed team QA memory for sharper future runs
 ```
 
 Pass `--base <ref> --head <ref>` for anything non-standard. Run bare `qamap` for a start-here guide, `qamap help` for the full reference, and see the [command reference](docs/commands.md) for every command and output shape.
@@ -76,7 +76,15 @@ Stop re-explaining the same QA context to your agent on every PR:
 qamap qa --format agent
 ```
 
-One minified JSON object (`schema: qamap.qa`) with change intents, lifecycle stages, QA scenarios, structured diff sources, affected flows, and required evidence. The complete line stays at or below 8KB; total and omitted intent/flow counts remain visible when lower-priority detail is compacted. It carries the decision content of the full report at a fraction of the context cost. The shape is a documented, versioned contract: [agent format contract](docs/agent-format.md). To make agents run this themselves, run `qamap init --agent` once: it adds a Pre-PR QA section to `AGENTS.md` and installs the packaged skill ([skills/qamap-pr-qa/SKILL.md](skills/qamap-pr-qa/SKILL.md)) into `.claude/skills/`. Details: [agent skill guide](docs/agent-skill.md).
+One minified JSON object (`schema: qamap.qa`) with change intents, lifecycle stages, QA scenarios, structured diff sources, affected flows, and required evidence. The complete line stays below 4KB; compacted payloads retain the highest-priority intent, scenarios, affected flow, and omitted counts instead of collapsing to an empty summary. It carries the decision content of the full report at a fraction of the context cost. The shape is a documented, versioned contract: [agent format contract](docs/agent-format.md).
+
+To make agents run this themselves, run `qamap init --agent` once, or install the portable project skill through the `skills` CLI:
+
+```sh
+npx --yes skills add IvoryCanvas/qamap --skill qamap-pr-qa
+```
+
+The built-in setup adds a Pre-PR QA section to `AGENTS.md` and installs the packaged skill ([skills/qamap-pr-qa/SKILL.md](skills/qamap-pr-qa/SKILL.md)) into the supported project skill directory. Details: [agent skill guide](docs/agent-skill.md).
 
 ## Why QAMap
 
@@ -96,7 +104,7 @@ QAMap는 PR을 리뷰하기 전에 로컬에서 실행하는 zero-LLM QA 설계 
 PR 커밋 의도와 diff, repo 구조를 읽고 변경 의도, 기능 생명주기, 정상·실패·경계·상태 전환 QA, 부족한 fixture/selector/assertion 근거를 정리합니다. 그 다음 기존 테스트 환경에 맞춰 Playwright, Maestro 또는 수동 체크리스트 초안을 제시합니다. 클라우드나 LLM 토큰을 쓰지 않습니다.
 
 ```sh
-pnpm dlx @ivorycanvas/qamap qa . --base origin/main --head HEAD
+npx --yes @ivorycanvas/qamap@latest qa . --base origin/main --head HEAD
 ```
 
 에이전트에게 넘길 때는 `--format agent`를 붙이면 같은 판단 내용을 압축된 JSON으로 받을 수 있어, 매 세션 repo 탐색에 토큰을 반복해서 쓰지 않아도 됩니다.

--- a/bench.config.json
+++ b/bench.config.json
@@ -74,6 +74,64 @@
       }
     },
     {
+      "name": "web-vue-document-state",
+      "fixture": "test/benchmarks/web-vue-document-state",
+      "commitMessage": "feat: import document and show completion state",
+      "expect": {
+        "runner": "playwright",
+        "minFlows": 1,
+        "minChangeIntents": 1,
+        "minDiffAnchoredFlows": 1,
+        "mustReachFiles": ["src/pages/documents.vue"],
+        "mustNameFlows": ["import document"],
+        "mustIncludeLifecycle": ["trigger start import", "document imported"],
+        "mustIncludeQaScenarios": ["Changed conditional state and fallback", "Destination path and query parameters"],
+        "mustFindEntrypoints": ["/documents"],
+        "mustFindSelectors": ["Import document", "Document imported"],
+        "mustFindSuccessSignals": ["Document imported"],
+        "mustNotFindEvidence": ["Payment sandbox", "Network response setup"],
+        "maxBlankActions": 0,
+        "maxGenericTitles": 0,
+        "maxAgentBytes": 8192
+      }
+    },
+    {
+      "name": "web-react-notification-state",
+      "fixture": "test/benchmarks/web-react-notification-state",
+      "commitMessage": "feat: send notification and show queued state",
+      "expect": {
+        "runner": "playwright",
+        "minFlows": 1,
+        "minChangeIntents": 1,
+        "minDiffAnchoredFlows": 1,
+        "mustReachFiles": ["src/pages/notifications.tsx"],
+        "mustNameFlows": ["send notification"],
+        "mustIncludeLifecycle": ["trigger send notification", "notification queued"],
+        "mustIncludeQaScenarios": ["Changed conditional state and fallback"],
+        "mustFindEntrypoints": ["/notifications"],
+        "mustFindSelectors": ["Send notification", "Notification queued"],
+        "mustFindSuccessSignals": ["Notification queued"],
+        "maxBlankActions": 0,
+        "maxGenericTitles": 0,
+        "maxAgentBytes": 8192
+      }
+    },
+    {
+      "name": "web-react-presentation-control",
+      "fixture": "test/benchmarks/web-react-presentation-control",
+      "commitMessage": "fix: preserve banner theme contrast",
+      "expect": {
+        "runner": "playwright",
+        "minFlows": 1,
+        "minChangeIntents": 1,
+        "mustReachFiles": ["src/components/Banner.tsx"],
+        "mustNotIncludeQaScenarios": ["Changed conditional state and fallback"],
+        "maxBlankActions": 0,
+        "maxGenericTitles": 0,
+        "maxAgentBytes": 8192
+      }
+    },
+    {
       "name": "web-sveltekit-settings",
       "fixture": "test/benchmarks/web-sveltekit-settings",
       "expect": {
@@ -230,14 +288,13 @@
           "src/pages/checkout/index.tsx"
         ],
         "mustNameFlows": ["checkout"],
-        "mustFindSelectors": ["checkout-submit"],
+        "mustFindSelectors": ["checkout-submit", "Place order"],
         "maxBlankActions": 0,
         "maxGenericTitles": 0,
-        "minTryableDrafts": 1,
-        "maxSelfCheckFail": 0,
-        "maxReviewOnlyFiles": 0,
+        "maxSelfCheckFail": 1,
+        "maxReviewOnlyFiles": 1,
         "maxTodos": 0,
-        "maxExecutionBlockers": 2,
+        "maxExecutionBlockers": 3,
         "maxAgentBytes": 4096
       }
     },

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -7,26 +7,26 @@ QAMap works best when teams treat it as the local QA design pass for any PR, not
 Start with the PR QA draft on a changed branch — no manifest, no config:
 
 ```sh
-pnpm dlx @ivorycanvas/qamap qa . --base origin/main --head HEAD
+npx --yes @ivorycanvas/qamap@latest qa . --base origin/main --head HEAD
 ```
 
 For coding agents, request the compact machine-readable summary instead:
 
 ```sh
-pnpm dlx @ivorycanvas/qamap qa . --base origin/main --head HEAD --format agent
+npx --yes @ivorycanvas/qamap@latest qa . --base origin/main --head HEAD --format agent
 ```
 
 First confirm the inferred commit intent, lifecycle, confidence, and runner-independent QA scenarios. When that judgment looks useful, preview and then write the adapter-specific draft files:
 
 ```sh
-pnpm dlx @ivorycanvas/qamap e2e draft . --base origin/main --head HEAD --dry-run
-pnpm dlx @ivorycanvas/qamap e2e draft . --base origin/main --head HEAD
+npx --yes @ivorycanvas/qamap@latest e2e draft . --base origin/main --head HEAD --dry-run
+npx --yes @ivorycanvas/qamap@latest e2e draft . --base origin/main --head HEAD
 ```
 
 For a combined PR verification report with readiness gates, add `verify`:
 
 ```sh
-pnpm dlx @ivorycanvas/qamap verify . --base origin/main --head HEAD --pr-body-file pr-body.md
+npx --yes @ivorycanvas/qamap@latest verify . --base origin/main --head HEAD --pr-body-file pr-body.md
 ```
 
 When developing QAMap itself from source:

--- a/docs/agent-format.md
+++ b/docs/agent-format.md
@@ -1,6 +1,6 @@
 # Agent Format Contract
 
-`qamap qa --format agent` prints one compact line of JSON designed to be pasted into a coding agent's context instead of the full markdown report. The complete line is capped at 8KB. When the uncapped result would be larger, QAMap preserves the strongest evidence and reports total and omitted counts instead of silently overflowing the context budget. This page is the contract for that output: what the fields mean, what an agent may rely on, and how the format is allowed to change.
+`qamap qa --format agent` prints one compact line of JSON designed to be pasted into a coding agent's context instead of the full markdown report. The complete line stays below 4KB. When the uncapped result would be larger, QAMap preserves the strongest intent, routed scenarios, affected flow, and total/omitted counts instead of silently overflowing the context budget. This page is the contract for that output: what the fields mean, what an agent may rely on, and how the format is allowed to change.
 
 ```sh
 qamap qa . --base origin/main --head HEAD --format agent
@@ -44,7 +44,7 @@ The intended loop for a coding agent:
 | `automation` | object? | Explicitly optional adapter handoff: `optIn`, `adapter`, `setupStatus`, `draftCommand`, and optional `setupCommand`. Use it only after the QA scenario is accepted. |
 | `flowCount`, `omittedFlowCount` | number | Total affected flows and the count omitted from the compact payload. |
 | `flows` | array | Affected user flows, most relevant first (capped). Each has `title`, `source`, backward-compatible `draft`, optional `runnable`, `entry`, and `verificationMode`, plus `changedFiles`, `reviewQuestion`, `successSignal`, `steps`, `selectors`, short `evidence` reasons, and compact `scenarioAutomation` entries (`id`, `decision`, `status`). Test-only changes expose `existingEvidence`; configuration, docs, generated artifacts, and changed tests use `verificationMode`. |
-| `compaction` | object | Present only when lower-priority detail was reduced to keep the complete line within 8KB. Carries `maxBytes` and the uncapped `originalBytes`. |
+| `compaction` | object | Present only when lower-priority detail was reduced to keep the complete line below 4KB. Carries `maxBytes`, the uncapped `originalBytes`, and `lean: true` when the smallest evidence-preserving shape was used. |
 | `requiredEvidence` | array | Required-priority QA evidence still missing, capped at 8: `flow`, `kind`, `title`. |
 | `recommendedEvidenceCount` | number | How many recommended-priority items were omitted; run without `--format agent` to see them. |
 | `requiredBootstrap` | array | Non-runner repository context steps (capped at 3): `title`, `action`. Runner setup is represented only under `automation`. |

--- a/docs/agent-skill.md
+++ b/docs/agent-skill.md
@@ -29,10 +29,10 @@ After that, agents that read `AGENTS.md` or project skills will run the QA pass 
 Run this before writing a PR body or asking for review. Agents should prefer the compact agent format — one minified JSON object (about 2 KB for a typical small PR) instead of a long report:
 
 ```sh
-pnpm dlx @ivorycanvas/qamap qa . --base origin/main --head HEAD --format agent
+npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@latest -- qamap qa . --base origin/main --head HEAD --format agent
 ```
 
-The result carries `intents[]` with scenario-level structured diff `sources`, `flows[]` (affected behavior, entry route, steps, selectors), `requiredEvidence[]`, optional `automation`, `prChecklist[]`, and `commands[]` under `schema: qamap.qa`.
+The result carries `intents[]` with scenario-level structured diff `sources`, `flows[]` (affected behavior, entry route, steps, selectors), `requiredEvidence[]`, optional `automation`, `prChecklist[]`, and `commands[]` under `schema: qamap.qa`. The one-off command uses npm directly so an agent does not trigger Corepack or rewrite the target repository's `packageManager` metadata.
 
 For a human-readable report, drop the flag; for installed projects write it to a file:
 
@@ -49,6 +49,14 @@ QAMap ships a portable skill template at:
 ```txt
 skills/qamap-pr-qa/SKILL.md
 ```
+
+Install it as a project skill with the `skills` CLI:
+
+```sh
+npx --yes skills add IvoryCanvas/qamap --skill qamap-pr-qa
+```
+
+This path is useful when a team already manages reusable agent skills through `skills-lock.json`. QAMap also keeps `qamap init --agent` for repositories that want the `AGENTS.md`, config, and packaged-skill setup in one idempotent command.
 
 Use it when an agent surface supports local skill folders, instruction folders, or reusable workflow prompts. The template is intentionally vendor-neutral: it tells an agent when to run `qamap qa`, how to pick a base branch, what sections to copy into the PR, and when to suggest manifest repair.
 
@@ -91,7 +99,7 @@ Then edit `.qamap/manifest.yaml` so future branches can reuse the corrected team
 
 ```txt
 Before finalizing a PR, run:
-pnpm dlx @ivorycanvas/qamap qa . --base origin/main --head HEAD --format agent
+npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@latest -- qamap qa . --base origin/main --head HEAD --format agent
 
 Paste the affected flow, suggested E2E/checklist, missing evidence, and PR checklist into the PR body or review note.
 If the recommendation is wrong, ask the maintainer which manifest domain, flow, anchor, or check should be corrected.

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -15,6 +15,8 @@ The command fails when any target violates its declared expectations. The initia
 - a web app with no tests;
 - a web app with Playwright and an existing mock handler;
 - Vue and SvelteKit web changes with framework-native route files;
+- equivalent React and Vue conditional-state changes that must recover a changed action and observable outcome despite different syntax;
+- a presentation-only React condition that must not create behavioral state-transition QA;
 - a web preferences change that must become submit, persistence, request-failure, and re-entry QA instead of a generic journey;
 - a mobile reminder change that must become scheduling, calendar, duplicate, resynchronization, and entry-routing QA;
 - an Expo app with Maestro;
@@ -47,6 +49,7 @@ Each target can declare:
 | `mustNotNameIntents` | Misleading terms that must not appear in inferred intent titles. |
 | `mustIncludeLifecycle` | Trigger, condition, action, state, effect, or outcome terms that must survive in the ordered lifecycle. |
 | `mustIncludeQaScenarios` | Failure, boundary, state-transition, or primary QA terms that must be proposed before runner compilation. |
+| `mustNotIncludeQaScenarios` | QA scenario terms that would be false positives for the fixture and must not be proposed. |
 | `mustFindIntentEvidence` | Commit or diff terms that must remain attached to intent provenance. |
 | `mustTraceScenarioFiles` | Changed files that must appear in at least one scenario's exact direct/supporting base- or head-side diff source. |
 | `maxUntracedCriticalScenarios` | Maximum critical scenarios without a direct/supporting diff source carrying a file and line number. Contextual commit evidence cannot satisfy this contract; lifecycle fixtures keep it at zero. |
@@ -68,7 +71,7 @@ Each target can declare:
 | `mustRecommendCommands` | Commands the setup or validation path must expose. |
 | `maxBlankActions` | Maximum malformed or empty draft steps; public fixtures keep this at zero. |
 | `maxGenericTitles` | Maximum titles ending in generic `primary journey` or `smoke flow` wording. |
-| `maxAgentBytes` | Maximum UTF-8 payload size for `qa --format agent`. Production output also has a global 8KB ceiling and discloses omitted intent/flow counts. |
+| `maxAgentBytes` | Maximum UTF-8 payload size for `qa --format agent`. Production output has a global 4KB ceiling and preserves the highest-priority retained intent/flow plus omitted counts. |
 | `minReadinessScore` | Minimum aggregate draft-readiness score after self-check, TODO, required-action, and execution-blocker penalties. |
 | `allowedReadinessLevels` | Accepted aggregate levels: `ready`, `near-runnable`, `needs-work`, or `blocked`. Use this to prevent a semantically plausible but unusable draft from satisfying the contract. |
 | `minTryableDrafts` | Minimum files classified as `runnable-candidate` or `near-runnable`. |
@@ -107,5 +110,7 @@ When a real repository produces a poor recommendation:
 4. Fix the inference and keep the fixture as permanent regression evidence.
 
 Any new production heuristic must be exercised by at least two unrelated positive domains and one negative or false-positive control. Domain vocabulary belongs in synthetic fixtures, not in shared inference rules.
+
+Cross-framework fixtures are semantic controls, not a claim that QAMap has separate product logic for each UI library. The same user-visible change is expressed through different syntax so a shared inference rule must survive both, while the negative control proves that merely seeing a condition is not enough to invent QA. Because every fixture is small, public, and deterministic, a regression can be reproduced without private source, network services, or a working application environment.
 
 Do not copy repository names, proprietary code, domain language, file paths, credentials, production data, or raw smoke output into a public fixture. Reduce the behavior to neutral synthetic vocabulary and keep private diagnostics outside the repository.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -17,7 +17,7 @@ pnpm exec qamap manifest explain . --base origin/main --head HEAD
 pnpm exec qamap e2e draft . --base origin/main --head HEAD --dry-run
 ```
 
-Use `pnpm dlx @ivorycanvas/qamap ...` for one-off runs without installing QAMap into the target repository.
+Use `npx --yes @ivorycanvas/qamap@latest ...` for one-off human runs without installing QAMap into the target repository. Packaged agent skills use an explicit `npm exec --package` form so they do not invoke the target repository's package manager or Corepack metadata flow.
 
 ## Reading The Output
 

--- a/docs/e2e-output-examples.md
+++ b/docs/e2e-output-examples.md
@@ -7,7 +7,7 @@ These examples show the shape of QAMap output that should be good enough for the
 First contact should work without a manifest:
 
 ```sh
-pnpm dlx @ivorycanvas/qamap qa . --base origin/main --head HEAD
+npx --yes @ivorycanvas/qamap@latest qa . --base origin/main --head HEAD
 ```
 
 The output should be specific enough to paste into a PR comment. This excerpt uses the committed web preferences lifecycle benchmark; it deliberately keeps the current compiler gaps visible:

--- a/docs/quickstart-demo.md
+++ b/docs/quickstart-demo.md
@@ -24,7 +24,7 @@ The reviewer wants to know:
 Run QAMap on the branch:
 
 ```sh
-pnpm dlx @ivorycanvas/qamap qa . --base origin/main --head HEAD
+npx --yes @ivorycanvas/qamap@latest qa . --base origin/main --head HEAD
 ```
 
 `qa` is important for first contact. It lets maintainers review change intent, behavior lifecycle, scenario confidence, exact diff sources, and a PR checklist without writing files or selecting a test runner.
@@ -32,24 +32,24 @@ pnpm dlx @ivorycanvas/qamap qa . --base origin/main --head HEAD
 After the team accepts a scenario and wants executable coverage:
 
 ```sh
-pnpm dlx @ivorycanvas/qamap e2e draft . --base origin/main --head HEAD --dry-run
-pnpm dlx @ivorycanvas/qamap e2e draft . --base origin/main --head HEAD
+npx --yes @ivorycanvas/qamap@latest e2e draft . --base origin/main --head HEAD --dry-run
+npx --yes @ivorycanvas/qamap@latest e2e draft . --base origin/main --head HEAD
 ```
 
 For a repository adopting QAMap as team QA memory, start with the manifest loop:
 
 ```sh
-pnpm dlx @ivorycanvas/qamap manifest context .
-pnpm dlx @ivorycanvas/qamap manifest init .
-pnpm dlx @ivorycanvas/qamap manifest validate .
-pnpm dlx @ivorycanvas/qamap manifest explain . --base origin/main --head HEAD
+npx --yes @ivorycanvas/qamap@latest manifest context .
+npx --yes @ivorycanvas/qamap@latest manifest init .
+npx --yes @ivorycanvas/qamap@latest manifest validate .
+npx --yes @ivorycanvas/qamap@latest manifest explain . --base origin/main --head HEAD
 ```
 
 For a read-only smoke test against a repository you do not want to modify, keep the manifest outside the repo and pass it back into the PR commands:
 
 ```sh
-pnpm dlx @ivorycanvas/qamap manifest init . --write /tmp/qamap-manifest.yaml
-pnpm dlx @ivorycanvas/qamap qa . --manifest /tmp/qamap-manifest.yaml --base origin/main --head HEAD
+npx --yes @ivorycanvas/qamap@latest manifest init . --write /tmp/qamap-manifest.yaml
+npx --yes @ivorycanvas/qamap@latest qa . --manifest /tmp/qamap-manifest.yaml --base origin/main --head HEAD
 ```
 
 The manifest is the durable part. It lets a team correct domains, flows, anchors, and checks once, then reuse that correction across future PRs without re-explaining the same QA context to an LLM.
@@ -252,8 +252,8 @@ Use a tiny branch where a form, button, route, or API client changed. The record
 
 ```sh
 git diff --stat origin/main...HEAD
-pnpm dlx @ivorycanvas/qamap qa . --base origin/main --head HEAD
-pnpm dlx @ivorycanvas/qamap verify . --base origin/main --head HEAD --format markdown
+npx --yes @ivorycanvas/qamap@latest qa . --base origin/main --head HEAD
+npx --yes @ivorycanvas/qamap@latest verify . --base origin/main --head HEAD --format markdown
 ```
 
 The best GIF is not a long terminal scroll. Show:
@@ -272,5 +272,5 @@ QAMap turns a PR diff into affected flows, missing QA evidence, and draft E2E/ch
 It runs locally, does not upload source code, and does not call an LLM API.
 
 Try it:
-pnpm dlx @ivorycanvas/qamap qa . --base origin/main --head HEAD
+npx --yes @ivorycanvas/qamap@latest qa . --base origin/main --head HEAD
 ```

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -1,5 +1,26 @@
 # Release Validation
 
+## 0.4.4 - 2026-07-15
+
+Validated as a cross-framework evidence and honest-draft patch. QAMap now recovers conservative change intent from connected diff behavior even when commit text is not descriptive, maps React and Vue conditional states to changed actions and observable outcomes, and keeps unsupported outcomes review-only instead of generating a green smoke assertion:
+
+| Gate | Current result |
+| --- | --- |
+| `pnpm release:check` | Passed end to end |
+| `pnpm test` | 152/152 passing |
+| `pnpm scan` | 0 findings |
+| `pnpm bench:ci` | 15/15 synthetic PR targets pass; React and Vue conditional-state positives recover actions/outcomes while a presentation-only negative control rejects behavioral state QA |
+| Coverage | Lines 88.04%, branches 84.32%, functions 95.50% |
+| Change Intent coverage | Lines 97.97%, branches 91.82%, functions 99.30% |
+| Agent payload | Global output stays below 4KB; complex web and mobile lifecycle fixtures retain intent/scenario/flow context in 3,172 and 3,133 bytes instead of falling back to an empty emergency summary |
+| One-off repository safety | The documented npm execution command left an isolated repository's `package.json` hash unchanged and created no lockfile or package-manager metadata |
+| Skill compatibility | The public repository was discovered by the `skills` CLI and `qamap-pr-qa` installed as a project skill in an isolated home/project |
+| Package preview | `pnpm pack --dry-run` and `npm pack --dry-run` pass for `@ivorycanvas/qamap@0.4.4`; 134 files, 924.1 kB packed |
+
+The React and Vue fixtures are not product-specific framework rules. They express equivalent conditional user behavior through different syntax, while the negative control proves that a presentation condition alone cannot create lifecycle QA. Benchmarks materialize temporary Git repositories, do not install fixture dependencies, and do not execute fixture applications.
+
+Low-confidence diff-only intent remains review-required and recommended. Located lines alone do not promote it to a required blocker. When a repository exposes a stable action and observable failure outcome, QAMap can still compile a separate Playwright failure scenario; when an outcome is absent, the draft emits `test.fixme` rather than treating the clicked control or document body as proof of success.
+
 ## 0.4.3 - 2026-07-14
 
 Validated as an evidence-routed QA-to-automation patch. Intent-backed scenarios are selected from exact diff evidence before an adapter is chosen, and every selected scenario carries a receipt that states whether its setup, action, and assertion were compiled, partially mapped, left uncompiled, or retained for review only:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,11 +34,13 @@ Before treating the next public release as ready, the golden demo must satisfy t
 There is no fixed end date or patch count for `0.4.x`. QAMap will remain on compatible patch releases while real repositories still expose material gaps in change intent, affected-flow selection, scenario evidence, or automation-draft quality. `0.5.x` is not the next scheduled milestone; it is a release bar that must be earned by a stable, explicitly approved execution contract and evidence from repeated use outside the maintainer's repositories.
 
 - Stabilize commit-range Change Intent analysis: related behavior commits, diff symbols, confidence, review requirements, lifecycle stages, and runner-independent QA scenarios.
+- Preserve a conservative diff-only intent when commit messages are not descriptive, while keeping low-confidence scenarios recommended and review-required until stronger evidence exists.
 - Keep `qamap.change-intent` as a direct Behavior Graph adapter while moving more source observations out of the compatibility adapter.
 - Preserve `qa` as the static, read-only product surface while designing explicit execution behind `verify`; never turn a scan into implicit project-code execution.
 - Treat the committed [benchmark contract](benchmarking.md) as the quality gate for recommendations, not only implementation correctness. Reduce real failures into public fixtures and require `pnpm bench:ci` on every PR.
 - Keep execution readiness separate from validation completeness. A draft may be locally runnable while still requiring failure coverage, fixture confirmation, or reviewer approval before it becomes trusted PR evidence.
 - Make `qa` the primary product surface. Its first screen and `--format agent` payload must agree on change intent, lifecycle, QA scenarios, affected behavior, repository evidence, draft path, and missing trust requirements.
+- Keep `qa --format agent` below 4KB without dropping the highest-priority intent, routed scenarios, affected flow, and omitted counts needed for an agent handoff.
 - Improve changed-file impact mapping from shared symbols and components to consuming routes, screens, API contracts, and manifest flows.
 - Keep the [release validation checklist](release-validation.md), [manifest guide](manifest.md), public [E2E output examples](e2e-output-examples.md), and README examples aligned with captured output from the public fixtures.
 - Stabilize the manifest feedback loop with `.qamap/manifest.yaml`, `manifest init`, `manifest validate`, `manifest explain`, JSON Schema, and manifest-driven E2E draft shaping.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.4.2",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ivorycanvas/qamap",
-      "version": "0.4.2",
+      "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Local zero-LLM PR QA designer that maps commit intent and diffs to traceable behavior lifecycles, QA scenarios, and optional automation drafts.",
   "type": "module",
   "packageManager": "pnpm@10.32.1",

--- a/scripts/bench.mjs
+++ b/scripts/bench.mjs
@@ -272,6 +272,7 @@ function evaluateContract(expect, result, plan, qa) {
   appendUnexpectedTerms(failures, "intent title", result.intentTitles, expect.mustNotNameIntents);
   appendMissingTerms(failures, "intent lifecycle", result.intentLifecycle, expect.mustIncludeLifecycle);
   appendMissingTerms(failures, "intent QA scenario", result.intentScenarios, expect.mustIncludeQaScenarios);
+  appendUnexpectedTerms(failures, "intent QA scenario", result.intentScenarios, expect.mustNotIncludeQaScenarios);
   appendMissingTerms(failures, "intent evidence", result.intentEvidence, expect.mustFindIntentEvidence);
   appendMissingTerms(failures, "scenario source file", result.scenarioSourceFiles, expect.mustTraceScenarioFiles);
   if (

--- a/skills/qamap-pr-qa/SKILL.md
+++ b/skills/qamap-pr-qa/SKILL.md
@@ -15,10 +15,10 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
 2. Run QAMap from the repository root. Prefer the compact agent format — it carries the same decision content as the markdown report in a fraction of the tokens:
 
    ```sh
-   pnpm dlx @ivorycanvas/qamap qa . --base <base> --head HEAD --format agent
+   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@latest -- qamap qa . --base <base> --head HEAD --format agent
    ```
 
-   For an installed project, prefer:
+   This one-off form runs outside the target repository's package-manager contract, so it does not invoke Corepack or add a `packageManager` field. For a project that already installs QAMap, prefer its local binary, for example:
 
    ```sh
    pnpm exec qamap qa . --base <base> --head HEAD --format agent
@@ -30,7 +30,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
 3. If the repository is a monorepo and the changed files are clearly inside one package, run a scoped pass too:
 
    ```sh
-   pnpm dlx @ivorycanvas/qamap qa <package-path> --workspace-root . --base <base> --head HEAD
+   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@latest -- qamap qa <package-path> --workspace-root . --base <base> --head HEAD
    ```
 
 4. Read and verify intent before generating code. In agent format:
@@ -45,7 +45,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
 5. Only after a human or team accepts the scenario and automation adapter, create or preview executable coverage:
 
    ```sh
-   pnpm exec qamap e2e draft . --base <base> --head HEAD
+   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@latest -- qamap e2e draft . --base <base> --head HEAD
    ```
 
    If the selected adapter is absent, inspect and explicitly accept the `automation.setupCommand` proposal. Never install a runner merely because QAMap detected a web or mobile surface.
@@ -67,7 +67,7 @@ When the recommendation is wrong or too broad, do not repeatedly re-prompt for t
 If the team accepts QAMap for ongoing use, suggest this follow-up:
 
 ```sh
-pnpm exec qamap manifest init .
+npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@latest -- qamap manifest init .
 ```
 
 Then humans should review `.qamap/manifest.yaml` and keep only durable team QA language.

--- a/src/change-intent.ts
+++ b/src/change-intent.ts
@@ -199,8 +199,8 @@ export async function analyzeChangeIntents(
     ),
   );
 
-  if (intents.length === 0 && (options.includeWorkingTree ?? false)) {
-    const diffIntent = buildDiffOnlyIntent(changedFiles, codeSignals);
+  if (intents.length === 0) {
+    const diffIntent = buildDiffOnlyIntent(changedFiles, codeSignals, options.includeWorkingTree ?? false);
     if (diffIntent) {
       intents.push(diffIntent);
     }
@@ -359,7 +359,10 @@ function buildCommitIntent(
 ): ChangeIntent {
   const keywords = uniqueStrings(commits.flatMap((commit) => commit.keywords));
   const files = selectIntentFiles(keywords, changedFiles, addedDiffText, clusterCount);
-  const relevantSignals = codeSignals.filter((signal) => files.includes(signal.file));
+  const relevantSignals = rankCodeSignalsForIntent(
+    codeSignals.filter((signal) => files.includes(signal.file)),
+    keywords,
+  );
   const relevantRiskEvidence = riskEvidence.filter((item) => item.file && files.includes(item.file));
   const lifecycle = buildLifecycle(commits, relevantSignals);
   const confidence = confidenceForIntent(commits, lifecycle, relevantSignals);
@@ -398,7 +401,11 @@ function buildCommitIntent(
   };
 }
 
-function buildDiffOnlyIntent(changedFiles: string[], codeSignals: CodeBehaviorSignal[]): ChangeIntent | undefined {
+function buildDiffOnlyIntent(
+  changedFiles: string[],
+  codeSignals: CodeBehaviorSignal[],
+  includesWorkingTree: boolean,
+): ChangeIntent | undefined {
   const lifecycle = lifecycleFromCodeSignals(codeSignals);
   const stageKinds = new Set(lifecycle.map((stage) => stage.kind));
   if (lifecycle.length < 3 || stageKinds.size < 3) {
@@ -406,14 +413,16 @@ function buildDiffOnlyIntent(changedFiles: string[], codeSignals: CodeBehaviorSi
   }
   const files = uniqueStrings(codeSignals.map((signal) => signal.file)).slice(0, maxIntentFiles);
   const titleSubject = humanizeIdentifier(path.basename(files[0] ?? "working tree change").replace(/\.[^.]+$/, ""));
-  const title = `${titleSubject} working-tree behavior`;
+  const title = `${titleSubject} ${includesWorkingTree ? "working-tree" : "changed"} behavior`;
   const evidence = uniqueEvidence(codeSignals.slice(0, 12).map((signal) => signal.evidence));
-  const id = stableId("intent", `working-tree:${files.join(":")}`);
+  const id = stableId("intent", `${includesWorkingTree ? "working-tree" : "diff"}:${files.join(":")}`);
   const keywords = extractKeywords(codeSignals.map((signal) => `${signal.symbol} ${signal.label}`).join(" "));
   return {
     id,
     title,
-    summary: "Inferred only from connected working-tree behavior signals; no commit intent was available.",
+    summary: includesWorkingTree
+      ? "Inferred only from connected working-tree behavior signals; no commit intent was available."
+      : "Inferred from connected changed-code behavior signals because commit text did not express a usable intent.",
     confidence: "low",
     commits: [],
     files: files.length > 0 ? files : changedFiles.slice(0, maxIntentFiles),
@@ -481,7 +490,7 @@ function buildLifecycle(commits: ParsedCommit[], signals: CodeBehaviorSignal[]):
     }
     const alreadyRepresented = stages.some((stage) =>
       stage.label.toLowerCase().includes(signal.symbol.toLowerCase()) ||
-      (existingKinds.has(signal.kind) && normalizedWords(stage.label).some((word) => normalizedWords(signal.label).includes(word))),
+      (stage.kind === signal.kind && lifecycleLabelsOverlap(stage.label, signal.label)),
     );
     if (alreadyRepresented) {
       continue;
@@ -528,14 +537,17 @@ function buildIntentQaScenarios(
 ): IntentQaScenario[] {
   const conditions = lifecycle.filter((stage) => stage.kind === "condition").map((stage) => stage.label);
   const actions = selectPrimaryLifecycleSteps(lifecycle);
-  const outcomes = lifecycle.filter((stage) => stage.kind === "observable-outcome").map((stage) => assertionForStage(stage));
+  const outcomeStages = lifecycle.filter((stage) => stage.kind === "observable-outcome");
+  const locatedOutcomeStages = outcomeStages.filter((stage) => hasActionableLocatedDiffEvidence(stage.evidence));
+  const outcomes = (locatedOutcomeStages.length > 0 ? locatedOutcomeStages : outcomeStages)
+    .map((stage) => assertionForStage(stage));
   const sideEffects = lifecycle.filter((stage) => stage.kind === "side-effect").map((stage) => assertionForStage(stage));
   const primaryEvidence = lifecycleEvidence(lifecycle, evidence);
   const primaryHasActionableEvidence = hasActionableLocatedDiffEvidence(primaryEvidence);
   const primary: IntentQaScenario = {
     id: stableId("scenario", `${intentId}:primary`),
     kind: "primary",
-    priority: primaryHasActionableEvidence ? "critical" : "recommended",
+    priority: primaryHasActionableEvidence && confidence !== "low" ? "critical" : "recommended",
     title,
     rationale: "Commit and diff evidence describe this changed behavior lifecycle; verify the complete observable path before merge.",
     setup: conditions.length > 0 ? conditions : ["Prepare representative pre-change and changed-branch state."],
@@ -585,6 +597,42 @@ function buildIntentQaScenarios(
     ], ["Removed validation", "Unauthorized access", "Alternative entry point"], removedAccessGuardEvidence));
   }
 
+  const changedConditionEvidence = scenarioEvidenceFor(
+    lifecycle,
+    evidence,
+    /\b(?:is|has|can|should|show|hide)[A-Z_\w]*|eligible|available|loaded|loading|empty|ready|selected/i,
+    /color|theme|style|class|layout|size|width|height|dark|light/i,
+  );
+  if (changedConditionEvidence.length > 0 && !/toggle|enable|disable|permission|authoriz|auth|guard/.test(searchable)) {
+    scenarios.push(makeScenario(intentId, "conditional-fallback", "state-transition", "recommended", "Changed conditional state and fallback", [
+      "Prepare the changed condition as true and false, including loading, unknown, or empty state when the diff exposes one.",
+    ], [
+      "Enter the affected surface for each changed condition branch.",
+      "Change the condition and re-enter the surface to expose stale branch state.",
+    ], [
+      "Verify each condition shows only its intended action and observable copy.",
+      "Verify the fallback branch does not leak the changed action or duplicate its side effects.",
+    ], ["Condition false", "Loading or unknown state", "Empty collection", "Re-entry"], changedConditionEvidence));
+  }
+
+  const destinationParameterEvidence = evidence.filter((item) =>
+    item.kind === "diff" &&
+    item.file &&
+    item.startLine !== undefined &&
+    /urlsearchparams|searchparams|query|location\.href|window\.location|destination|redirect/i.test(`${item.symbol ?? ""} ${item.value}`)
+  );
+  if (destinationParameterEvidence.length > 0) {
+    scenarios.push(makeScenario(intentId, "destination-parameters", "boundary", "recommended", "Destination path and query parameters", [
+      "Prepare representative identifiers and conditionally included destination parameters.",
+    ], [
+      "Trigger the changed navigation for the primary state and each parameter branch supported by the diff.",
+      "Repeat the navigation with missing optional data and encoded values.",
+    ], [
+      "Verify the destination path and required query parameters match the changed source values.",
+      "Verify optional parameters appear only for their intended state and remain correctly encoded.",
+    ], ["Missing optional parameter", "Encoded value", "Repeated navigation"], destinationParameterEvidence));
+  }
+
   if (/schedul|reminder|calendar|\bdate\b|\btime\b|daily|tomorrow|timezone/.test(searchable)) {
     scenarios.push(makeScenario(intentId, "calendar-boundary", "boundary", "critical", "Scheduling, calendar, and duplicate boundary", [
       "Prepare records near day, month, and timezone boundaries.",
@@ -610,7 +658,13 @@ function buildIntentQaScenarios(
   }
 
   const entryRoutingSearchable = searchable.replaceAll("navigation.setoptions", "");
-  if (/tap|open|navigat|redirect|route|deep.?link|payload|destination/.test(entryRoutingSearchable)) {
+  const explicitOpenDestination = /\bopen\b[^.;]{0,80}\b(?:linked|destination|route|screen|page|detail|summary)\b/.test(
+    entryRoutingSearchable,
+  );
+  if (/navigat|redirect|route|deep.?link|payload|destination/.test(entryRoutingSearchable) || explicitOpenDestination) {
+    const routingEvidencePattern = explicitOpenDestination
+      ? /open|navigat|redirect|route|deep.?link|payload|destination/i
+      : /navigat|redirect|route|deep.?link|payload|destination/i;
     scenarios.push(makeScenario(intentId, "entry-routing", "failure", "critical", "Entry payload and destination routing", [
       "Prepare valid, missing, and stale entry payloads.",
     ], [
@@ -622,7 +676,7 @@ function buildIntentQaScenarios(
     ], ["Missing payload", "Stale identifier", "Repeated entry"], scenarioEvidenceFor(
       lifecycle,
       evidence,
-      /tap|open|navigat|redirect|route|deep.?link|payload|destination/i,
+      routingEvidencePattern,
       /navigation\.setoptions/i,
     )));
   }
@@ -651,7 +705,7 @@ function buildIntentQaScenarios(
     ], ["Stale cache", "App restart", "Repeated synchronization"], scenarioEvidenceFor(lifecycle, evidence, /sync|persist|storage|cache|reload|re.?entry|save|store/i)));
   }
 
-  return uniqueScenarios(scenarios).slice(0, 4);
+  return rankIntentQaScenarios(uniqueScenarios(scenarios)).slice(0, 5);
 }
 
 function lifecycleEvidence(
@@ -712,10 +766,34 @@ function selectPrimaryLifecycleSteps(lifecycle: BehaviorLifecycleStage[]): strin
     if (limit === 0 || count >= limit || isImplementationOnlyLifecycleStep(stage.label)) {
       continue;
     }
+    if (steps.some((step) => lifecycleStepsDescribeSameAction(step, stage.label))) {
+      continue;
+    }
     counts.set(stage.kind, count + 1);
     steps.push(stage.label);
   }
   return steps;
+}
+
+function lifecycleStepsDescribeSameAction(left: string, right: string): boolean {
+  const leftWords = meaningfulLifecycleWords(left);
+  const rightWords = new Set(meaningfulLifecycleWords(right));
+  return leftWords.some((word) => rightWords.has(word));
+}
+
+function lifecycleLabelsOverlap(left: string, right: string): boolean {
+  const leftWords = meaningfulLifecycleWords(left);
+  const rightWords = new Set(meaningfulLifecycleWords(right));
+  const overlap = leftWords.filter((word) => rightWords.has(word));
+  return overlap.length >= 2 || (leftWords.length === 1 && rightWords.size === 1 && overlap.length === 1);
+}
+
+function meaningfulLifecycleWords(value: string): string[] {
+  const ignored = new Set([
+    "activate", "action", "check", "complete", "execute", "handle", "invoke", "observe", "result", "run",
+    "show", "start", "state", "trigger", "verify",
+  ]);
+  return normalizedWords(value).filter((word) => word.length >= 4 && !ignored.has(word));
 }
 
 function isImplementationOnlyLifecycleStep(label: string): boolean {
@@ -802,7 +880,7 @@ function collectDiffRiskEvidence(addedDiffEvidence: AddedDiffEvidence): ChangeIn
             ));
           }
           const routingMatch = line.text.match(
-            /(payload|deep.?link|destination|redirect|router\.push|navigate\w*)/i,
+            /(payload|deep.?link|destination|redirect|router\.push|navigate\w*|URLSearchParams|searchParams|location\.href|window\.location)/i,
           );
           if (routingMatch && !/navigation\.setoptions/i.test(line.text)) {
             evidence.push(diffRiskEvidence(
@@ -863,8 +941,56 @@ function collectCodeBehaviorSignalsFromText(
   hunk?: AddedDiffHunk,
   line?: number,
 ): void {
+  for (const match of text.matchAll(/(?:@click(?:\.\w+)*|v-on:click(?:\.\w+)*|onClick)\s*=\s*(?:["']|\{)\s*(?:this\.)?([A-Za-z_$][\w$]*)/g)) {
+    const symbol = match[1];
+    const label = `Trigger ${humanizeIdentifier(symbol)}.`;
+    signals.push({
+      kind: "trigger",
+      label,
+      file,
+      symbol,
+      evidence: codeSignalEvidence(label, file, symbol, hunk, line),
+    });
+  }
+  const conditionExpressions = [
+    ...[...text.matchAll(/v-(?:if|else-if)\s*=\s*["']([^"']+)["']/g)].map((match) => match[1]),
+    ...[...text.matchAll(/\bif\s*\(([^)]{1,240})\)/g)].map((match) => match[1]),
+    ...[...text.matchAll(/\{\s*((?:is|has|can|should|show|hide)[A-Z_][A-Za-z0-9_$]*(?:\.[A-Za-z0-9_$]+)?)\s*(?:&&|\?)/g)]
+      .map((match) => match[1]),
+  ];
+  for (const expression of conditionExpressions) {
+    const identifiers = expression.match(/\b(?:is|has|can|should|show|hide)[A-Z_][A-Za-z0-9_$]*/g) ?? [];
+    for (const symbol of identifiers) {
+      const label = `Check ${humanizeIdentifier(symbol)}.`;
+      signals.push({
+        kind: "condition",
+        label,
+        file,
+        symbol,
+        evidence: codeSignalEvidence(label, file, symbol, hunk, line),
+      });
+    }
+  }
+  const conditionalCopyMatches = [
+    ...text.matchAll(/v-(?:if|show)\s*=\s*["'][^"']+["'][^>]*>\s*([^<>{}\n]{2,120})\s*</g),
+    ...text.matchAll(/\{\s*(?:is|has|can|should|show|hide)[A-Z_][A-Za-z0-9_$]*(?:\.[A-Za-z0-9_$]+)?\s*&&\s*<[^>]+>\s*([^<>{}\n]{2,120})\s*</g),
+  ];
+  for (const match of conditionalCopyMatches) {
+    const visibleText = match[1].replace(/\s+/g, " ").trim();
+    const label = `Show ${visibleText}.`;
+    signals.push({
+      kind: "observable-outcome",
+      label,
+      file,
+      symbol: visibleText,
+      evidence: codeSignalEvidence(label, file, visibleText, hunk, line),
+    });
+  }
   for (const match of text.matchAll(/\b(on[A-Z][A-Za-z0-9_]*)\b/g)) {
     const symbol = match[1];
+    if (/^on(?:Click|Press|Submit|Change)$/.test(symbol)) {
+      continue;
+    }
     const label = `Handle ${humanizeIdentifier(symbol)}.`;
     signals.push({
       kind: "trigger",
@@ -876,6 +1002,10 @@ function collectCodeBehaviorSignalsFromText(
   }
   for (const match of text.matchAll(/\b([A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)?)\s*\(/g)) {
     const symbol = match[1];
+    const prefix = text.slice(0, match.index ?? 0);
+    if (/\b(?:function|class)\s+$/.test(prefix)) {
+      continue;
+    }
     const leaf = symbol.split(".").at(-1) ?? symbol;
     if (ignoredCallNames.has(leaf) || leaf.length < 3) {
       continue;
@@ -924,13 +1054,16 @@ function lifecycleKindForIdentifier(identifier: string): BehaviorLifecycleStageK
   if (/(?:navigate|redirect|router\.(?:push|replace)|openurl|openlink|show|display|preview|render)/.test(value)) {
     return "observable-outcome";
   }
-  if (/(?:schedule|notify|notification|request|fetch|mutate|post|send|emit|track|publish|upload|download)/.test(value)) {
-    return "side-effect";
-  }
   if (/(?:resync|sync|persist|store|save|update|set[A-Z_]|cache|write|delete|remove|cancel|invalidate)/i.test(identifier)) {
     return "state-change";
   }
-  if (/(?:permission|authorized|authenticated|enabled|disabled|validate|guard|can[A-Z_]|should[A-Z_])/i.test(identifier)) {
+  if (/(?:schedule|notify|notification|request|fetch|mutate|post|send|emit|track|publish|upload|download)/.test(value)) {
+    return "side-effect";
+  }
+  if (
+    /(?:permission|authorized|authenticated|enabled|disabled|validate|guard)/i.test(identifier) ||
+    /^(?:is|has|can|should|show|hide)[A-Z_]/.test(identifier)
+  ) {
     return "condition";
   }
   return undefined;
@@ -1057,6 +1190,21 @@ function normalizedWords(value: string): string[] {
     .filter(Boolean);
 }
 
+function rankCodeSignalsForIntent(signals: CodeBehaviorSignal[], keywords: string[]): CodeBehaviorSignal[] {
+  const keywordSet = new Set(keywords.map(normalizeToken));
+  const presentationOnly = /color|theme|style|class|layout|size|width|height|dark|light/i;
+  return signals
+    .map((signal, index) => {
+      const words = normalizedWords(`${signal.symbol} ${signal.label} ${signal.file}`).map(normalizeToken);
+      const overlap = words.filter((word) => keywordSet.has(word)).length;
+      const behaviorWeight = signal.kind === "trigger" || signal.kind === "observable-outcome" ? 3 : 0;
+      const presentationPenalty = presentationOnly.test(`${signal.symbol} ${signal.label}`) ? 4 : 0;
+      return { signal, index, score: overlap * 4 + behaviorWeight - presentationPenalty };
+    })
+    .sort((left, right) => right.score - left.score || left.index - right.index)
+    .map(({ signal }) => signal);
+}
+
 function normalizeToken(value: string): string {
   let token = value.toLowerCase().replace(/[^a-z0-9가-힣]/g, "");
   if (/^schedul/.test(token)) return "schedule";
@@ -1130,6 +1278,38 @@ function uniqueScenarios(scenarios: IntentQaScenario[]): IntentQaScenario[] {
   });
 }
 
+function rankIntentQaScenarios(scenarios: IntentQaScenario[]): IntentQaScenario[] {
+  const kindRank: Record<IntentQaScenarioKind, number> = {
+    primary: 0,
+    failure: 1,
+    boundary: 2,
+    "state-transition": 3,
+  };
+  return scenarios
+    .map((scenario, index) => ({ scenario, index }))
+    .sort((left, right) => {
+      if (left.scenario.kind === "primary" || right.scenario.kind === "primary") {
+        if (left.scenario.kind === "primary" && right.scenario.kind === "primary") {
+          return left.index - right.index;
+        }
+        return left.scenario.kind === "primary" ? -1 : 1;
+      }
+      const priorityDifference = Number(left.scenario.priority !== "critical") -
+        Number(right.scenario.priority !== "critical");
+      if (priorityDifference !== 0) {
+        return priorityDifference;
+      }
+      const kindDifference = kindRank[left.scenario.kind] - kindRank[right.scenario.kind];
+      if (kindDifference !== 0) {
+        return kindDifference;
+      }
+      const leftDirectEvidence = left.scenario.evidence.filter((item) => item.relation === "direct").length;
+      const rightDirectEvidence = right.scenario.evidence.filter((item) => item.relation === "direct").length;
+      return rightDirectEvidence - leftDirectEvidence || left.index - right.index;
+    })
+    .map(({ scenario }) => scenario);
+}
+
 function uniqueEvidence(evidence: ChangeIntentEvidence[]): ChangeIntentEvidence[] {
   const seen = new Set<string>();
   return evidence.filter((item) => {
@@ -1190,7 +1370,8 @@ function changeIntentSource(
   signals: CodeBehaviorSignal[],
 ): ChangeIntentAnalysis["source"] {
   if (intents.length === 0) return "none";
-  if (commits.length > 0 && signals.length > 0) return "commits-and-diff";
-  if (commits.length > 0) return "commits";
+  const usesCommitIntent = intents.some((intent) => intent.commits.length > 0);
+  if (usesCommitIntent && commits.length > 0 && signals.length > 0) return "commits-and-diff";
+  if (usesCommitIntent && commits.length > 0) return "commits";
   return "diff-only";
 }

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -99,7 +99,8 @@ export type E2eSelectorKind =
   | "input-aria-label"
   | "placeholder"
   | "role-button"
-  | "role-link";
+  | "role-link"
+  | "click-text";
 
 export interface E2ePlanOptions extends TestPlanOptions {
   runner?: E2eRunnerName;
@@ -705,7 +706,7 @@ export async function generateE2eDraft(rootInput: string, options: E2eDraftOptio
   const runner = plan.recommendedRunner.name;
   const outputDirectory = path.resolve(root, options.output ?? defaultDraftOutputDirectory(runner));
   const draftLimit = options.maxDrafts && options.maxDrafts > 0 ? Math.floor(options.maxDrafts) : undefined;
-  const flows = (await buildDraftFlows(plan)).slice(0, draftLimit);
+  const flows = (await buildDraftFlows(plan, addedDiffText)).slice(0, draftLimit);
   const dryRun = options.dryRun ?? false;
 
   if (!dryRun) {
@@ -5175,7 +5176,7 @@ async function buildFlow(
     return undefined;
   }
   const coverage = candidate.coverage ?? buildCoverageTargets(candidate.kind, files, runner);
-  const setupHints = await inferFlowSetupHints(root, files, candidate.kind);
+  const setupHints = await inferFlowSetupHints(root, files, candidate.kind, addedDiffText);
   const interactionEvidenceApplies = !isVerificationOnlyKind(candidate.kind);
   const selectors = interactionEvidenceApplies
     ? await inferFlowSelectors(root, files, runner, addedDiffText)
@@ -5192,7 +5193,7 @@ async function buildFlow(
     setupHints,
     fixtureReadiness: await inferFlowFixtureReadiness(root, files, candidate.kind, setupHints, fixtureContext),
     selectors,
-    missingTestability: interactionEvidenceApplies ? await findFlowTestabilityGaps(root, files, runner) : [],
+    missingTestability: interactionEvidenceApplies ? await findFlowTestabilityGaps(root, files, runner, selectors) : [],
     intentId: candidate.intentId,
     intentConfidence: candidate.intentConfidence,
     intentEvidence: candidate.intentEvidence,
@@ -5293,7 +5294,12 @@ async function inferFlowEntrypoints(root: string, files: string[], runner: E2eRu
   return uniqueEntrypoints(entrypoints).slice(0, 6);
 }
 
-async function inferFlowSetupHints(root: string, files: string[], kind: E2eFlowKind): Promise<E2eSetupHint[]> {
+async function inferFlowSetupHints(
+  root: string,
+  files: string[],
+  kind: E2eFlowKind,
+  addedDiffText: Record<string, string> = {},
+): Promise<E2eSetupHint[]> {
   if (
     kind === "artifact" ||
     kind === "catalog" ||
@@ -5315,6 +5321,7 @@ async function inferFlowSetupHints(root: string, files: string[], kind: E2eFlowK
 
   const filesText = files.join("\n");
   const combinedText = `${filesText}\n${fileTexts.map((item) => item.text).join("\n")}`;
+  const changedText = files.map((file) => addedDiffText[file] ?? "").filter(Boolean).join("\n");
   const shouldUseContentSignals = kind !== "config" && kind !== "content" && kind !== "command";
   const signalText = shouldUseContentSignals ? combinedText : filesText;
   const matchingFiles = (pattern: RegExp) =>
@@ -5338,8 +5345,9 @@ async function inferFlowSetupHints(root: string, files: string[], kind: E2eFlowK
     );
   }
 
-  if (kind === "api" || /(?:fetch|axios|graphql|trpc|rpc|client|endpoint|request|response|msw|nock|mock|\/api\/)/i.test(signalText)) {
-    const networkFiles = matchingFiles(/api|client|endpoint|request|response|graphql|trpc|rpc|fetch|axios|msw|nock|mock/i);
+  const networkEvidence = /(?:fetch\s*\(|axios(?:\.|\s*\()|graphql|trpc|\brpc\b|apiClient|endpoint|msw|nock|\/api\/|(?:^|\/)(?:api|requests?|responses?|clients?|endpoints?)(?:\/|[-_.]|$))/im;
+  if (kind === "api" || networkEvidence.test(signalText)) {
+    const networkFiles = matchingFiles(networkEvidence);
     hints.push(
       setupHint(
         "network",
@@ -5377,7 +5385,14 @@ async function inferFlowSetupHints(root: string, files: string[], kind: E2eFlowK
     );
   }
 
-  if (/(?:payment|billing|checkout|purchase|subscription|invoice|settlement|stripe|iap|in-app-purchase|storekit|revenuecat)/i.test(signalText)) {
+  const paymentPathSignal = /(?:^|\/|[-_])(payment|billing|checkout|purchase|subscription|invoice|settlement)(?:\/|[-_.]|$)/i;
+  const paymentProviderSignal = /(?:stripe|\biap\b|in-app-purchase|storekit|revenuecat)/i;
+  const changedPaymentSignal = /(?:payment|billing|checkout|purchase|subscription|invoice|settlement)/i;
+  if (
+    paymentPathSignal.test(filesText) ||
+    paymentProviderSignal.test(signalText) ||
+    changedPaymentSignal.test(changedText)
+  ) {
     const paymentFiles = matchingFiles(/payment|billing|checkout|purchase|subscription|invoice|settlement|stripe|iap|in-app-purchase|storekit|revenuecat/i);
     hints.push(
       setupHint(
@@ -5709,7 +5724,8 @@ function isApiDependencyPath(file: string): boolean {
 }
 
 function hasApiDependencyText(text: string): boolean {
-  return /(?:fetch\(|axios\.|graphql|gql`|trpc\.|useQuery|useMutation|queryKey|apiClient|client\.(?:get|post|put|patch|delete)|\/api\/|endpoint|request|response)/i.test(text);
+  return /(?:fetch\s*\(|axios\.|graphql|gql`|trpc\.|useQuery|useMutation|queryKey|apiClient|client\.(?:get|post|put|patch|delete)|\/api\/|endpoint)/i.test(text) ||
+    /\b(?:request|response)[A-Z_][A-Za-z0-9_$]*/.test(text);
 }
 
 async function findApiEndpointHints(root: string, files: string[]): Promise<string[]> {
@@ -6179,8 +6195,16 @@ function stripKnownExtension(file: string): string {
   return file.replace(/\.(?:d\.)?(?:[cm]?[jt]sx?|vue|svelte|mdx?)$/i, "");
 }
 
-async function findFlowTestabilityGaps(root: string, files: string[], runner: E2eRunnerName): Promise<string[]> {
+async function findFlowTestabilityGaps(
+  root: string,
+  files: string[],
+  runner: E2eRunnerName,
+  selectors: E2eSelector[] = [],
+): Promise<string[]> {
   const gaps: string[] = [];
+  const selectorFiles = new Set(
+    selectors.filter(selectorCanDriveInteraction).map((selector) => selector.file),
+  );
   for (const file of files.slice(0, 8)) {
     if (!isUiImplementationFile(file)) {
       continue;
@@ -6189,11 +6213,19 @@ async function findFlowTestabilityGaps(root: string, files: string[], runner: E2
     if (!text) {
       continue;
     }
-    if (hasInteractiveUi(text) && !hasStableSelector(text, runner)) {
+    const delegatedToSelectorBearingComponent =
+      selectorFiles.size > 0 &&
+      !selectorFiles.has(file) &&
+      !hasNativeInteractiveUi(text);
+    if (hasInteractiveUi(text) && !hasStableSelector(text, runner) && !delegatedToSelectorBearingComponent) {
       gaps.push(`Add stable ${selectorName(runner)} selectors in ${file} for the controls this flow taps or types into.`);
     }
   }
   return uniqueStrings(gaps);
+}
+
+function hasNativeInteractiveUi(text: string): boolean {
+  return /<(?:button|input|textarea|select|Pressable|Touchable\w*|TextInput|Switch|Slider)\b/i.test(text);
 }
 
 async function buildGlobalTestabilityGaps(root: string, runner: E2eRunnerName): Promise<string[]> {
@@ -6768,15 +6800,18 @@ function dedupeFlows(flows: E2eFlow[]): E2eFlow[] {
   return deduped;
 }
 
-async function buildDraftFlows(plan: E2ePlanResult): Promise<DraftE2eFlow[]> {
+async function buildDraftFlows(
+  plan: E2ePlanResult,
+  addedDiffText: Record<string, string> = {},
+): Promise<DraftE2eFlow[]> {
   const baseFlows = plan.flows.length > 0 ? plan.flows : [buildFallbackFlow(plan)];
-  const manifestFlows = await buildManifestDraftFlows(plan, baseFlows);
+  const manifestFlows = await buildManifestDraftFlows(plan, baseFlows, addedDiffText);
   const domainScenarios = shouldUseDomainScenariosForDraft(plan) ? plan.domainLanguage.scenarios : [];
   const scenarioFlows = await Promise.all(
     domainScenarios
       .filter((scenario) => scenario.files.length > 0 || scenario.source === "core-flow")
       .slice(0, 4)
-      .map((scenario) => buildDomainScenarioDraftFlow(plan, scenario, baseFlows)),
+      .map((scenario) => buildDomainScenarioDraftFlow(plan, scenario, baseFlows, addedDiffText)),
   );
 
   if (manifestFlows.length === 0 && scenarioFlows.length === 0) {
@@ -6909,20 +6944,21 @@ function preferredDraftSource(left: DraftFlowSource | undefined, right: DraftFlo
 async function buildManifestDraftFlows(
   plan: E2ePlanResult,
   baseFlows: E2eFlow[],
+  addedDiffText: Record<string, string> = {},
 ): Promise<DraftE2eFlow[]> {
   const flowMatches = plan.verificationManifestMatches
     .filter((match) => match.kind === "flow")
     .slice(0, 4);
   const checkMatches = plan.verificationManifestMatches.filter((match) => match.kind === "check");
   const flowDrafts = await Promise.all(
-    flowMatches.map((match) => buildManifestDraftFlow(plan, match, checkMatches, baseFlows)),
+    flowMatches.map((match) => buildManifestDraftFlow(plan, match, checkMatches, baseFlows, addedDiffText)),
   );
   const flowMatchedFiles = new Set(flowMatches.flatMap((match) => match.matchedFiles));
   const domainDrafts = await Promise.all(
     plan.verificationManifestMatches
       .filter((match) => match.kind === "domain" && match.matchedFiles.some((file) => !flowMatchedFiles.has(file)))
       .slice(0, 4)
-      .map((match) => buildManifestDomainDraftFlow(plan, match, baseFlows)),
+      .map((match) => buildManifestDomainDraftFlow(plan, match, baseFlows, addedDiffText)),
   );
   return [...flowDrafts, ...domainDrafts.filter((flow): flow is DraftE2eFlow => Boolean(flow))].slice(0, 4);
 }
@@ -6931,6 +6967,7 @@ async function buildManifestDomainDraftFlow(
   plan: E2ePlanResult,
   match: VerificationManifestMatch,
   baseFlows: E2eFlow[],
+  addedDiffText: Record<string, string> = {},
 ): Promise<DraftE2eFlow | undefined> {
   const manifestFiles = normalizeScenarioFilesForRoot(plan, match.matchedFiles);
   const baseFlow = bestOverlappingBaseFlowForManifestMatch(manifestFiles, baseFlows);
@@ -6951,7 +6988,7 @@ async function buildManifestDomainDraftFlow(
     ]),
     selectors: uniqueSelectors([
       ...baseFlow.selectors,
-      ...(await inferFlowSelectors(plan.root, files, plan.recommendedRunner.name)),
+      ...(await inferFlowSelectors(plan.root, files, plan.recommendedRunner.name, addedDiffText)),
     ]),
     draftSource: "verification-manifest",
     manifestMatch: match,
@@ -6967,6 +7004,7 @@ async function buildManifestDraftFlow(
   match: VerificationManifestMatch,
   checkMatches: VerificationManifestMatch[],
   baseFlows: E2eFlow[],
+  addedDiffText: Record<string, string> = {},
 ): Promise<DraftE2eFlow> {
   const relatedChecks = checkMatches.filter((check) => check.id.startsWith(`${match.id}.`));
   const manifestFiles = normalizeScenarioFilesForRoot(plan, match.matchedFiles);
@@ -6983,29 +7021,30 @@ async function buildManifestDraftFlow(
   ]);
   const selectors = uniqueSelectors([
     ...filterSelectorsForFiles(baseFlows.flatMap((flow) => flow.selectors), files),
-    ...(await inferFlowSelectors(plan.root, files, runner)),
+    ...(await inferFlowSelectors(plan.root, files, runner, addedDiffText)),
   ]);
   const refinedSteps = refineManifestStepsForInferredSelectors(
     refineStepsForInferredSelectors(manifestSteps.length > 0 ? manifestSteps : (baseFlow?.steps ?? []), selectors),
     selectors,
   );
+  const executableSteps = refinedSteps.filter((step) => !isCoverageOnlyScenarioStep(step));
   const setupHints = uniqueSetupHints([
     ...filterSetupHintsForFiles(baseFlows.flatMap((flow) => flow.setupHints), files),
-    ...(await inferFlowSetupHints(plan.root, files, "domain")),
+    ...(await inferFlowSetupHints(plan.root, files, "domain", addedDiffText)),
   ]);
   const flow: Omit<DraftE2eFlow, "languageBrief"> = {
     kind: baseFlow?.kind ?? "domain",
     title: match.name,
     reason: match.reason,
     files,
-    steps: refinedSteps,
+    steps: executableSteps,
     coverage,
     coverageEvidence: baseFlow?.coverageEvidence ?? [],
     entrypoints,
     setupHints,
     fixtureReadiness: scenarioFixtureReadiness(baseFlow, setupHints),
     selectors,
-    missingTestability: await findFlowTestabilityGaps(plan.root, files, runner),
+    missingTestability: await findFlowTestabilityGaps(plan.root, files, runner, selectors),
     draftSource: "verification-manifest",
     manifestMatch: match,
     manifestCheckMatches: relatedChecks,
@@ -7122,6 +7161,7 @@ async function buildDomainScenarioDraftFlow(
   plan: E2ePlanResult,
   scenario: DomainScenarioSuggestion,
   baseFlows: E2eFlow[],
+  addedDiffText: Record<string, string> = {},
 ): Promise<DraftE2eFlow> {
   const coreFlow = matchedCoreFlowForScenario(plan, scenario);
   const baseFlow = bestBaseFlowForScenario(scenario, baseFlows);
@@ -7137,6 +7177,7 @@ async function buildDomainScenarioDraftFlow(
         ? scenarioFiles
         : (baseFlow?.files ?? []),
   ).slice(0, 20);
+  const matchedIntent = matchingChangeIntentForFiles(plan.changeAnalysis, files);
   const coverage = baseFlow?.coverage ?? buildCoverageTargets("domain", files, plan.recommendedRunner.name);
   const runner = plan.recommendedRunner.name;
   const entrypoints = uniqueEntrypoints([
@@ -7147,12 +7188,15 @@ async function buildDomainScenarioDraftFlow(
   ]);
   const selectors = uniqueSelectors([
     ...filterSelectorsForFiles(baseFlows.flatMap((flow) => flow.selectors), files),
-    ...(await inferFlowSelectors(plan.root, files, runner)),
+    ...(await inferFlowSelectors(plan.root, files, runner, addedDiffText)),
   ]);
   const refinedSteps = refineStepsForInferredSelectors(steps, selectors);
+  const executableSteps = refinedSteps.filter((step) => !isCoverageOnlyScenarioStep(step));
   const setupHints = uniqueSetupHints([
     ...filterSetupHintsForFiles(baseFlows.flatMap((flow) => flow.setupHints), files),
-    ...(shouldInferDomainScenarioSetupHints(baseFlow) ? await inferFlowSetupHints(plan.root, files, "domain") : []),
+    ...(shouldInferDomainScenarioSetupHints(baseFlow)
+      ? await inferFlowSetupHints(plan.root, files, "domain", addedDiffText)
+      : []),
   ]);
   const draftScenario = {
     ...scenario,
@@ -7165,14 +7209,19 @@ async function buildDomainScenarioDraftFlow(
     title,
     reason,
     files,
-    steps: refinedSteps,
+    steps: executableSteps,
     coverage,
     coverageEvidence: baseFlow?.coverageEvidence ?? [],
     entrypoints,
     setupHints,
     fixtureReadiness: scenarioFixtureReadiness(baseFlow, setupHints),
     selectors,
-    missingTestability: await findFlowTestabilityGaps(plan.root, files, runner),
+    missingTestability: await findFlowTestabilityGaps(plan.root, files, runner, selectors),
+    intentId: baseFlow?.intentId ?? matchedIntent?.id,
+    intentConfidence: baseFlow?.intentConfidence ?? matchedIntent?.confidence,
+    intentEvidence: baseFlow?.intentEvidence ?? matchedIntent?.evidence,
+    lifecycle: baseFlow?.lifecycle ?? matchedIntent?.lifecycle,
+    qaScenarios: baseFlow?.qaScenarios ?? matchedIntent?.scenarios,
     draftSource: scenario.source === "core-flow" ? "core-flow" : "domain-language",
     domainScenario: draftScenario,
     coreFlow,
@@ -7181,6 +7230,32 @@ async function buildDomainScenarioDraftFlow(
     ...flow,
     languageBrief: buildFlowLanguageBrief(flow),
   };
+}
+
+function matchingChangeIntentForFiles(
+  analysis: ChangeIntentAnalysis,
+  files: string[],
+): ChangeIntentAnalysis["intents"][number] | undefined {
+  const fileSet = new Set(files);
+  const confidenceRank: Record<ChangeIntentConfidence, number> = { high: 0, medium: 1, low: 2 };
+  return analysis.intents
+    .map((intent, index) => ({
+      intent,
+      index,
+      overlap: intent.files.filter((file) => fileSet.has(file)).length,
+    }))
+    .filter((candidate) => candidate.overlap > 0)
+    .sort((left, right) =>
+      right.overlap - left.overlap ||
+      confidenceRank[left.intent.confidence] - confidenceRank[right.intent.confidence] ||
+      left.index - right.index
+    )[0]?.intent;
+}
+
+function isCoverageOnlyScenarioStep(step: string): boolean {
+  return /^Try one (?:empty, blocked, rejected, or failed|failure, boundary, or recovery)\b/i.test(step) ||
+    /^Verify loading, empty, error, and success states when they are reachable\b/i.test(step) ||
+    /^Verify .+ shows the expected visible result\b/i.test(step);
 }
 
 function shouldInferDomainScenarioSetupHints(baseFlow: E2eFlow | undefined): boolean {
@@ -7664,10 +7739,18 @@ function evaluatePlaywrightDraftSelfCheck(
   const weakSmokeAssertions = content.match(/expect\(page\.locator\(["']body["']\)\)\.toBeVisible\(\)/g)?.length ?? 0;
   checks.push(draftSelfCheckItem(
     "Domain assertions",
-    weakSmokeAssertions === 0 ? "pass" : "warning",
+    weakSmokeAssertions === 0 ? "pass" : "fail",
     weakSmokeAssertions === 0
       ? "The draft does not rely on body-only smoke assertions."
-      : `${weakSmokeAssertions} body-only smoke assertion${weakSmokeAssertions === 1 ? "" : "s"} must be replaced with observable domain outcomes.`,
+      : `${weakSmokeAssertions} body-only smoke assertion${weakSmokeAssertions === 1 ? "" : "s"} cannot count as changed-behavior coverage.`,
+  ));
+  const uncompiledSteps = content.match(/QAMap could not infer a stable locator for this step/g)?.length ?? 0;
+  checks.push(draftSelfCheckItem(
+    "Compiled actions",
+    uncompiledSteps === 0 ? "pass" : "fail",
+    uncompiledSteps === 0
+      ? "Every emitted Playwright step has a deterministic locator or adapter instruction."
+      : `${uncompiledSteps} selected step${uncompiledSteps === 1 ? "" : "s"} remain explicitly skipped until repository evidence supplies a locator.`,
   ));
   checks.push(draftSelfCheckItem(
     "Execution profile",
@@ -8194,7 +8277,7 @@ function playwrightRoutedScenarioDrafts(flow: E2eFlow): PlaywrightRoutedScenario
     }
     const testName = `${flow.title}: ${scenario.title}`.replaceAll('"', "'");
     const routePattern = playwrightMockRoutePattern(endpoint);
-    const status = failureResponseStatus(scenarioText);
+    const status = failureResponseStatus([scenario.title, ...scenario.steps].join(" "));
     drafts.push({
       scenarioId: scenario.id,
       mappedSteps: Math.min(1, scenario.steps.length),
@@ -9457,11 +9540,18 @@ function takeSelectorForStep(selectors: E2eSelector[], step: string): E2eSelecto
     return undefined;
   }
   if (isInputStep(step)) {
-    const matched = takePreferredSelector(selectors, (selector) => isInputSelector(selector) && selectorMatchesStep(selector, step));
+    const matched = takeBestSelectorForStep(
+      selectors,
+      step,
+      (selector) => isInputSelector(selector) && selectorMatchesStep(selector, step),
+    );
     if (matched) {
       return matched;
     }
-    const fallbackInput = takePreferredSelector(selectors, isInputSelector);
+    const fallbackInput = takePreferredSelector(
+      selectors,
+      (selector) => Boolean(selector.addedInDiff) && isInputSelector(selector),
+    );
     if (fallbackInput) {
       return fallbackInput;
     }
@@ -9470,24 +9560,36 @@ function takeSelectorForStep(selectors: E2eSelector[], step: string): E2eSelecto
     return undefined;
   }
   const diffGateForStep = isAssertionStep(step) || isVerificationStep(step)
-    ? selectorCanSupportAssertion
+    ? (selector: E2eSelector) => selectorCanSupportStepAssertion(selector, step)
     : selectorCanDriveInteraction;
-  const matched = takePreferredSelector(
+  const matched = takeBestSelectorForStep(
     selectors,
-    (selector) => !isInputSelector(selector) && selectorMatchesStep(selector, step),
-    diffGateForStep,
+    step,
+    (selector) =>
+      !isInputSelector(selector) &&
+      selectorMatchesStep(selector, step) &&
+      diffGateForStep(selector),
   );
   if (matched) {
     return matched;
   }
   if (isAssertionStep(step)) {
-    const assertion = takePreferredSelector(selectors, selectorCanSupportAssertion);
-    if (assertion) {
-      return assertion;
+    const assertionCandidates = selectors.filter(
+      (selector) =>
+        Boolean(selector.addedInDiff) &&
+        selector.kind === "visible-text" &&
+        selectorCanSupportAssertion(selector),
+    );
+    if (assertionCandidates.length === 1) {
+      const assertionIndex = selectors.indexOf(assertionCandidates[0]);
+      return selectors.splice(assertionIndex, 1)[0];
     }
   }
   if (canUsePrimarySelector(step)) {
-    const fallback = takePreferredSelector(selectors, selectorCanDriveInteraction);
+    const fallback = takePreferredSelector(
+      selectors,
+      (selector) => Boolean(selector.addedInDiff) && selectorCanDriveInteraction(selector),
+    );
     if (fallback) {
       return fallback;
     }
@@ -9496,8 +9598,41 @@ function takeSelectorForStep(selectors: E2eSelector[], step: string): E2eSelecto
 }
 
 function selectorMatchesStep(selector: E2eSelector, step: string): boolean {
-  const selectorText = selector.value.toLowerCase();
-  return keywordsForStep(step).some((keyword) => selectorText.includes(keyword));
+  return selectorStepMatchScore(selector, step) > 0;
+}
+
+function takeBestSelectorForStep(
+  selectors: E2eSelector[],
+  step: string,
+  predicate: (selector: E2eSelector) => boolean,
+): E2eSelector | undefined {
+  const ranked = selectors
+    .map((selector, index) => ({ selector, index }))
+    .filter(({ selector }) => predicate(selector))
+    .map(({ selector, index }) => ({
+      selector,
+      index,
+      score: selectorStepMatchScore(selector, step) + (selector.addedInDiff ? 2 : 0),
+    }))
+    .sort((left, right) => right.score - left.score || left.index - right.index);
+  if (ranked.length === 0) {
+    return undefined;
+  }
+  return selectors.splice(ranked[0].index, 1)[0];
+}
+
+function selectorStepMatchScore(selector: E2eSelector, step: string): number {
+  const stepWords = keywordsForStep(step);
+  const selectorWords = keywordsForStep(selector.value);
+  return stepWords.reduce((score, stepWord) => {
+    if (selectorWords.includes(stepWord)) {
+      return score + 4;
+    }
+    if (selectorWords.some((selectorWord) => selectorWord.includes(stepWord) || stepWord.includes(selectorWord))) {
+      return score + 1;
+    }
+    return score;
+  }, 0);
 }
 
 function canUsePrimarySelector(step: string): boolean {
@@ -9514,6 +9649,16 @@ function selectorCanDriveInteraction(selector: E2eSelector): boolean {
 
 function selectorCanSupportAssertion(selector: E2eSelector): boolean {
   return selector.kind !== "placeholder" && !isPassiveControlLabel(selector.value);
+}
+
+function selectorCanSupportStepAssertion(selector: E2eSelector, step: string): boolean {
+  if (!selectorCanSupportAssertion(selector)) {
+    return false;
+  }
+  if (selector.kind === "visible-text") {
+    return true;
+  }
+  return /\b(?:button|link|control|field|input|action|selector|accessible|label|enabled|disabled|checked|selected)\b/i.test(step);
 }
 
 function isInputSelector(selector: E2eSelector): boolean {
@@ -9553,11 +9698,18 @@ function keywordsForStep(step: string): string[] {
     "into",
     "next",
     "after",
+    "변경",
+    "상태",
+    "화면",
+    "확인",
   ]);
   return step
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
-    .filter((part) => part.length >= 3 && !stopWords.has(part));
+    .toLocaleLowerCase()
+    .split(/[^\p{L}\p{N}]+/u)
+    .filter((part) => {
+      const minimumLength = /[^\x00-\x7F]/.test(part) ? 2 : 3;
+      return part.length >= minimumLength && !stopWords.has(part);
+    });
 }
 
 function maestroSelectorValue(selector: E2eSelector): string {
@@ -9831,8 +9983,8 @@ function normalizeManifestStepKey(value: string): string {
 function playwrightFallbackActionForStep(step: string): string[] {
   return [
     `// QAMap could not infer a stable locator for this step: ${step}`,
-    "// Keep this as a runnable smoke assertion, then replace it with a domain-specific locator when the app exposes one.",
-    'await expect(page.locator("body")).toBeVisible();',
+    "// Keep the draft review-only instead of allowing an unrelated smoke assertion to pass.",
+    `test.fixme(true, "QAMap needs repository evidence for: ${quoteJs(step)}");`,
   ];
 }
 
@@ -9861,7 +10013,7 @@ function isGestureStep(step: string): boolean {
 }
 
 function isInteractionStep(step: string): boolean {
-  return /^(?:choose|select|open|tap|click|create|save|submit|continue|complete|renew|apply|approve|confirm|send|fill|input|enter|type|provide|return|switch|exercise|activate)\b/i.test(step);
+  return /^(?:choose|select|open|tap|click|trigger|handle|create|save|submit|continue|complete|renew|apply|approve|confirm|send|fill|input|enter|type|provide|return|switch|exercise|activate)\b/i.test(step);
 }
 
 function isVerificationStep(step: string): boolean {
@@ -9903,6 +10055,7 @@ function extractSelectorsFromText(file: string, text: string, runner: E2eRunnerN
       ),
       ...withoutSelectorValueDuplicates(extractAttributeSelectors(file, text, ["aria-label"], "aria-label"), webInputSelectors),
       ...extractRoleSelectorsFromText(file, text),
+      ...extractInteractiveTextSelectors(file, text),
     );
   }
 
@@ -9961,9 +10114,9 @@ function extractTextNodeSelectors(file: string, text: string): E2eSelector[] {
     }
   }
 
-  const htmlTextNodeMatcher = /<(p|span|strong|em|small|label|li|output|h[1-6])\b[^>]*>\s*([^<>{}\n][^<>{}]*)\s*<\/\1>/g;
+  const htmlTextNodeMatcher = /<(p|span|strong|em|small|label|li|output|h[1-6]|div)\b[^>]*>([\s\S]{0,300}?)<\/\1>/g;
   for (const match of text.matchAll(htmlTextNodeMatcher)) {
-    const value = normalizeSelectorValue(match[2]);
+    const value = normalizeRenderedText(match[2]);
     if (value) {
       selectors.push({ kind: "visible-text", value, file });
     }
@@ -10001,7 +10154,76 @@ function extractRenderedStateSelectors(file: string, text: string): E2eSelector[
       }
     }
   }
+  const interpolatedNames = new Set(
+    [...text.matchAll(/\{\{?\s*([A-Za-z_$][\w$]*)\s*\}?\}/g)].map((match) => match[1]),
+  );
+  for (const name of interpolatedNames) {
+    for (const value of renderedLiteralValues(text, name)) {
+      selectors.push({ kind: "visible-text", value, file });
+    }
+  }
   return selectors;
+}
+
+function extractInteractiveTextSelectors(file: string, text: string): E2eSelector[] {
+  const selectors: E2eSelector[] = [];
+  const namedInteractive = /<(button|a|[A-Za-z][\w.-]*(?:Button|Link|NavLink))\b([^>]*)>([\s\S]{0,500}?)<\/\1>/gi;
+  const handledInteractive = /<([A-Za-z][\w.-]*)\b((?=[^>]*(?:(?:@click(?:\.\w+)*|v-on:click(?:\.\w+)*|onClick|href|to)\s*=))[^>]*)>([\s\S]{0,500}?)<\/\1>/g;
+  for (const match of [...text.matchAll(namedInteractive), ...text.matchAll(handledInteractive)]) {
+    const tag = match[1];
+    const attributes = match[2];
+    const body = match[3];
+    const normalizedTag = tag.toLowerCase();
+    const isButton = normalizedTag === "button" || normalizedTag.endsWith("button");
+    const isLink = normalizedTag === "a" || normalizedTag === "link" || normalizedTag === "navlink";
+    const hasClickHandler = /(?:^|\s)(?:@click(?:\.\w+)*|v-on:click(?:\.\w+)*|onClick)\s*=/.test(attributes);
+    const hasNavigationTarget = /(?:^|\s)(?:href|to)\s*=/.test(attributes);
+    if (!isButton && !isLink && !hasClickHandler && !hasNavigationTarget) {
+      continue;
+    }
+
+    const values = uniqueStrings([
+      normalizeRenderedText(body) ?? "",
+      ...[...body.matchAll(/\{\{?\s*([A-Za-z_$][\w$]*)\s*\}?\}/g)]
+        .flatMap((identifier) => renderedLiteralValues(text, identifier[1])),
+    ]).filter(isUsefulSelector);
+    const kind: E2eSelectorKind = isButton ? "role-button" : isLink ? "role-link" : "click-text";
+    for (const value of values) {
+      selectors.push({ kind, value, file });
+    }
+  }
+  return selectors;
+}
+
+function renderedLiteralValues(text: string, name: string): string[] {
+  const escapedName = escapeRegExp(name);
+  const expressions: string[] = [];
+  const method = new RegExp(`\\b${escapedName}\\s*\\(\\s*\\)\\s*\\{([\\s\\S]{0,800}?)\\n\\s*\\}`, "m").exec(text);
+  if (method?.[1]) {
+    expressions.push(method[1]);
+  }
+  const computed = new RegExp(
+    `\\b(?:const|let)\\s+${escapedName}\\s*=\\s*(?:computed\\(\\s*\\(\\s*\\)\\s*=>\\s*)?([^;\\n]{1,500})`,
+    "m",
+  ).exec(text);
+  if (computed?.[1]) {
+    expressions.push(computed[1]);
+  }
+
+  return uniqueStrings(
+    expressions.flatMap((expression) =>
+      [...expression.matchAll(/["'`]([^"'`\n]{2,120})["'`]/g)]
+        .map((match) => normalizeSelectorValue(match[1]) ?? "")
+        .filter((value) => Boolean(value) && isUsefulSelector(value))
+    ),
+  );
+}
+
+function normalizeRenderedText(value: string | undefined): string | undefined {
+  if (!value || /\{\{?|\}\}?/.test(value)) {
+    return undefined;
+  }
+  return normalizeSelectorValue(value.replace(/<[^>]+>/g, " "));
 }
 
 function extractRoleSelectorsFromText(file: string, text: string): E2eSelector[] {
@@ -10281,7 +10503,10 @@ function selectorRank(kind: E2eSelectorKind): number {
   if (kind === "role-button" || kind === "role-link") {
     return 3;
   }
-  return 4;
+  if (kind === "click-text") {
+    return 4;
+  }
+  return 5;
 }
 
 function slugify(value: string): string {

--- a/src/qa.ts
+++ b/src/qa.ts
@@ -111,7 +111,7 @@ export async function generateQaDraft(rootInput: string, options: QaDraftOptions
 }
 
 const agentListLimit = 6;
-const agentPayloadByteLimit = 8 * 1024 - 1;
+const agentPayloadByteLimit = 4 * 1024 - 1;
 
 function truncateForAgent(value: string, maxLength = 140): string {
   return value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
@@ -241,16 +241,39 @@ export function formatAgentQaDraft(result: QaDraftResult): string {
 interface AgentSummaryShape {
   [key: string]: unknown;
   intents: Array<{
+    title?: unknown;
+    confidence?: unknown;
+    reviewRequired?: unknown;
+    sources?: unknown[];
     lifecycle: unknown[];
     scenarioCount?: number;
     omittedScenarioCount?: number;
-    scenarios: Array<{ assertions: string[] }>;
+    scenarios: Array<{
+      id?: unknown;
+      priority?: unknown;
+      kind?: unknown;
+      title?: unknown;
+      confidence?: unknown;
+      sources?: unknown[];
+      assertions: string[];
+      routing?: { decision?: unknown };
+      automation?: { status?: unknown; blocker?: string };
+    }>;
   }>;
   flows: Array<{
+    title?: unknown;
+    source?: unknown;
+    draft?: unknown;
+    runnable?: unknown;
+    verificationMode?: unknown;
+    entry?: unknown;
+    reviewQuestion?: unknown;
+    successSignal?: unknown;
     changedFiles: string[];
     steps: string[];
     selectors: string[];
     existingEvidence?: string[];
+    scenarioAutomation?: unknown[];
     evidence: string[];
   }>;
   requiredEvidence: unknown[];
@@ -321,6 +344,65 @@ function serializeAgentSummary(summary: AgentSummaryShape): string {
   });
   if (Buffer.byteLength(minimalPayload) <= agentPayloadByteLimit) {
     return minimalPayload;
+  }
+
+  const leanIntents = compact.intents.slice(0, 1).map((intent) => ({
+    title: intent.title,
+    confidence: intent.confidence,
+    reviewRequired: intent.reviewRequired,
+    sources: intent.sources?.slice(0, 1),
+    lifecycle: intent.lifecycle.slice(0, 3),
+    scenarioCount: intent.scenarioCount,
+    omittedScenarioCount: Math.max(0, (intent.scenarioCount ?? intent.scenarios.length) - 2),
+    scenarios: intent.scenarios.slice(0, 2).map((scenario) => ({
+      id: scenario.id,
+      priority: scenario.priority,
+      kind: scenario.kind,
+      title: scenario.title,
+      confidence: scenario.confidence,
+      sources: scenario.sources?.slice(0, 1),
+      routing: scenario.routing ? { decision: scenario.routing.decision } : undefined,
+      automation: scenario.automation
+        ? { status: scenario.automation.status }
+        : undefined,
+    })),
+  }));
+  const leanFlows = compact.flows.slice(0, 1).map((flow) => ({
+    title: flow.title,
+    source: flow.source,
+    draft: flow.draft,
+    runnable: flow.runnable,
+    verificationMode: flow.verificationMode,
+    entry: flow.entry,
+    changedFiles: flow.changedFiles.slice(0, 1),
+    successSignal: flow.successSignal,
+    selectors: flow.selectors.slice(0, 1),
+  }));
+  const leanPayload = JSON.stringify({
+    schema: summary.schema,
+    base: truncateForAgent(String(summary.base ?? ""), 120),
+    head: truncateForAgent(String(summary.head ?? ""), 120),
+    project: summary.project,
+    runner: summary.runner,
+    manifest: summary.manifest ? truncateForAgent(String(summary.manifest), 120) : null,
+    readiness: summary.readiness,
+    scenarioCoverage: summary.scenarioCoverage,
+    testSuite: summary.testSuite,
+    intentCount: summary.intentCount,
+    omittedIntentCount: Math.max(0, numericCount(summary.intentCount) - leanIntents.length),
+    intents: leanIntents,
+    flowCount: summary.flowCount,
+    omittedFlowCount: Math.max(0, numericCount(summary.flowCount) - leanFlows.length),
+    flows: leanFlows,
+    requiredEvidence: compact.requiredEvidence.slice(0, 1),
+    recommendedEvidenceCount: summary.recommendedEvidenceCount,
+    requiredBootstrap: [],
+    prChecklist: compact.prChecklist.slice(0, 1),
+    commands: compact.commands.slice(0, 1),
+    compaction: { maxBytes: agentPayloadByteLimit, originalBytes: Buffer.byteLength(payload), lean: true },
+  });
+  if (Buffer.byteLength(leanPayload) <= agentPayloadByteLimit) {
+    return leanPayload;
   }
 
   return JSON.stringify({

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const TOOL_NAME = "QAMap";
-export const VERSION = "0.4.3";
+export const VERSION = "0.4.4";

--- a/test/benchmarks/web-react-notification-state/base/package.json
+++ b/test/benchmarks/web-react-notification-state/base/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "benchmark-web-react-notification-state",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "@playwright/test": "1.56.0",
+    "react": "19.0.0",
+    "vite": "7.0.0"
+  }
+}

--- a/test/benchmarks/web-react-notification-state/base/playwright.config.ts
+++ b/test/benchmarks/web-react-notification-state/base/playwright.config.ts
@@ -1,0 +1,1 @@
+export default { use: { baseURL: "http://127.0.0.1:4173" } };

--- a/test/benchmarks/web-react-notification-state/base/src/pages/notifications.tsx
+++ b/test/benchmarks/web-react-notification-state/base/src/pages/notifications.tsx
@@ -1,0 +1,3 @@
+export function NotificationsPage() {
+  return <main><h1>Notifications</h1></main>;
+}

--- a/test/benchmarks/web-react-notification-state/head/src/pages/notifications.tsx
+++ b/test/benchmarks/web-react-notification-state/head/src/pages/notifications.tsx
@@ -1,0 +1,17 @@
+import { useState } from "react";
+
+export function NotificationsPage() {
+  const [isNotificationReady, setNotificationReady] = useState(false);
+
+  function sendNotification() {
+    setNotificationReady(true);
+  }
+
+  return (
+    <main>
+      <h1>Notifications</h1>
+      <button type="button" onClick={sendNotification}>Send notification</button>
+      {isNotificationReady && <p>Notification queued</p>}
+    </main>
+  );
+}

--- a/test/benchmarks/web-react-presentation-control/base/package.json
+++ b/test/benchmarks/web-react-presentation-control/base/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "benchmark-web-react-presentation-control",
+  "private": true,
+  "scripts": {
+    "dev": "vite"
+  },
+  "dependencies": {
+    "react": "19.0.0",
+    "vite": "7.0.0"
+  }
+}

--- a/test/benchmarks/web-react-presentation-control/base/src/components/Banner.tsx
+++ b/test/benchmarks/web-react-presentation-control/base/src/components/Banner.tsx
@@ -1,0 +1,3 @@
+export function Banner() {
+  return <p>Account notice</p>;
+}

--- a/test/benchmarks/web-react-presentation-control/head/src/components/Banner.tsx
+++ b/test/benchmarks/web-react-presentation-control/head/src/components/Banner.tsx
@@ -1,0 +1,4 @@
+export function Banner() {
+  const shouldUseDarkText = true;
+  return <p className={shouldUseDarkText ? "text-dark" : "text-light"}>Account notice</p>;
+}

--- a/test/benchmarks/web-vue-document-state/base/package.json
+++ b/test/benchmarks/web-vue-document-state/base/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "benchmark-web-vue-document-state",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "@playwright/test": "1.56.0",
+    "vite": "7.0.0",
+    "vue": "3.5.0"
+  }
+}

--- a/test/benchmarks/web-vue-document-state/base/playwright.config.ts
+++ b/test/benchmarks/web-vue-document-state/base/playwright.config.ts
@@ -1,0 +1,1 @@
+export default { use: { baseURL: "http://127.0.0.1:4173" } };

--- a/test/benchmarks/web-vue-document-state/base/src/pages/documents.vue
+++ b/test/benchmarks/web-vue-document-state/base/src/pages/documents.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { ref } from "vue";
+
+const subscriptionPlan = "archived";
+const isImportReady = ref(false);
+</script>
+
+<template>
+  <main>
+    <h1>Documents</h1>
+    <p>Choose a document</p>
+  </main>
+</template>

--- a/test/benchmarks/web-vue-document-state/head/src/pages/documents.vue
+++ b/test/benchmarks/web-vue-document-state/head/src/pages/documents.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+
+const subscriptionPlan = "archived";
+const isImportReady = ref(false);
+const isImportComplete = ref(false);
+const actionLabel = computed(() => isImportReady.value ? "Import document" : "Request access");
+
+function startImport() {
+  if (!isImportReady.value) return;
+  const params = new URLSearchParams({ source: "documents" });
+  isImportComplete.value = true;
+  window.location.href = `/documents/imported?${params.toString()}`;
+}
+</script>
+
+<template>
+  <main>
+    <h1>Documents</h1>
+    <button type="button" @click="startImport">{{ actionLabel }}</button>
+    <p v-if="isImportComplete">Document imported</p>
+  </main>
+</template>

--- a/test/change-intent.test.mjs
+++ b/test/change-intent.test.mjs
@@ -297,6 +297,46 @@ test("change intent marks connected working-tree signals as review-required diff
   assert.equal(analysis.intents[0].evidence.some((item) => item.symbol === "async"), false);
 });
 
+test("change intent falls back to committed diff signals when commit text is not behavior-bearing", async (t) => {
+  const root = await makeRepo(t);
+  await write(root, "src/pages/billing.tsx", "export function Billing() { return null; }\n");
+  commit(root, "benchmark baseline");
+  branch(root, "fix/billing-summary");
+  await write(
+    root,
+    "src/pages/billing.tsx",
+    [
+      "export function Billing() {",
+      '  const [status, setStatus] = useState("");',
+      "  async function openBilling() {",
+      '    const response = await fetch("/api/billing/summary");',
+      '    setStatus(response.ok ? "Billing loaded" : "Could not load billing");',
+      "  }",
+      '  return <button onClick={openBilling}>Open billing</button>;',
+      "}",
+    ].join("\n"),
+  );
+  commit(root, "load billing summary");
+
+  const analysis = await analyze(root, ["src/pages/billing.tsx"]);
+  const intent = analysis.intents[0];
+  const networkScenario = intent?.scenarios.find((scenario) => /failure, timeout, and retry/i.test(scenario.title));
+
+  assert.equal(analysis.source, "diff-only");
+  assert.equal(analysis.intents.length, 1);
+  assert.equal(intent.commits.length, 0);
+  assert.equal(intent.confidence, "low");
+  assert.equal(intent.reviewRequired, true);
+  assert.match(intent.summary, /commit text did not express a usable intent/i);
+  assert.ok(intent.lifecycle.some((stage) => stage.kind === "trigger"));
+  assert.ok(intent.lifecycle.some((stage) => stage.kind === "state-change"));
+  assert.ok(intent.lifecycle.some((stage) => stage.kind === "side-effect"));
+  assert.equal(intent.scenarios.find((scenario) => scenario.kind === "primary")?.priority, "recommended");
+  assert.ok(networkScenario);
+  assert.equal(routeQaScenario(networkScenario).decision, "recommended");
+  assert.equal(intent.scenarios.some((scenario) => /entry payload/i.test(scenario.title)), false);
+});
+
 test("E2E planning promotes commit intent before runner-specific draft generation", async (t) => {
   const root = await makeRepo(t);
   await write(
@@ -415,11 +455,13 @@ test("E2E planning promotes commit intent before runner-specific draft generatio
   }));
   const compactAgentOutput = formatAgentQaDraft(oversizedQa);
   const compactAgentSummary = JSON.parse(compactAgentOutput);
-  assert.ok(Buffer.byteLength(compactAgentOutput) <= 8 * 1024);
+  assert.ok(Buffer.byteLength(compactAgentOutput) <= 4 * 1024);
   assert.equal(compactAgentSummary.intentCount, 12);
   assert.equal(compactAgentSummary.flowCount, 20);
   assert.equal(compactAgentSummary.omittedIntentCount, 12 - compactAgentSummary.intents.length);
   assert.equal(compactAgentSummary.omittedFlowCount, 20 - compactAgentSummary.flows.length);
+  assert.ok(compactAgentSummary.intents.length > 0);
+  assert.ok(compactAgentSummary.flows.length > 0);
   assert.ok(compactAgentSummary.compaction);
 
   const pathologicalQa = structuredClone(oversizedQa);
@@ -428,8 +470,10 @@ test("E2E planning promotes commit intent before runner-specific draft generatio
   pathologicalQa.manifestPath = `${"manifest/".repeat(1000)}qamap.yaml`;
   const boundedAgentOutput = formatAgentQaDraft(pathologicalQa);
   const boundedAgentSummary = JSON.parse(boundedAgentOutput);
-  assert.ok(Buffer.byteLength(boundedAgentOutput) <= 8 * 1024);
+  assert.ok(Buffer.byteLength(boundedAgentOutput) <= 4 * 1024);
   assert.equal(boundedAgentSummary.schema.name, "qamap.qa");
+  assert.ok(boundedAgentSummary.intents.length > 0);
+  assert.ok(boundedAgentSummary.flows.length > 0);
 });
 
 test("evidence-routed failure QA becomes a separate partial Playwright scenario without domain rules", async (t) => {
@@ -559,6 +603,163 @@ test("evidence-routed failure QA does not reuse an unrelated action selector", a
 
   const spec = await readFile(path.join(root, file.path), "utf8");
   assert.doesNotMatch(spec, /Routed QA scenario:/);
+});
+
+test("Vue conditional actions retain changed UI evidence without unrelated payment setup", async (t) => {
+  const root = await makeRepo(t);
+  await write(
+    root,
+    "package.json",
+    JSON.stringify({
+      scripts: { dev: "vite", "test:e2e": "playwright test" },
+      dependencies: { vue: "3.5.0", vite: "7.0.0", "@playwright/test": "1.56.0" },
+    }),
+  );
+  await write(root, "playwright.config.ts", "export default { use: { baseURL: 'http://127.0.0.1:4173' } };\n");
+  await write(
+    root,
+    "src/pages/documents.vue",
+    [
+      "<script setup lang=\"ts\">",
+      "import { ref } from 'vue';",
+      "const subscriptionPlan = 'archived';",
+      "const isImportReady = ref(false);",
+      "</script>",
+      "<template><main><h1>Documents</h1><p>Choose a document</p></main></template>",
+    ].join("\n"),
+  );
+  commit(root, "benchmark baseline");
+  branch(root, "feat/document-import");
+
+  await write(
+    root,
+    "src/pages/documents.vue",
+    [
+      "<script setup lang=\"ts\">",
+      "import { computed, ref } from 'vue';",
+      "const subscriptionPlan = 'archived';",
+      "const isImportReady = ref(false);",
+      "const isImportComplete = ref(false);",
+      "const actionLabel = computed(() => isImportReady.value ? 'Import document' : 'Request access');",
+      "function startImport() {",
+      "  if (!isImportReady.value) return;",
+      "  const params = new URLSearchParams({ source: 'documents' });",
+      "  isImportComplete.value = true;",
+      "  window.location.href = `/documents/imported?${params.toString()}`;",
+      "}",
+      "</script>",
+      "<template>",
+      "  <main>",
+      "    <h1>Documents</h1>",
+      "    <button type=\"button\" @click=\"startImport\">{{ actionLabel }}</button>",
+      "    <p v-if=\"isImportComplete\">Document imported</p>",
+      "  </main>",
+      "</template>",
+    ].join("\n"),
+  );
+  commit(root, "feat: import document and show completion state");
+
+  const analysis = await analyze(root, ["src/pages/documents.vue"]);
+  assert.ok(
+    analysis.intents[0].lifecycle.some((stage) => /document imported/i.test(stage.label)),
+    JSON.stringify({ lifecycle: analysis.intents[0].lifecycle, evidence: analysis.intents[0].evidence }),
+  );
+  assert.ok(analysis.intents[0].scenarios.some((scenario) => /conditional state and fallback/i.test(scenario.title)));
+  assert.ok(analysis.intents[0].scenarios.some((scenario) => /destination path and query parameters/i.test(scenario.title)));
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const selectors = plan.flows.flatMap((flow) => flow.selectors.map((selector) => selector.value));
+  const setupTitles = plan.flows.flatMap((flow) => flow.setupHints.map((hint) => hint.title));
+  assert.ok(selectors.includes("Import document"));
+  assert.ok(selectors.includes("Request access"));
+  assert.ok(selectors.includes("Document imported"));
+  assert.equal(setupTitles.some((title) => /payment sandbox/i.test(title)), false);
+
+  const draft = await generateE2eDraft(root, { base: "main", head: "HEAD", output: ".generated-e2e" });
+  const file = draft.files.find((candidate) => candidate.source === "change-intent");
+  assert.ok(file);
+  const spec = await readFile(path.join(root, file.path), "utf8");
+  assert.match(spec, /page\.getByRole\("button", \{ name: "Import document" \}\)\.click\(\)/);
+  assert.match(spec, /page\.getByText\("Document imported"\)/);
+  assert.doesNotMatch(spec, /page\.locator\("body"\)/);
+});
+
+test("React conditional UI produces state QA from changed behavior evidence", async (t) => {
+  const root = await makeRepo(t);
+  await write(
+    root,
+    "package.json",
+    JSON.stringify({
+      scripts: { dev: "vite", "test:e2e": "playwright test" },
+      dependencies: { react: "19.0.0", vite: "7.0.0", "@playwright/test": "1.56.0" },
+    }),
+  );
+  await write(root, "playwright.config.ts", "export default { use: { baseURL: 'http://127.0.0.1:4173' } };\n");
+  await write(
+    root,
+    "src/pages/notifications.tsx",
+    "export function NotificationsPage() { return <main><h1>Notifications</h1></main>; }\n",
+  );
+  commit(root, "benchmark baseline");
+  branch(root, "feat/notification-ready-state");
+
+  await write(
+    root,
+    "src/pages/notifications.tsx",
+    [
+      "export function NotificationsPage() {",
+      "  const [isNotificationReady, setNotificationReady] = useState(false);",
+      "  function sendNotification() { setNotificationReady(true); }",
+      "  return <main>",
+      "    <h1>Notifications</h1>",
+      "    <button onClick={sendNotification}>Send notification</button>",
+      "    {isNotificationReady && <p>Notification queued</p>}",
+      "  </main>;",
+      "}",
+    ].join("\n"),
+  );
+  commit(root, "feat: send notification and show queued state");
+
+  const analysis = await analyze(root, ["src/pages/notifications.tsx"]);
+  const conditional = analysis.intents[0].scenarios.find((scenario) => /conditional state and fallback/i.test(scenario.title));
+  assert.ok(conditional);
+  assert.ok(conditional.evidence.some((item) => item.file === "src/pages/notifications.tsx" && item.startLine));
+
+  const draft = await generateE2eDraft(root, { base: "main", head: "HEAD", output: ".generated-e2e" });
+  const file = draft.files.find((candidate) => candidate.source === "change-intent");
+  assert.ok(file);
+  const spec = await readFile(path.join(root, file.path), "utf8");
+  assert.match(spec, /page\.getByRole\("button", \{ name: "Send notification" \}\)\.click\(\)/);
+  assert.match(spec, /page\.getByText\("Notification queued"\)/);
+});
+
+test("presentation-only conditions do not become lifecycle QA scenarios", async (t) => {
+  const root = await makeRepo(t);
+  await write(
+    root,
+    "src/components/Banner.tsx",
+    "export function Banner() { return <p>Account notice</p>; }\n",
+  );
+  commit(root, "benchmark baseline");
+  branch(root, "style/banner-theme");
+  await write(
+    root,
+    "src/components/Banner.tsx",
+    [
+      "export function Banner() {",
+      "  const shouldUseDarkText = true;",
+      "  return <p className={shouldUseDarkText ? 'text-dark' : 'text-light'}>Account notice</p>;",
+      "}",
+    ].join("\n"),
+  );
+  commit(root, "fix: preserve banner theme contrast");
+
+  const analysis = await analyze(root, ["src/components/Banner.tsx"]);
+  assert.equal(analysis.intents.length, 1);
+  assert.equal(
+    analysis.intents[0].scenarios.some((scenario) => /conditional state and fallback/i.test(scenario.title)),
+    false,
+  );
 });
 
 async function analyze(root, files) {

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -675,7 +675,9 @@ test("generateE2ePlan recommends mobile flows for Expo changes", async () => {
   assert.match(uiDraft, /Loading, empty, error, and success states/);
   assert.match(uiDraft, /Validation gaps before this draft can be required/);
   assert.doesNotMatch(uiDraft, /TODO:/);
-  assert.match(uiDraft, /QAMap could not infer a stable Maestro selector/);
+  assert.match(uiDraft, /tapOn: \{ id: "record-mode-ink" \}/);
+  assert.match(uiDraft, /assertVisible: "Ink"/);
+  assert.doesNotMatch(uiDraft, /QAMap could not infer a stable Maestro selector/);
   assert.equal(cliPlan.recommendedRunner.name, "maestro");
   assert.equal(cliDraft.runner, "maestro");
   assert.ok(cliDraft.files.some((file) => file.source === "domain-language"));
@@ -2667,14 +2669,28 @@ test("fixture guidance names the mock handler file to extend and shapes mock pay
     output: "tests/e2e",
     runner: "playwright",
   });
-  const draftFile = draft.files.find((file) => file.fixtureReadinessStatus === "partial");
-  assert.ok(draftFile);
+  const draftFile = draft.files.find(
+    (file) =>
+      file.fixtureReadinessStatus === "partial" &&
+      file.qaScenarios?.some((scenario) => scenario.kind === "failure"),
+  );
+  assert.ok(
+    draftFile,
+    JSON.stringify(
+      draft.files.map((file) => ({
+        flow: file.flowTitle,
+        source: file.source,
+        fixture: file.fixtureReadinessStatus,
+        scenarios: file.qaScenarios?.map((scenario) => ({ kind: scenario.kind, title: scenario.title })),
+      })),
+    ),
+  );
   const spec = await readFile(path.join(root, draftFile.path), "utf8");
   assert.match(spec, /invoices: "qamap-invoices"/);
   assert.match(spec, /total: "qamap-total"/);
   assert.match(spec, /Response shape keys reuse src\/mocks\/handlers\.ts/);
   assert.doesNotMatch(spec, /source: "qamap-draft"/);
-  assert.match(spec, /page\.unroute\("\*\*\/api\/(?:invoices|payments\/summary)"\)/);
+  assert.match(spec, /page\.route\("\*\*\/api\/(?:invoices|payments\/summary)"/);
   assert.match(spec, /status: 500/);
   assert.match(spec, /expect\(page\.getByText\("Could not load billing"\)\)\.toBeVisible\(\)/);
   assert.doesNotMatch(spec, /page\.locator\("body"\)/);
@@ -3054,21 +3070,25 @@ test("generateE2ePlan captures Playwright execution profile and self-check block
   assert.match(markdown, /## Execution Profile/);
   assert.match(markdown, /Start command: `pnpm run dev`/);
   assert.match(markdown, /Base URL: `http:\/\/127\.0\.0\.1:4173`/);
-  assert.equal(draftFile.runnableStatus, "near-runnable");
-  assert.equal(draftFile.selfCheck?.status, "warning");
+  assert.equal(draftFile.runnableStatus, "review-only");
+  assert.equal(draftFile.selfCheck?.status, "fail");
   assert.equal(
     draftFile.selfCheck?.checks.find((check) => check.name === "Domain assertions")?.status,
-    "warning",
+    "pass",
+  );
+  assert.equal(
+    draftFile.selfCheck?.checks.find((check) => check.name === "Compiled actions")?.status,
+    "fail",
   );
   assert.equal(draftFile.selfCheck?.blockers.some((blocker) => /Unresolved placeholders/.test(blocker)), false);
-  assert.equal(draft.readinessSummary.nearRunnable > 0, true);
-  assert.equal(draft.readinessSummary.selfCheckWarning > 0, true);
+  assert.equal(draft.readinessSummary.reviewOnly > 0, true);
+  assert.equal(draft.readinessSummary.selfCheckFail > 0, true);
   assert.equal(draft.readinessSummary.topBlockers.some((blocker) => /Unresolved placeholders/.test(blocker)), false);
   assert.deepEqual(draftFile.executionBlockers?.filter((blocker) => /Playwright|baseURL|start command/i.test(blocker)), []);
   assert.equal((draftFile.blockingValidationGapCount ?? 0) > 0, true);
   assert.deepEqual(draftFile.executionBlockers?.filter((blocker) => /validation gap/i.test(blocker)), []);
-  assert.match(formatMarkdownE2eDraft(draft), /Near-runnable files: 1/);
-  assert.match(formatMarkdownE2eDraft(draft), /Replace starter smoke assertions with domain assertions/);
+  assert.match(formatMarkdownE2eDraft(draft), /Review-only files: 1/);
+  assert.doesNotMatch(formatMarkdownE2eDraft(draft), /Replace starter smoke assertions with domain assertions/);
   assert.doesNotMatch(formatMarkdownE2eDraft(draft), /Replace TODO locators/);
   assert.match(formatMarkdownE2eDraft(draft), /## Draft Self Checks/);
   assert.match(formatMarkdownE2eDraft(draft), /Stage: [a-z ]+ \(\d of 4\) — readiness \d+\/100/);
@@ -3077,6 +3097,8 @@ test("generateE2ePlan captures Playwright execution profile and self-check block
   assert.match(spec, /Test command: pnpm run test:e2e/);
   assert.match(spec, /Base URL: http:\/\/127\.0\.0\.1:4173/);
   assert.match(spec, /page\.getByTestId\("profile-save"\)\.click\(\)/);
+  assert.match(spec, /test\.fixme\(true, "QAMap needs repository evidence for:/);
+  assert.doesNotMatch(spec, /page\.locator\("body"\)/);
   assert.doesNotMatch(spec, /\/\/ TODO: Complete the main Profile action/);
 });
 
@@ -3168,7 +3190,8 @@ test("generateE2ePlan infers Playwright base URLs from dev scripts", async () =>
   assert.match(setupDraftText, /test\("Settings Save"/);
   assert.match(setupDraftText, /page\.goto\("\/settings"\)/);
   assert.match(setupDraftText, /page\.getByLabel\("Save settings"\)\.click\(\)/);
-  assert.match(setupDraftText, /expect\(page\.getByRole\("button", \{ name: "Save settings" \}\)\)\.toBeVisible\(\)/);
+  assert.match(setupDraftText, /test\.fixme\(true, "QAMap needs repository evidence for:/);
+  assert.doesNotMatch(setupDraftText, /expect\(page\.getByRole\("button", \{ name: "Save settings" \}\)\)\.toBeVisible\(\)/);
   assert.match(setupDraftText, /Goal: Protect Settings Save by exercise Save with realistic data from the changed branch/);
   assert.doesNotMatch(setupDraftText, /TODO: Start from the normal entry point/);
   assert.doesNotMatch(setupDraftText, /test\.step\("Start from the normal entry point/);
@@ -3686,7 +3709,8 @@ test("generateE2ePlan matches committed core flow definitions", async () => {
   assert.match(spec, /await test\.step\("Verify declined payment recovery\.", async \(\) => \{/);
   assert.match(spec, /page\.goto\("\/checkout"\)/);
   assert.match(spec, /Step intent: Complete checkout with a valid payment method\./);
-  assert.match(spec, /page\.getByTestId\("checkout-submit"\)\.click\(\)/);
+  assert.match(spec, /page\.getByRole\("button", \{ name: "Complete checkout" \}\)\.click\(\)/);
+  assert.match(spec, /web-test-id: checkout-submit/);
 });
 
 test("generateE2ePlan uses committed domain manifests for language and draft routes", async () => {
@@ -5854,7 +5878,8 @@ test("package metadata includes the portable PR QA skill template", async () => 
 
   assert.ok(packageJson.files.includes("skills"));
   assert.match(skillText, /name: qamap-pr-qa/);
-  assert.match(skillText, /pnpm dlx @ivorycanvas\/qamap qa/);
+  assert.match(skillText, /npm exec --yes --registry=https:\/\/registry\.npmjs\.org --package=@ivorycanvas\/qamap@latest -- qamap qa/);
+  assert.doesNotMatch(skillText, /pnpm dlx/);
   assert.match(skillText, /Manifest Repair/);
 });
 


### PR DESCRIPTION
## Intent

Make first-run, manifest-free QA output follow changed behavior evidence instead of generic runner advice.

- infer connected lifecycle intent from committed diffs even when commit text is not behavior-bearing
- extract React and Vue conditional actions, outcomes, destination state, and failure evidence
- keep low-confidence QA review-required and recommend rather than require it
- compile grounded Playwright and Maestro actions when evidence exists, and emit `test.fixme` instead of a misleading body-only smoke test when it does not
- cap `qa --format agent` below 4 KB while retaining intents, top scenarios, routing, automation status, and omission counts
- make one-off npm and skills.sh installation leave the target repository package metadata untouched

## Agent / Review Risk

The change expands regex-based static inference across framework syntax. False positives and false negatives remain possible when behavior is assembled dynamically or hidden behind project-specific abstractions. Cross-framework positive fixtures and a presentation-only negative control pin the intended boundary.

## Validation Evidence

- [x] `pnpm test` (152/152)
- [x] `pnpm scan` (0 findings)
- [x] Relevant `qamap verify`, `qamap test-plan`, or `qamap e2e plan/draft` output reviewed
- [x] `pnpm bench:ci` (15/15)
- [x] `pnpm release:check`
- [x] `npm publish --dry-run --access public`

Coverage: lines 88.04%, branches 84.32%, functions 95.50%.

## E2E / Manual Coverage

- Vue conditional document-state change recovers its changed action and visible outcome as a near-runnable Playwright draft.
- React notification-state change recovers state-transition QA without fabricating unrelated setup.
- React presentation-only conditional remains excluded from behavioral QA.
- Existing web, mobile, API, shared-component, configuration, and test-only benchmarks continue to pass.
- Isolated one-off npm execution leaves package metadata unchanged.
- Isolated skills CLI installation discovers and installs the packaged `qamap-pr-qa` skill.

## Maintainer Notes

This prepares `v0.4.4`. Squash merge after required checks pass, then publish, create the annotated tag, and create the GitHub Release.

## Collaboration Checklist

- [x] The branch uses an allowed prefix and contains no coding-agent product name.
- [x] The PR title follows `Type: imperative summary`.
- [x] `@ivory-code` is assigned.
- [x] Exactly one `type:` label and only relevant `area:` labels are applied.
- [x] The PR is intended to be squash-merged after required checks pass.