### PR TITLE
Feat: add short QA package commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added framework-neutral conditional-state extraction for React and Vue changes, including changed actions, conditional outcomes, destination parameters, and Unicode selector terms.
 - Added public React and Vue conditional-state benchmarks plus a presentation-only negative control. Benchmark contracts can now reject QA scenarios that must not be inferred.
 - Added a tested `skills` CLI installation path for the packaged `qamap-pr-qa` project skill.
+- Added `qamap init --scripts` for collision-safe repeat-use shortcuts: `qa` for committed branch changes, `qa:local` for working-tree changes, and `qa:e2e` for a read-only E2E draft preview.
 
 ### Changed
 
@@ -18,6 +19,8 @@
 - One-off skill commands use an explicit npm execution environment so they do not invoke Corepack or rewrite a target repository's package-manager metadata.
 - Selector fallback now prefers diff-added, step-related controls and observable copy. Generic exploratory checks remain coverage guidance instead of executable happy-path steps.
 - The README now leads with a real packaged-CLI routing demo and separates scenario priority from automation compilation status before introducing runners or manifests.
+- Quick-start and adoption guidance now separates one-off execution from a shorter checked-in package workflow, while keeping the direct CLI available for non-JavaScript repositories.
+- Human QA output now states whether the run considered committed branch changes only or also included the local working tree, making `qa` and `qa:local` visibly distinct.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,23 @@ npx --yes @ivorycanvas/qamap@latest qa
 
 A manifest and test runner are **not required** for the first run.
 
+For repeat use in a JavaScript repository, install QAMap once and add short package scripts:
+
+```sh
+pnpm add -D @ivorycanvas/qamap
+pnpm exec qamap init --scripts
+```
+
+After that, the everyday workflow is deliberately small:
+
+```sh
+pnpm qa          # committed changes on the current branch
+pnpm qa:local    # also include uncommitted local changes
+pnpm qa:e2e      # preview an E2E draft without writing files
+```
+
+`init --scripts` detects npm, pnpm, Yarn, or Bun, preserves unrelated scripts, and never replaces a name collision unless `--force` is explicit. Non-JavaScript repositories keep using the universal `qamap qa` command directly.
+
 ## What You Get
 
 QAMap keeps QA selection and test generation as two separate decisions:

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -23,6 +23,17 @@ npx --yes @ivorycanvas/qamap@latest e2e draft . --base origin/main --head HEAD -
 npx --yes @ivorycanvas/qamap@latest e2e draft . --base origin/main --head HEAD
 ```
 
+For a repository that will run QAMap repeatedly, replace the long one-off command with checked-in package scripts:
+
+```sh
+pnpm add -D @ivorycanvas/qamap
+pnpm exec qamap init --scripts
+pnpm qa
+pnpm qa:local
+```
+
+`pnpm qa` reads the committed branch diff. `pnpm qa:local` includes uncommitted working-tree changes while a developer is still iterating. The initializer keeps existing script names unless `--force` is explicitly accepted.
+
 For a combined PR verification report with readiness gates, add `verify`:
 
 ```sh
@@ -226,4 +237,3 @@ QAMap is intentionally small:
 It is built for teams using AI coding agents, MCP-powered tools, or any workflow where an agent can read, edit, test, commit, or open pull requests.
 
 For PR verification, QAMap treats the repository itself as the working base: committed manifests hold durable team language, ignored local history holds generated run observations, and the current branch diff supplies what changed now.
-

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -15,6 +15,7 @@ pnpm exec qamap manifest init .
 pnpm exec qamap manifest validate .
 pnpm exec qamap manifest explain . --base origin/main --head HEAD
 pnpm exec qamap e2e draft . --base origin/main --head HEAD --dry-run
+pnpm exec qamap init --scripts .
 ```
 
 Use `npx --yes @ivorycanvas/qamap@latest ...` for one-off human runs without installing QAMap into the target repository. Packaged agent skills use an explicit `npm exec --package` form so they do not invoke the target repository's package manager or Corepack metadata flow.
@@ -83,8 +84,21 @@ That means QAMap is most valuable when it becomes the team's verification base: 
 | `qamap context . --write AGENTS.md` | Generate starter agent instructions for the repo. |
 | `qamap init .` | Create a starter `qamap.config.json`. |
 | `qamap init --agent .` | One-command agent onboarding: add a marked QAMap Pre-PR QA section to `AGENTS.md`, install the packaged skill to `.claude/skills/qamap-pr-qa/SKILL.md`, and create `qamap.config.json` if missing. Idempotent; existing `AGENTS.md` content is preserved. |
+| `qamap init --scripts .` | Add collision-safe `qa`, `qa:local`, and `qa:e2e` package scripts for repeat use in a JavaScript repository. |
 
 For monorepos, pass `--workspace-root` when scanning a package. Package-local checks still use the package directory, while repo-level guardrails such as `AGENTS.md`, `.github/workflows`, `LICENSE`, `SECURITY.md`, and `CONTRIBUTING.md` are read from the workspace root.
+
+### Short Package Scripts
+
+After installing QAMap as a development dependency, run `qamap init --scripts .` once. The initializer detects the repository package manager and adds these shortcuts without changing an existing script unless `--force` is passed:
+
+| Script | Installed command | Purpose |
+| --- | --- | --- |
+| `qa` | `qamap qa .` | Analyze committed changes on the current branch. |
+| `qa:local` | `qamap qa . --include-working-tree` | Include staged, unstaged, and untracked working-tree changes. |
+| `qa:e2e` | `qamap e2e draft . --dry-run` | Preview the optional E2E draft without writing files. |
+
+For pnpm, these become `pnpm qa`, `pnpm qa:local`, and `pnpm qa:e2e`. npm uses `npm run <script>`; Yarn and Bun use their normal script syntax. The generated commands omit a hard-coded base branch so QAMap can infer the repository default. Repositories that cannot infer a base can still pass `--base <ref>` through the script or use the full CLI command.
 
 `qamap review` compares a branch against a base ref for PR-style workflows. It separates newly introduced findings from risky files that already had findings on the base branch but were modified again, which helps reviewers notice when a PR touches known-dangerous surfaces such as committed `.env` files, MCP configs, or release scripts.
 

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -2,24 +2,27 @@
 
 ## 0.4.4 - 2026-07-15
 
-Validated as a cross-framework evidence and honest-draft patch. QAMap now recovers conservative change intent from connected diff behavior even when commit text is not descriptive, maps React and Vue conditional states to changed actions and observable outcomes, and keeps unsupported outcomes review-only instead of generating a green smoke assertion:
+Validated as a cross-framework evidence, honest-draft, and repeat-use UX patch. QAMap recovers conservative change intent from connected diff behavior even when commit text is not descriptive, maps React and Vue conditional states to changed actions and observable outcomes, keeps unsupported outcomes review-only, and can install short collision-safe package scripts for everyday branch and working-tree QA:
 
 | Gate | Current result |
 | --- | --- |
 | `pnpm release:check` | Passed end to end |
-| `pnpm test` | 152/152 passing |
+| `pnpm test` | 166/166 passing |
 | `pnpm scan` | 0 findings |
 | `pnpm bench:ci` | 15/15 synthetic PR targets pass; React and Vue conditional-state positives recover actions/outcomes while a presentation-only negative control rejects behavioral state QA |
-| Coverage | Lines 88.04%, branches 84.32%, functions 95.50% |
-| Change Intent coverage | Lines 97.97%, branches 91.82%, functions 99.30% |
+| Coverage | Lines 88.32%, branches 84.69%, functions 95.53% |
+| Change Intent coverage | Lines 97.40%, branches 91.15%, functions 99.30% |
+| Short-command initializer | Lines 100%, branches 97.14%, functions 100%; npm, pnpm, Yarn, Bun, collisions, force replacement, malformed metadata, idempotency, and CLI entry are covered |
 | Agent payload | Global output stays below 4KB; complex web and mobile lifecycle fixtures retain intent/scenario/flow context in 3,172 and 3,133 bytes instead of falling back to an empty emergency summary |
 | One-off repository safety | The documented npm execution command left an isolated repository's `package.json` hash unchanged and created no lockfile or package-manager metadata |
 | Skill compatibility | The public repository was discovered by the `skills` CLI and `qamap-pr-qa` installed as a project skill in an isolated home/project |
-| Package preview | `pnpm pack --dry-run` and `npm pack --dry-run` pass for `@ivorycanvas/qamap@0.4.4`; 134 files, 924.1 kB packed |
+| Package preview | `pnpm pack --dry-run` and `npm pack --dry-run` pass for `@ivorycanvas/qamap@0.4.4`; 137 files, 928.3 kB packed |
 
 The React and Vue fixtures are not product-specific framework rules. They express equivalent conditional user behavior through different syntax, while the negative control proves that a presentation condition alone cannot create lifecycle QA. Benchmarks materialize temporary Git repositories, do not install fixture dependencies, and do not execute fixture applications.
 
 Low-confidence diff-only intent remains review-required and recommended. Located lines alone do not promote it to a required blocker. When a repository exposes a stable action and observable failure outcome, QAMap can still compile a separate Playwright failure scenario; when an outcome is absent, the draft emits `test.fixme` rather than treating the clicked control or document body as proof of success.
+
+Repeat-use setup is explicit and repository-local: `qamap init --scripts` adds `qa`, `qa:local`, and `qa:e2e` only to JavaScript package metadata, preserves conflicting script names unless `--force` is passed, and reports the package-specific install command when QAMap is not yet a dependency. The `qa` report also states whether working-tree changes were included so the two analysis scopes cannot be confused.
 
 ## 0.4.3 - 2026-07-14
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,7 @@ import { formatMarkdownReport, formatSarifReport, formatTextReport, hasFindingsA
 import { formatAgentQaDraft, formatMarkdownQaDraft, generateQaDraft } from "./qa.js";
 import { formatMarkdownReviewReport, formatReviewReport, reviewProject } from "./review.js";
 import { scanProject } from "./scanner.js";
+import { formatQaScriptInitReport, initializeQaScripts } from "./script-init.js";
 import { isAtLeastSeverity, isSeverity } from "./severity.js";
 import { formatMarkdownTestPlan, generateTestPlan } from "./test-plan.js";
 import { colorizeReport, shouldColorize } from "./terminal.js";
@@ -83,6 +84,7 @@ interface ParsedOptions {
   recordHistory?: boolean;
   dryRun?: boolean;
   agent?: boolean;
+  scripts?: boolean;
 }
 
 async function main(argv: string[]): Promise<number> {
@@ -487,9 +489,17 @@ async function main(argv: string[]): Promise<number> {
 
   if (command === "init") {
     const options = parseOptions(rest);
+    if (options.agent && options.scripts) {
+      throw new Error("Choose either --agent or --scripts for one init run.");
+    }
     if (options.agent) {
       const result = await initAgentSetup(options.path, { force: options.force });
       await printOrWrite(formatAgentInitReport(result));
+      return 0;
+    }
+    if (options.scripts) {
+      const result = await initializeQaScripts(options.path, { force: options.force });
+      await printOrWrite(formatQaScriptInitReport(result));
       return 0;
     }
     const outputPath = await writeDefaultConfig(options.path, options.write ?? "qamap.config.json", options.force);
@@ -524,6 +534,11 @@ function parseOptions(args: string[]): ParsedOptions {
 
     if (arg === "--agent") {
       options.agent = true;
+      continue;
+    }
+
+    if (arg === "--scripts") {
+      options.scripts = true;
       continue;
     }
 
@@ -924,6 +939,10 @@ Want your agent to run QAMap by itself? Run once: qamap init --agent
       Adds a Pre-PR QA section to AGENTS.md and installs the packaged
       QAMap skill, so agents run the QA pass before every handoff.
 
+Want shorter commands for repeat use? Run once: qamap init --scripts
+      Adds qa, qa:local, and qa:e2e package scripts without replacing
+      existing scripts unless --force is passed.
+
 Full command reference: qamap help`);
 }
 
@@ -956,6 +975,7 @@ Usage:
   qamap context [path] [--write [file]] [--force]
   qamap init [path] [--write <file>] [--force]
   qamap init --agent [path] [--force]
+  qamap init --scripts [path] [--force]
 
 Severities:
   info, low, medium, high
@@ -994,6 +1014,7 @@ Examples:
   qamap context . --write AGENTS.md
   qamap init .
   qamap init --agent .
+  qamap init --scripts .
 `);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,12 @@ export { formatAgentQaDraft, formatMarkdownQaDraft, generateQaDraft } from "./qa
 export { formatMarkdownReviewReport, formatReviewReport, reviewProject } from "./review.js";
 export { isRequiredScenarioEvidence, routeQaScenario } from "./scenario-routing.js";
 export { scanProject } from "./scanner.js";
+export {
+  formatQaScriptInitReport,
+  initializeQaScripts,
+  qamapPackageName,
+  recommendedQaScripts,
+} from "./script-init.js";
 export { collectTestSuiteInventory, evaluateFlowCoverageEvidence, summarizeTestSuiteInventory } from "./test-evidence.js";
 export {
   addedDiffTextFromEvidence,
@@ -207,6 +213,13 @@ export type {
 } from "./flows.js";
 export type { GitHubActionMode, GitHubActionOptions, GitHubActionResult } from "./github.js";
 export type { QaScenarioDecision, QaScenarioSelectionReceipt } from "./scenario-routing.js";
+export type {
+  JavaScriptPackageManager,
+  QaScriptEntry,
+  QaScriptInitResult,
+  QaScriptName,
+  QaScriptStatus,
+} from "./script-init.js";
 export type { E2ePlanHistorySnapshot, LocalHistoryInitResult, LocalHistoryReference } from "./history.js";
 export type {
   DomainManifestSuggestionResult,

--- a/src/qa.ts
+++ b/src/qa.ts
@@ -26,6 +26,7 @@ export interface QaDraftResult {
   generatedAt: string;
   base: string;
   head: string;
+  includeWorkingTree: boolean;
   project: E2eProjectType;
   runner: E2eRunnerName;
   manifestPath?: string;
@@ -92,6 +93,7 @@ export async function generateQaDraft(rootInput: string, options: QaDraftOptions
     generatedAt: new Date().toISOString(),
     base: draft.plan.base,
     head: draft.plan.head,
+    includeWorkingTree: draft.plan.includeWorkingTree,
     project: draft.plan.project.type,
     runner: draft.runner,
     manifestPath: draft.plan.verificationManifestPath,
@@ -543,6 +545,7 @@ export function formatMarkdownQaDraft(result: QaDraftResult): string {
   lines.push(`- Root: \`${escapeMarkdownInline(result.root)}\``);
   lines.push(`- Base: \`${escapeMarkdownInline(result.base)}\``);
   lines.push(`- Head: \`${escapeMarkdownInline(result.head)}\``);
+  lines.push(`- Change scope: ${result.includeWorkingTree ? "committed and uncommitted working-tree changes" : "committed branch changes only"}`);
   lines.push(`- Project: ${formatProjectType(result.project)}`);
   lines.push(`- Manifest: ${result.manifestPath ? `\`${escapeMarkdownInline(result.manifestPath)}\`` : "not found; using repo signals and PR diff only"}`);
   lines.push(`- Stage: ${formatDraftReadinessStage(result.readiness)}`);

--- a/src/script-init.ts
+++ b/src/script-init.ts
@@ -1,0 +1,217 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { pathExists } from "./fs.js";
+
+export const qamapPackageName = "@ivorycanvas/qamap";
+
+export const recommendedQaScripts = {
+  qa: "qamap qa .",
+  "qa:local": "qamap qa . --include-working-tree",
+  "qa:e2e": "qamap e2e draft . --dry-run",
+} as const;
+
+export type QaScriptName = keyof typeof recommendedQaScripts;
+export type QaScriptStatus = "created" | "updated" | "unchanged" | "skipped";
+export type JavaScriptPackageManager = "npm" | "pnpm" | "yarn" | "bun";
+
+export interface QaScriptEntry {
+  name: QaScriptName;
+  command: string;
+  status: QaScriptStatus;
+  detail: string;
+}
+
+export interface QaScriptInitResult {
+  root: string;
+  packageJsonPath: string;
+  packageManager: JavaScriptPackageManager;
+  scripts: QaScriptEntry[];
+  dependencyPresent: boolean;
+  installCommand?: string;
+  runCommands: Record<QaScriptName, string>;
+}
+
+interface PackageJsonRecord extends Record<string, unknown> {
+  packageManager?: unknown;
+  scripts?: unknown;
+  dependencies?: unknown;
+  devDependencies?: unknown;
+  optionalDependencies?: unknown;
+}
+
+export async function initializeQaScripts(
+  rootInput: string,
+  options: { force?: boolean } = {},
+): Promise<QaScriptInitResult> {
+  const root = path.resolve(rootInput);
+  const packageJsonPath = path.join(root, "package.json");
+  if (!(await pathExists(packageJsonPath))) {
+    throw new Error(
+      `Could not find package.json at ${packageJsonPath}. Short package scripts are available only for JavaScript repositories; use \`qamap qa .\` directly elsewhere.`,
+    );
+  }
+
+  const raw = await fs.readFile(packageJsonPath, "utf8");
+  const packageJson = parsePackageJson(raw, packageJsonPath);
+  const scripts = normalizeScripts(packageJson.scripts, packageJsonPath);
+  const entries: QaScriptEntry[] = [];
+  let changed = false;
+
+  for (const [name, command] of Object.entries(recommendedQaScripts) as Array<[QaScriptName, string]>) {
+    const existing = scripts[name];
+    if (existing === command) {
+      entries.push({ name, command, status: "unchanged", detail: "already configured" });
+      continue;
+    }
+    if (existing !== undefined && !options.force) {
+      entries.push({
+        name,
+        command,
+        status: "skipped",
+        detail: `kept existing script: ${existing}`,
+      });
+      continue;
+    }
+
+    scripts[name] = command;
+    changed = true;
+    entries.push({
+      name,
+      command,
+      status: existing === undefined ? "created" : "updated",
+      detail: existing === undefined ? "added QAMap shortcut" : "replaced existing script (--force)",
+    });
+  }
+
+  if (changed) {
+    packageJson.scripts = scripts;
+    await fs.writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, detectIndent(raw))}\n`, "utf8");
+  }
+
+  const packageManager = await detectPackageManager(root, packageJson.packageManager);
+  const dependencyPresent = hasQamapDependency(packageJson);
+
+  return {
+    root,
+    packageJsonPath,
+    packageManager,
+    scripts: entries,
+    dependencyPresent,
+    installCommand: dependencyPresent ? undefined : installCommandFor(packageManager),
+    runCommands: {
+      qa: runCommandFor(packageManager, "qa"),
+      "qa:local": runCommandFor(packageManager, "qa:local"),
+      "qa:e2e": runCommandFor(packageManager, "qa:e2e"),
+    },
+  };
+}
+
+export function formatQaScriptInitReport(result: QaScriptInitResult): string {
+  const lines = ["# QAMap Short Commands", ""];
+  for (const script of result.scripts) {
+    lines.push(`- [${script.status}] \`${script.name}\` -> \`${script.command}\` (${script.detail})`);
+  }
+
+  lines.push("");
+  if (result.installCommand) {
+    lines.push("QAMap is not declared in this package yet. Install it before using the shortcuts:");
+    lines.push("");
+    lines.push(`  ${result.installCommand}`);
+    lines.push("");
+  }
+
+  lines.push("Use:");
+  lines.push("");
+  lines.push(`  ${result.runCommands.qa}          committed changes on the current branch`);
+  lines.push(`  ${result.runCommands["qa:local"]}    include uncommitted working-tree changes`);
+  lines.push(`  ${result.runCommands["qa:e2e"]}      preview an E2E draft without writing files`);
+  lines.push("");
+  lines.push("The base branch is inferred. Pass extra QAMap options through the package script when a repository needs an explicit base.");
+  lines.push("");
+  return lines.join("\n");
+}
+
+function parsePackageJson(raw: string, packageJsonPath: string): PackageJsonRecord {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Could not parse package.json at ${packageJsonPath}: ${message}`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`package.json must contain a JSON object: ${packageJsonPath}`);
+  }
+  return parsed as PackageJsonRecord;
+}
+
+function normalizeScripts(value: unknown, packageJsonPath: string): Record<string, string> {
+  if (value === undefined) {
+    return {};
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`package.json scripts must be an object: ${packageJsonPath}`);
+  }
+
+  const scripts: Record<string, string> = {};
+  for (const [name, command] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof command !== "string") {
+      throw new Error(`package.json script ${name} must be a string: ${packageJsonPath}`);
+    }
+    scripts[name] = command;
+  }
+  return scripts;
+}
+
+function detectIndent(raw: string): number | string {
+  const match = raw.match(/^([ \t]+)"/m);
+  if (!match) {
+    return 2;
+  }
+  return match[1].includes("\t") ? "\t" : Math.max(1, match[1].length);
+}
+
+async function detectPackageManager(root: string, declared: unknown): Promise<JavaScriptPackageManager> {
+  if (typeof declared === "string") {
+    const name = declared.split("@")[0];
+    if (name === "npm" || name === "pnpm" || name === "yarn" || name === "bun") {
+      return name;
+    }
+  }
+  if (await pathExists(path.join(root, "pnpm-lock.yaml"))) {
+    return "pnpm";
+  }
+  if (await pathExists(path.join(root, "yarn.lock"))) {
+    return "yarn";
+  }
+  if ((await pathExists(path.join(root, "bun.lock"))) || (await pathExists(path.join(root, "bun.lockb")))) {
+    return "bun";
+  }
+  return "npm";
+}
+
+function hasQamapDependency(packageJson: PackageJsonRecord): boolean {
+  return [packageJson.dependencies, packageJson.devDependencies, packageJson.optionalDependencies].some(
+    (group) => Boolean(group && typeof group === "object" && !Array.isArray(group) && qamapPackageName in group),
+  );
+}
+
+function installCommandFor(packageManager: JavaScriptPackageManager): string {
+  if (packageManager === "pnpm") {
+    return `pnpm add -D ${qamapPackageName}`;
+  }
+  if (packageManager === "yarn") {
+    return `yarn add -D ${qamapPackageName}`;
+  }
+  if (packageManager === "bun") {
+    return `bun add -d ${qamapPackageName}`;
+  }
+  return `npm install --save-dev ${qamapPackageName}`;
+}
+
+function runCommandFor(packageManager: JavaScriptPackageManager, script: QaScriptName): string {
+  if (packageManager === "npm" || packageManager === "bun") {
+    return `${packageManager} run ${script}`;
+  }
+  return `${packageManager} ${script}`;
+}

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -23,6 +23,7 @@ import {
   formatMarkdownE2eSetup,
   formatAgentQaDraft,
   formatMarkdownQaDraft,
+  formatQaScriptInitReport,
   formatMarkdownReviewReport,
   formatMarkdownTestPlan,
   formatMarkdownVerifyReport,
@@ -38,6 +39,7 @@ import {
   generateTestPlan,
   loadVerificationManifest,
   initializeLocalHistory,
+  initializeQaScripts,
   loadConfig,
   localHistoryGitignorePatterns,
   reviewProject,
@@ -4348,6 +4350,184 @@ test("writeDefaultConfig creates a starter config", async () => {
   assert.equal(loaded.config.failOn, "high");
   assert.deepEqual(loaded.config.ignoreRules, []);
   assert.deepEqual(loaded.config.validationCommands, []);
+});
+
+test("initializeQaScripts adds short repeat-use commands and stays idempotent", async () => {
+  const root = await makeTempRepo();
+  await writeFile(
+    path.join(root, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "script-smoke",
+        packageManager: "pnpm@10.0.0",
+        scripts: { test: "node --test" },
+        devDependencies: { "@ivorycanvas/qamap": "^0.4.4" },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const first = await initializeQaScripts(root);
+  assert.deepEqual(first.scripts.map((script) => script.status), ["created", "created", "created"]);
+  assert.equal(first.packageManager, "pnpm");
+  assert.equal(first.dependencyPresent, true);
+  assert.equal(first.installCommand, undefined);
+  assert.deepEqual(first.runCommands, {
+    qa: "pnpm qa",
+    "qa:local": "pnpm qa:local",
+    "qa:e2e": "pnpm qa:e2e",
+  });
+
+  const packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
+  assert.equal(packageJson.scripts.test, "node --test");
+  assert.equal(packageJson.scripts.qa, "qamap qa .");
+  assert.equal(packageJson.scripts["qa:local"], "qamap qa . --include-working-tree");
+  assert.equal(packageJson.scripts["qa:e2e"], "qamap e2e draft . --dry-run");
+
+  const second = await initializeQaScripts(root);
+  assert.deepEqual(second.scripts.map((script) => script.status), ["unchanged", "unchanged", "unchanged"]);
+  const report = formatQaScriptInitReport(second);
+  assert.match(report, /pnpm qa\s+committed changes/);
+  assert.match(report, /pnpm qa:local\s+include uncommitted/);
+});
+
+test("initializeQaScripts preserves collisions unless force is explicit", async () => {
+  const root = await makeTempRepo();
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      name: "script-collision",
+      scripts: { qa: "company-qa" },
+    }),
+  );
+
+  const first = await initializeQaScripts(root);
+  assert.equal(first.scripts[0].status, "skipped");
+  assert.equal(first.packageManager, "npm");
+  assert.equal(first.dependencyPresent, false);
+  assert.equal(first.installCommand, "npm install --save-dev @ivorycanvas/qamap");
+  assert.match(formatQaScriptInitReport(first), /npm install --save-dev @ivorycanvas\/qamap/);
+  let packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
+  assert.equal(packageJson.scripts.qa, "company-qa");
+
+  const forced = await initializeQaScripts(root, { force: true });
+  assert.equal(forced.scripts[0].status, "updated");
+  packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
+  assert.equal(packageJson.scripts.qa, "qamap qa .");
+});
+
+test("initializeQaScripts explains that non-JavaScript repositories keep the direct CLI", async () => {
+  const root = await makeTempRepo();
+  await assert.rejects(
+    initializeQaScripts(root),
+    /Short package scripts are available only for JavaScript repositories; use `qamap qa \.` directly elsewhere/,
+  );
+});
+
+test("init --scripts exposes the short-command setup through the CLI", async () => {
+  const root = await makeTempRepo();
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      name: "script-cli",
+      packageManager: "pnpm@10.0.0",
+      devDependencies: { "@ivorycanvas/qamap": "^0.4.4" },
+    }),
+  );
+
+  const { stdout } = await execFileAsync(process.execPath, [cliPath, "init", "--scripts", root]);
+  const packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
+
+  assert.match(stdout, /# QAMap Short Commands/);
+  assert.match(stdout, /pnpm qa:local/);
+  assert.equal(packageJson.scripts.qa, "qamap qa .");
+  assert.equal(packageJson.scripts["qa:local"], "qamap qa . --include-working-tree");
+});
+
+test("initializeQaScripts detects lockfile package managers and preserves indentation", async (t) => {
+  const cases = [
+    {
+      name: "pnpm",
+      lockfile: "pnpm-lock.yaml",
+      install: "pnpm add -D @ivorycanvas/qamap",
+      run: "pnpm qa",
+    },
+    {
+      name: "yarn",
+      lockfile: "yarn.lock",
+      install: "yarn add -D @ivorycanvas/qamap",
+      run: "yarn qa",
+    },
+    {
+      name: "bun",
+      lockfile: "bun.lockb",
+      install: "bun add -d @ivorycanvas/qamap",
+      run: "bun run qa",
+    },
+  ];
+
+  for (const fixture of cases) {
+    await t.test(fixture.name, async () => {
+      const root = await makeTempRepo();
+      await writeFile(path.join(root, "package.json"), '{\n\t"name": "manager-smoke"\n}\n');
+      await writeFile(path.join(root, fixture.lockfile), "");
+
+      const result = await initializeQaScripts(root);
+      const updated = await readFile(path.join(root, "package.json"), "utf8");
+
+      assert.equal(result.packageManager, fixture.name);
+      assert.equal(result.installCommand, fixture.install);
+      assert.equal(result.runCommands.qa, fixture.run);
+      assert.match(updated, /\n\t"name"/);
+      assert.match(updated, /\n\t"scripts"/);
+    });
+  }
+});
+
+test("initializeQaScripts rejects malformed package metadata before writing", async (t) => {
+  const cases = [
+    { name: "invalid JSON", value: "{", error: /Could not parse package\.json/ },
+    { name: "array root", value: "[]", error: /package\.json must contain a JSON object/ },
+    { name: "invalid scripts object", value: '{"scripts":"qa"}', error: /package\.json scripts must be an object/ },
+    { name: "invalid script command", value: '{"scripts":{"qa":1}}', error: /package\.json script qa must be a string/ },
+  ];
+
+  for (const fixture of cases) {
+    await t.test(fixture.name, async () => {
+      const root = await makeTempRepo();
+      await writeFile(path.join(root, "package.json"), fixture.value);
+      await assert.rejects(initializeQaScripts(root), fixture.error);
+      assert.equal(await readFile(path.join(root, "package.json"), "utf8"), fixture.value);
+    });
+  }
+});
+
+test("qa output makes the short-command change scope visible", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src"), { recursive: true });
+  await writeFile(path.join(root, "package.json"), JSON.stringify({ name: "scope-smoke" }));
+  await writeFile(path.join(root, "src/save.tsx"), "export function Save() { return <button>Save</button>; }\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "baseline"]);
+  await git(root, ["branch", "-M", "main"]);
+  await git(root, ["switch", "-c", "feature/save-state"]);
+  await writeFile(
+    path.join(root, "src/save.tsx"),
+    "export function Save() { return <button onClick={() => save()}>Save changes</button>; }\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "feat: save profile changes"]);
+  await writeFile(path.join(root, "src/retry.ts"), "export const retrySave = () => save();\n");
+
+  const committed = await generateQaDraft(root, { base: "main", head: "HEAD" });
+  const local = await generateQaDraft(root, { base: "main", head: "HEAD", includeWorkingTree: true });
+
+  assert.equal(committed.includeWorkingTree, false);
+  assert.equal(local.includeWorkingTree, true);
+  assert.match(formatMarkdownQaDraft(committed), /Change scope: committed branch changes only/);
+  assert.match(formatMarkdownQaDraft(local), /Change scope: committed and uncommitted working-tree changes/);
 });
 
 test("initializeLocalHistory protects local runs with gitignore entries", async () => {


### PR DESCRIPTION
## Intent

Add an opt-in `qamap init --scripts` onboarding path for repositories that run QAMap repeatedly. It installs collision-safe package shortcuts:

- `qa` for committed branch changes
- `qa:local` for committed plus working-tree changes
- `qa:e2e` for a read-only E2E draft preview

The initializer detects npm, pnpm, Yarn, and Bun, preserves unrelated scripts, and only replaces collisions when `--force` is explicit. Human QA output now states which change scope was analyzed.

## Agent / Review Risk

Low and localized to package metadata initialization. The command requires the explicit `--scripts` flag, rejects malformed package metadata before writing, stays idempotent, and does not apply to non-JavaScript repositories. Existing script names are preserved by default.

## Validation Evidence

- [x] `pnpm test` (166/166 passing)
- [x] `pnpm scan` (0 findings)
- [x] Relevant QAMap output reviewed through `pnpm bench:ci` (15/15 targets)
- [x] `pnpm release:check`
- [x] Coverage: lines 88.32%, branches 84.69%, functions 95.53%
- [x] New initializer coverage: lines 100%, branches 97.14%, functions 100%
- [x] `npm pack --dry-run --json` includes the new compiled module

## E2E / Manual Coverage

No application E2E runner is needed for this package-metadata workflow. Tests cover the exported initializer, the real CLI entry point, idempotency, collisions, force replacement, malformed JSON, npm/pnpm/Yarn/Bun detection, indentation preservation, and visible branch-versus-working-tree output.

## Maintainer Notes

This keeps the universal one-off CLI unchanged. JavaScript repositories can opt into short checked-in scripts after adding QAMap as a development dependency.

## Collaboration Checklist

- [x] The branch uses an allowed prefix and contains no coding-agent product name.
- [x] The PR title follows `Type: imperative summary`.
- [x] `@ivory-code` is assigned.
- [x] Exactly one `type:` label and only relevant `area:` labels are applied.
- [x] The PR is intended to be squash-merged after required checks pass.
