### PR TITLE
Fix: ground QA routing in the full diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ### Changed
 
+- QA routing now analyzes every behavior-bearing file in the full branch diff even when its commit subject is release-shaped or otherwise non-behavioral. Commit subjects label intent; they no longer define the analysis boundary.
+- Runner setup is reported as an optional automation prerequisite instead of an execution blocker for the runner-independent QA judgment and scenario-routing stages.
+- Low-confidence diff intent now composes with repository-derived action scenarios when that produces a more concrete draft, while broad multi-risk changes retain one evidence-rich lifecycle for deterministic compilers.
+- Selector evidence is sampled across changed files and control types so one large component or registry cannot crowd routes, outcomes, and actionable controls out of the draft.
 - Agent output now stays below 4KB and preserves at least the highest-priority intent, routed scenarios, affected flow, source, and omitted counts when compacted.
 - Low-confidence diff-only scenarios remain recommendations until stronger intent evidence promotes them; they no longer become required automation blockers merely because a diff hunk has a location.
 - One-off skill commands use an explicit npm execution environment so they do not invoke Corepack or rewrite a target repository's package-manager metadata.
@@ -24,6 +28,10 @@
 
 ### Fixed
 
+- Commit clusters now use each commit's actual changed files, ignore shared Conventional Commit scope as product evidence, and analyze residual behavior files that were previously hidden behind unrelated commit titles.
+- Reverse-import analysis now parses JSONC path aliases without treating strings such as `@/*` and `**/*.ts` as comments, restoring changed-component propagation to real route surfaces.
+- URL-backed UI state now produces restoration, reload, default cleanup, and invalid-value fallback QA when the diff reads and writes the same query key.
+- Share and media lifecycle evidence can compile deterministic Playwright scenarios for native completion, cancellation, clipboard fallback, play, pause, completion, and restart without requiring a pre-existing Playwright setup.
 - Generated drafts no longer pass by asserting only the document body or by reusing the clicked control as proof of success. Missing outcomes produce an explicit review-only `test.fixme` marker.
 - Generic UI copy such as `Request access`, `Open billing`, or an existing `subscription` symbol no longer fabricates network, external-entry, or payment setup without supporting diff evidence.
 - Vue templates, computed labels, React handlers, multiline visible text, and exact token overlap now produce more stable action and outcome selectors.

--- a/src/change-intent.ts
+++ b/src/change-intent.ts
@@ -37,6 +37,7 @@ export interface ChangeIntentCommit {
   sha: string;
   subject: string;
   body?: string;
+  files?: string[];
   conventionalType?: string;
   scope?: string;
   statement: string;
@@ -119,7 +120,8 @@ const ignoredCommitTypes = new Set(["build", "chore", "ci", "docs", "release", "
 const maxCommits = 50;
 const maxIntentFiles = 20;
 const maxLifecycleStages = 12;
-const maxSignals = 40;
+const maxQaScenariosPerIntent = 10;
+const maxSignals = 96;
 
 const stopWords = new Set([
   "a",
@@ -187,20 +189,33 @@ export async function analyzeChangeIntents(
   const riskEvidence = collectDiffRiskEvidence(options.addedDiffEvidence ?? {});
   const changedFiles = options.changedFiles.map((file) => file.path);
   const commitClusters = clusterBehaviorCommits(parsedCommits);
-  const intents = commitClusters.map((cluster, index) =>
-    buildCommitIntent(
-      cluster,
-      index,
-      commitClusters.length,
-      changedFiles,
-      options.addedDiffText ?? {},
-      codeSignals,
-      riskEvidence,
-    ),
-  );
+  const intents = commitClusters
+    .map((cluster, index) =>
+      buildCommitIntent(
+        cluster,
+        index,
+        commitClusters.length,
+        changedFiles,
+        options.addedDiffText ?? {},
+        codeSignals,
+        riskEvidence,
+      )
+    )
+    .filter((intent) => intent.files.length > 0);
 
-  if (intents.length === 0) {
-    const diffIntent = buildDiffOnlyIntent(changedFiles, codeSignals, options.includeWorkingTree ?? false);
+  const coveredFiles = new Set(intents.flatMap((intent) => intent.files));
+  const residualFiles = changedFiles.filter((file) => isBehaviorBearingFile(file) && !coveredFiles.has(file));
+  if (residualFiles.length > 0) {
+    const residualFileSet = new Set(residualFiles);
+    const diffIntent = buildDiffOnlyIntent(
+      residualFiles,
+      codeSignals.filter((signal) => residualFileSet.has(signal.file)),
+      riskEvidence.filter((evidence) => {
+        const file = evidence.file ?? evidence.previousFile;
+        return file !== undefined && residualFileSet.has(file);
+      }),
+      options.includeWorkingTree ?? false,
+    );
     if (diffIntent) {
       intents.push(diffIntent);
     }
@@ -236,7 +251,8 @@ async function collectCommitEvidence(
     "--reverse",
     "--no-merges",
     `--max-count=${maxCommits}`,
-    "--format=%H%x1f%s%x1f%b%x1e",
+    "--name-only",
+    "--format=%x1e%H%x1f%s%x1f%b%x1f",
     `${base}..${head}`,
   ];
   if (relativeRoot) {
@@ -248,7 +264,7 @@ async function collectCommitEvidence(
       .split("\u001e")
       .map((record) => record.trim())
       .filter(Boolean)
-      .map(parseCommitRecord)
+      .map((record) => parseCommitRecord(record, relativeRoot))
       .filter((commit) => !/^merge\b/i.test(commit.subject));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -257,14 +273,28 @@ async function collectCommitEvidence(
   }
 }
 
-function parseCommitRecord(record: string): ChangeIntentCommit {
-  const [sha = "", subject = "", body = ""] = record.split("\u001f");
+function parseCommitRecord(record: string, relativeRoot: string): ChangeIntentCommit {
+  const [sha = "", subject = "", body = "", fileBlock = ""] = record.split("\u001f");
+  const files = uniqueStrings(
+    fileBlock
+      .split(/\r?\n/)
+      .map((file) => scopeCommitFile(toPosixPath(file.trim()), relativeRoot))
+      .filter((file): file is string => Boolean(file)),
+  );
   return {
     sha: sha.trim(),
     subject: subject.trim(),
     body: body.trim() || undefined,
+    files,
     statement: subject.trim(),
   };
+}
+
+function scopeCommitFile(file: string, relativeRoot: string): string | undefined {
+  if (!file) return undefined;
+  if (!relativeRoot) return file;
+  const prefix = `${relativeRoot}/`;
+  return file.startsWith(prefix) ? file.slice(prefix.length) : undefined;
 }
 
 function parseCommit(commit: ChangeIntentCommit): ParsedCommit {
@@ -341,11 +371,23 @@ function clusterBehaviorCommits(commits: ParsedCommit[]): ParsedCommit[][] {
 }
 
 function commitsShareIntent(left: ParsedCommit, right: ParsedCommit): boolean {
-  if (left.scope && right.scope && normalizeToken(left.scope) === normalizeToken(right.scope)) {
+  const rightKeywords = new Set(right.keywords);
+  const scopeTokens = new Set(
+    [left.scope, right.scope]
+      .filter((scope): scope is string => Boolean(scope))
+      .map(normalizeToken),
+  );
+  const sharedKeywords = left.keywords.filter((keyword) =>
+    rightKeywords.has(keyword) && keyword.length >= 4 && !scopeTokens.has(keyword)
+  );
+  if (sharedKeywords.length > 0) {
     return true;
   }
-  const rightKeywords = new Set(right.keywords);
-  return left.keywords.some((keyword) => rightKeywords.has(keyword) && keyword.length >= 4);
+
+  // Conventional scopes often name an entire package (for example `web` or
+  // `app`), not one user intent. Scope equality must not merge unrelated
+  // feature commits by itself.
+  return false;
 }
 
 function buildCommitIntent(
@@ -358,7 +400,13 @@ function buildCommitIntent(
   riskEvidence: ChangeIntentEvidence[],
 ): ChangeIntent {
   const keywords = uniqueStrings(commits.flatMap((commit) => commit.keywords));
-  const files = selectIntentFiles(keywords, changedFiles, addedDiffText, clusterCount);
+  const files = selectIntentFiles(
+    keywords,
+    changedFiles,
+    addedDiffText,
+    clusterCount,
+    uniqueStrings(commits.flatMap((commit) => commit.files ?? [])),
+  );
   const relevantSignals = rankCodeSignalsForIntent(
     codeSignals.filter((signal) => files.includes(signal.file)),
     keywords,
@@ -366,7 +414,10 @@ function buildCommitIntent(
   const relevantRiskEvidence = riskEvidence.filter((item) => item.file && files.includes(item.file));
   const lifecycle = buildLifecycle(commits, relevantSignals);
   const confidence = confidenceForIntent(commits, lifecycle, relevantSignals);
-  const title = sentenceTitle(commits.find((commit) => commit.seed)?.statement ?? commits[0].statement);
+  const titleCommit = commits.find((commit) => commit.conventionalType === "feat" || commit.conventionalType === "feature") ??
+    commits.find((commit) => commit.seed) ??
+    commits[0];
+  const title = sentenceTitle(titleCommit.statement);
   const evidence = uniqueEvidence([
     ...commits.map((commit) => ({
       kind: "commit" as const,
@@ -377,7 +428,7 @@ function buildCommitIntent(
     ...relevantSignals.slice(0, 12).map((signal) => ({
       ...signal.evidence,
     })),
-    ...relevantRiskEvidence.slice(0, 8),
+    ...selectRiskEvidence(relevantRiskEvidence, 12),
   ]);
   const id = stableId("intent", `${index}:${commits.map((commit) => commit.sha).join(":")}:${title}`);
   const summary = commits
@@ -404,6 +455,7 @@ function buildCommitIntent(
 function buildDiffOnlyIntent(
   changedFiles: string[],
   codeSignals: CodeBehaviorSignal[],
+  riskEvidence: ChangeIntentEvidence[],
   includesWorkingTree: boolean,
 ): ChangeIntent | undefined {
   const lifecycle = lifecycleFromCodeSignals(codeSignals);
@@ -412,11 +464,17 @@ function buildDiffOnlyIntent(
     return undefined;
   }
   const files = uniqueStrings(codeSignals.map((signal) => signal.file)).slice(0, maxIntentFiles);
-  const titleSubject = humanizeIdentifier(path.basename(files[0] ?? "working tree change").replace(/\.[^.]+$/, ""));
+  const titleSubject = diffIntentSubject(files[0]);
   const title = `${titleSubject} ${includesWorkingTree ? "working-tree" : "changed"} behavior`;
-  const evidence = uniqueEvidence(codeSignals.slice(0, 12).map((signal) => signal.evidence));
+  const evidence = uniqueEvidence([
+    ...codeSignals.slice(0, 16).map((signal) => signal.evidence),
+    ...selectRiskEvidence(riskEvidence, 24),
+  ]);
   const id = stableId("intent", `${includesWorkingTree ? "working-tree" : "diff"}:${files.join(":")}`);
-  const keywords = extractKeywords(codeSignals.map((signal) => `${signal.symbol} ${signal.label}`).join(" "));
+  const keywords = extractKeywords([
+    ...codeSignals.map((signal) => `${signal.symbol} ${signal.label}`),
+    ...riskEvidence.map((item) => `${item.symbol ?? ""} ${item.value}`),
+  ].join(" "));
   return {
     id,
     title,
@@ -434,13 +492,28 @@ function buildDiffOnlyIntent(
   };
 }
 
+function diffIntentSubject(file: string | undefined): string {
+  if (!file) return "Working tree";
+  const extensionless = path.basename(file).replace(/\.[^.]+$/, "");
+  const subject = /^(?:index|page|route)$/i.test(extensionless)
+    ? path.basename(path.dirname(file))
+    : extensionless;
+  return humanizeIdentifier(subject || "changed behavior");
+}
+
 function selectIntentFiles(
   keywords: string[],
   changedFiles: string[],
   addedDiffText: Record<string, string>,
   clusterCount: number,
+  commitFiles: string[],
 ): string[] {
   const behaviorFiles = changedFiles.filter(isBehaviorBearingFile);
+  const changedSet = new Set(behaviorFiles);
+  const commitChangedFiles = commitFiles.filter((file) => changedSet.has(file));
+  if (commitChangedFiles.length > 0) {
+    return commitChangedFiles.slice(0, maxIntentFiles);
+  }
   if (clusterCount === 1) {
     return behaviorFiles.slice(0, maxIntentFiles);
   }
@@ -448,7 +521,7 @@ function selectIntentFiles(
     const searchable = `${file} ${addedDiffText[file] ?? ""}`.toLowerCase();
     return keywords.some((keyword) => searchable.includes(keyword));
   });
-  return (matched.length > 0 ? matched : behaviorFiles).slice(0, maxIntentFiles);
+  return matched.slice(0, maxIntentFiles);
 }
 
 function buildLifecycle(commits: ParsedCommit[], signals: CodeBehaviorSignal[]): BehaviorLifecycleStage[] {
@@ -480,11 +553,7 @@ function buildLifecycle(commits: ParsedCommit[], signals: CodeBehaviorSignal[]):
     }
   }
 
-  const existingKinds = new Set(stages.map((stage) => stage.kind));
   for (const signal of signals) {
-    if (stages.length >= maxLifecycleStages) {
-      break;
-    }
     if (isImplementationOnlyLifecycleStep(`${signal.label} ${signal.symbol}`)) {
       continue;
     }
@@ -496,17 +565,47 @@ function buildLifecycle(commits: ParsedCommit[], signals: CodeBehaviorSignal[]):
       continue;
     }
     stages.push(createLifecycleStage(signal.kind, signal.label, "medium", [signal.evidence], [signal.file]));
-    existingKinds.add(signal.kind);
   }
 
-  return orderLifecycleStages(uniqueLifecycleStages(stages)).slice(0, maxLifecycleStages);
+  return limitLifecycleStages(stages);
 }
 
 function lifecycleFromCodeSignals(signals: CodeBehaviorSignal[]): BehaviorLifecycleStage[] {
   const stages = signals
     .filter((signal) => !isImplementationOnlyLifecycleStep(`${signal.label} ${signal.symbol}`))
     .map((signal) => createLifecycleStage(signal.kind, signal.label, "low", [signal.evidence], [signal.file]));
-  return orderLifecycleStages(uniqueLifecycleStages(stages)).slice(0, maxLifecycleStages);
+  return limitLifecycleStages(stages);
+}
+
+function limitLifecycleStages(stages: BehaviorLifecycleStage[]): BehaviorLifecycleStage[] {
+  const unique = uniqueLifecycleStages(stages);
+  const selected: BehaviorLifecycleStage[] = [];
+  const selectedIds = new Set<string>();
+  const orderedKinds: BehaviorLifecycleStageKind[] = [
+    "trigger",
+    "condition",
+    "action",
+    "state-change",
+    "side-effect",
+    "observable-outcome",
+  ];
+
+  // Large UI files can expose dozens of click handlers before a later service
+  // contributes the state change or observable outcome. Preserve lifecycle
+  // diversity before filling the remaining budget in source order.
+  for (const kind of orderedKinds) {
+    for (const stage of unique.filter((candidate) => candidate.kind === kind).slice(0, 2)) {
+      selected.push(stage);
+      selectedIds.add(stage.id);
+    }
+  }
+  for (const stage of unique) {
+    if (selected.length >= maxLifecycleStages) break;
+    if (selectedIds.has(stage.id)) continue;
+    selected.push(stage);
+  }
+
+  return orderLifecycleStages(selected).slice(0, maxLifecycleStages);
 }
 
 function createLifecycleStage(
@@ -597,6 +696,24 @@ function buildIntentQaScenarios(
     ], ["Removed validation", "Unauthorized access", "Alternative entry point"], removedAccessGuardEvidence));
   }
 
+  const changedAccessEvidence = evidence.filter((item) =>
+    item.kind === "diff" &&
+    item.side === "head" &&
+    item.relation === "direct" &&
+    /public access|protected access|unauthenticated|authentication boundary/i.test(item.value)
+  );
+  if (changedAccessEvidence.length > 0) {
+    scenarios.push(makeScenario(intentId, "access-boundary", "failure", "recommended", "Public and protected entry access", [
+      "Prepare authenticated and unauthenticated sessions for every changed entry path.",
+    ], [
+      "Open each changed public path without a session and repeat with an authenticated session.",
+      "Open the matching protected path without a session.",
+    ], [
+      "Verify public pages and their required assets remain available without authentication.",
+      "Verify protected pages still require the intended authentication boundary.",
+    ], ["Public asset request", "Expired session", "Direct protected deep link"], changedAccessEvidence));
+  }
+
   const changedConditionEvidence = scenarioEvidenceFor(
     lifecycle,
     evidence,
@@ -621,7 +738,44 @@ function buildIntentQaScenarios(
     item.startLine !== undefined &&
     /urlsearchparams|searchparams|query|location\.href|window\.location|destination|redirect/i.test(`${item.symbol ?? ""} ${item.value}`)
   );
-  if (destinationParameterEvidence.length > 0) {
+  const queryEvidenceByKey = new Map<string, ChangeIntentEvidence[]>();
+  for (const item of destinationParameterEvidence) {
+    if (item.side && item.side !== "head") continue;
+    const key = item.value.match(/query parameter "([^"]+)"/i)?.[1];
+    if (!key) continue;
+    const items = queryEvidenceByKey.get(key) ?? [];
+    items.push(item);
+    queryEvidenceByKey.set(key, items);
+  }
+  const synchronizedQueryKeys = [...queryEvidenceByKey.entries()]
+    .filter(([, items]) =>
+      items.some((item) => /\breads query parameter\b/i.test(item.value)) &&
+      items.some((item) => /\b(?:writes|removes) query parameter\b/i.test(item.value))
+    )
+    .map(([key]) => key);
+  if (synchronizedQueryKeys.length > 0) {
+    const synchronizedFiles = new Set(synchronizedQueryKeys.flatMap((key) =>
+      (queryEvidenceByKey.get(key) ?? []).map((item) => item.file).filter((file): file is string => Boolean(file))
+    ));
+    const urlStateEvidence = uniqueEvidence([
+      ...synchronizedQueryKeys.flatMap((key) => queryEvidenceByKey.get(key) ?? []),
+      ...evidence.filter((item) =>
+        item.side === "head" &&
+        Boolean(item.file && synchronizedFiles.has(item.file)) &&
+        /allowed UI state values/i.test(item.value)
+      ),
+    ]);
+    scenarios.push(makeScenario(intentId, "url-backed-state", "state-transition", "recommended", "URL-backed state restoration and fallback", [
+      `Prepare valid, missing, and invalid values for ${synchronizedQueryKeys.map((key) => `"${key}"`).join(", ")}.`,
+    ], [
+      "Open the affected surface directly with each valid URL-backed state and reload it.",
+      "Change the state through the UI, return to the default state, and then open an invalid value.",
+    ], [
+      "Verify direct entry and reload restore the selected state while UI changes update the URL.",
+      "Verify the default state removes optional URL state and invalid values fall back safely.",
+    ], ["Missing parameter", "Invalid value", "Reload", "Back and forward navigation"], urlStateEvidence));
+  }
+  if (destinationParameterEvidence.length > 0 && synchronizedQueryKeys.length === 0) {
     scenarios.push(makeScenario(intentId, "destination-parameters", "boundary", "recommended", "Destination path and query parameters", [
       "Prepare representative identifiers and conditionally included destination parameters.",
     ], [
@@ -693,6 +847,75 @@ function buildIntentQaScenarios(
     ], ["Unauthorized", "Timeout", "Server error", "Duplicate retry"], scenarioEvidenceFor(lifecycle, evidence, /fetch|request|network|endpoint|api|mutation|response|timeout/i)));
   }
 
+  const shareEvidence = scenarioEvidenceFor(
+    lifecycle,
+    evidence,
+    /navigator\.share|navigator\.clipboard|\bclipboard\b|\baborterror\b|(?:^|[\s.])(?:share|copy)(?:\s|\(|\.|$)/i,
+  );
+  if (hasActionableLocatedDiffEvidence(shareEvidence)) {
+    scenarios.push(makeScenario(intentId, "share-fallback", "failure", "recommended", "Share completion, cancellation, and fallback", [
+      "Prepare a device with native sharing, a cancelled share, and an environment without native sharing.",
+    ], [
+      "Trigger the changed share action in each capability state.",
+      "Inspect the exact destination passed to native sharing or the fallback clipboard action.",
+    ], [
+      "Verify completion feedback appears only after a completed share or successful fallback.",
+      "Verify cancellation stays silent and fallback copies the intended canonical destination without leaking unrelated context.",
+    ], ["User cancels the share sheet", "Native sharing unavailable", "Clipboard write fails", "Unrelated query context"], shareEvidence));
+  }
+
+  const mediaEvidence = scenarioEvidenceFor(
+    lifecycle,
+    evidence,
+    /<audio\b|<video\b|\bhtmlmediaelement\b|(?:^|[\s.])(?:audio|video|media|play|pause|ended|currenttime)(?:\s|\(|\.|$)/i,
+  );
+  if (hasActionableLocatedDiffEvidence(mediaEvidence)) {
+    scenarios.push(makeScenario(intentId, "media-state", "state-transition", "recommended", "Media start, stop, completion, and restart state", [
+      "Prepare a loadable media source and a blocked or failed playback state.",
+    ], [
+      "Start playback, stop it, start again, and let it reach completion.",
+      "Repeat when playback is rejected or the media cannot load.",
+    ], [
+      "Verify visible controls reflect the real playback state after every transition.",
+      "Verify completion and failure leave the control in a recoverable state without duplicate playback.",
+    ], ["Playback permission rejected", "Media load failure", "Repeated start", "Natural completion"], mediaEvidence));
+  }
+
+  const availabilityEvidence = evidence.filter((item) =>
+    item.kind === "diff" &&
+    item.side === "head" &&
+    item.relation === "direct" &&
+    /availability window|exposure window|expiry boundary/i.test(item.value)
+  );
+  if (availabilityEvidence.length > 0) {
+    scenarios.push(makeScenario(intentId, "availability-window", "boundary", "recommended", "Availability window boundaries", [
+      "Prepare times immediately before, at, during, and immediately after the changed availability window.",
+    ], [
+      "Enter the affected surface at each boundary time.",
+      "Repeat through direct navigation and the normal product entry point.",
+    ], [
+      "Verify the feature is unavailable before the start and after the end.",
+      "Verify the feature is available at the documented inclusive boundaries without timezone drift.",
+    ], ["One second before start", "Exact start", "Exact end", "One second after end", "Timezone offset"], availabilityEvidence));
+  }
+
+  const scopedStorageEvidence = scenarioEvidenceFor(
+    lifecycle,
+    evidence,
+    /sessionstorage|localstorage|\.setitem|\.removeitem|persisted context/i,
+  );
+  if (scopedStorageEvidence.length > 0) {
+    scenarios.push(makeScenario(intentId, "scoped-storage", "state-transition", "recommended", "Scoped persisted context isolation and cleanup", [
+      "Prepare two distinct entity or user contexts plus invalid and stale stored data.",
+    ], [
+      "Capture context for the first identity, then enter and complete the second identity flow.",
+      "Complete the matching first flow and re-enter it afterward.",
+    ], [
+      "Verify stored context is consumed only by its matching identity and malformed data is ignored safely.",
+      "Verify successful completion clears only the matching context and stale context cannot leak into a later flow.",
+    ], ["Mismatched identity", "Malformed storage", "Repeated completion", "Second tab or re-entry"], scopedStorageEvidence));
+  }
+
   if (/sync|persist|storage|cache|reload|re.?entry|save|store/.test(searchable)) {
     scenarios.push(makeScenario(intentId, "state-reentry", "state-transition", "recommended", "Re-entry and stale state recovery", [
       "Prepare current and stale persisted state.",
@@ -705,7 +928,7 @@ function buildIntentQaScenarios(
     ], ["Stale cache", "App restart", "Repeated synchronization"], scenarioEvidenceFor(lifecycle, evidence, /sync|persist|storage|cache|reload|re.?entry|save|store/i)));
   }
 
-  return rankIntentQaScenarios(uniqueScenarios(scenarios)).slice(0, 5);
+  return rankIntentQaScenarios(uniqueScenarios(scenarios)).slice(0, maxQaScenariosPerIntent);
 }
 
 function lifecycleEvidence(
@@ -854,7 +1077,42 @@ function collectCodeBehaviorSignals(
     }
     collectCodeBehaviorSignalsFromText(signals, file, text);
   }
-  return uniqueCodeSignals(signals).slice(0, maxSignals);
+  return selectCodeSignals(signals);
+}
+
+function selectCodeSignals(signals: CodeBehaviorSignal[]): CodeBehaviorSignal[] {
+  const unique = uniqueCodeSignals(signals);
+  const selected: CodeBehaviorSignal[] = [];
+  const selectedKeys = new Set<string>();
+  const files = uniqueStrings(unique.map((signal) => signal.file));
+  const kinds: BehaviorLifecycleStageKind[] = [
+    "trigger",
+    "condition",
+    "state-change",
+    "side-effect",
+    "observable-outcome",
+    "action",
+  ];
+
+  // Give every changed behavior file a chance to contribute each lifecycle
+  // kind before a single large component consumes the global signal budget.
+  for (const file of files) {
+    for (const kind of kinds) {
+      const signal = unique.find((candidate) => candidate.file === file && candidate.kind === kind);
+      if (!signal) continue;
+      const key = `${signal.kind}:${signal.file}:${signal.symbol}`;
+      selected.push(signal);
+      selectedKeys.add(key);
+      if (selected.length >= maxSignals) return selected;
+    }
+  }
+  for (const signal of unique) {
+    const key = `${signal.kind}:${signal.file}:${signal.symbol}`;
+    if (selectedKeys.has(key)) continue;
+    selected.push(signal);
+    if (selected.length >= maxSignals) break;
+  }
+  return selected;
 }
 
 function collectDiffRiskEvidence(addedDiffEvidence: AddedDiffEvidence): ChangeIntentEvidence[] {
@@ -882,26 +1140,111 @@ function collectDiffRiskEvidence(addedDiffEvidence: AddedDiffEvidence): ChangeIn
           const routingMatch = line.text.match(
             /(payload|deep.?link|destination|redirect|router\.push|navigate\w*|URLSearchParams|searchParams|location\.href|window\.location)/i,
           );
-          if (routingMatch && !/navigation\.setoptions/i.test(line.text)) {
+          const queryOperation = line.text.match(
+            /\b((?:params|queryParams|searchParams)|[A-Za-z_$][\w$]*\.searchParams)\.(get|set|delete)\(\s*["'`]([^"'`]+)["'`]/i,
+          );
+          if ((routingMatch || queryOperation) && !/navigation\.setoptions/i.test(line.text)) {
+            const queryDescription = queryOperation
+              ? `${side === "base" ? "Removed" : "Changed"} line ${queryOperation[2] === "get" ? "reads" : queryOperation[2] === "set" ? "writes" : "removes"} query parameter "${queryOperation[3]}".`
+              : `${side === "base" ? "Removed" : "Changed"} line contains entry or routing evidence for ${routingMatch![1]}.`;
             evidence.push(diffRiskEvidence(
               file,
               hunk,
               line.line,
-              routingMatch[1],
-              `${side === "base" ? "Removed" : "Changed"} line contains entry or routing evidence for ${routingMatch[1]}.`,
+              queryOperation ? `${queryOperation[1]}.${queryOperation[2]}(${queryOperation[3]})` : routingMatch![1],
+              queryDescription,
               side,
             ));
+          }
+          const allowedStateMatch = line.text.match(
+            /\b(?:const|function)\s+([A-Za-z_$][\w$]*)[^=]*=(?:[^=]|=(?!=))*?\b([A-Za-z_$][\w$]*)\s*===\s*["'`]([^"'`]+)["'`](?:\s*\|\|\s*\2\s*===\s*["'`]([^"'`]+)["'`])+/,
+          );
+          if (allowedStateMatch) {
+            const values = uniqueStrings([...line.text.matchAll(/===\s*["'`]([^"'`]+)["'`]/g)].map((match) => match[1]));
+            if (values.length > 1) {
+              evidence.push(diffRiskEvidence(
+                file,
+                hunk,
+                line.line,
+                allowedStateMatch[1],
+                `${side === "base" ? "Removed" : "Changed"} line declares allowed UI state values: ${values.join(", ")}.`,
+                side,
+              ));
+            }
           }
           const guardMatch = line.text.match(
             /(guard\w*|validat\w*|permission\w*|authoriz\w*|authenticat\w*|isAllowed|isDenied|protected)/i,
           );
-          if (side === "base" && guardMatch) {
+          if (guardMatch) {
             evidence.push(diffRiskEvidence(
               file,
               hunk,
               line.line,
               guardMatch[1],
-              `Removed line contains guard or validation evidence for ${guardMatch[1]}.`,
+              `${side === "base" ? "Removed" : "Changed"} line contains guard or validation evidence for ${guardMatch[1]}.`,
+              side,
+            ));
+          }
+          const accessMatch = line.text.match(
+            /(PUBLIC_[A-Z0-9_]*(?:PATH|ROUTE|ASSET)|(?:unauthenticated|public|protected)[A-Za-z0-9_]*(?:Path|Route|Asset)|NextResponse\.next|login redirect)/,
+          );
+          if (accessMatch) {
+            evidence.push(diffRiskEvidence(
+              file,
+              hunk,
+              line.line,
+              accessMatch[1],
+              `${side === "base" ? "Removed" : "Changed"} line contains ${/public|nextresponse\.next/i.test(accessMatch[1]) ? "public access" : "protected access"} boundary evidence for ${accessMatch[1]}.`,
+              side,
+            ));
+          }
+          const availabilityMatch = line.text.match(
+            /\b(startAt|endAt|startsAt|endsAt|availableFrom|availableUntil|expiresAt|exposureWindow|availabilityWindow)\b/i,
+          );
+          if (availabilityMatch) {
+            evidence.push(diffRiskEvidence(
+              file,
+              hunk,
+              line.line,
+              availabilityMatch[1],
+              `${side === "base" ? "Removed" : "Changed"} line contains availability window or expiry boundary evidence for ${availabilityMatch[1]}.`,
+              side,
+            ));
+          }
+          const storageMatch = line.text.match(
+            /(sessionStorage|localStorage|AsyncStorage|\.setItem\b|\.removeItem\b)/i,
+          );
+          if (storageMatch) {
+            evidence.push(diffRiskEvidence(
+              file,
+              hunk,
+              line.line,
+              storageMatch[1],
+              `${side === "base" ? "Removed" : "Changed"} line contains persisted context lifecycle evidence for ${storageMatch[1]}.`,
+              side,
+            ));
+          }
+          const shareSymbol = sharingCapabilitySymbol(line.text);
+          if (shareSymbol) {
+            evidence.push(diffRiskEvidence(
+              file,
+              hunk,
+              line.line,
+              shareSymbol,
+              `${side === "base" ? "Removed" : "Changed"} line contains sharing capability or fallback evidence for ${shareSymbol}.`,
+              side,
+            ));
+          }
+          const mediaMatch = line.text.match(
+            /(<audio\b|<video\b|\.play\b|\.pause\b|\bended\b|currentTime)/i,
+          );
+          if (mediaMatch) {
+            evidence.push(diffRiskEvidence(
+              file,
+              hunk,
+              line.line,
+              mediaMatch[1],
+              `${side === "base" ? "Removed" : "Changed"} line contains media state transition evidence for ${mediaMatch[1]}.`,
               side,
             ));
           }
@@ -910,6 +1253,42 @@ function collectDiffRiskEvidence(addedDiffEvidence: AddedDiffEvidence): ChangeIn
     }
   }
   return uniqueEvidence(evidence);
+}
+
+function sharingCapabilitySymbol(text: string): string | undefined {
+  if (/^\s*import\b/.test(text)) {
+    return undefined;
+  }
+  const match = text.match(
+    /(navigator\.share|navigator\.clipboard|clipboard\.writeText|document\.execCommand\s*\(\s*["']copy["']|AbortError|(?:^|[.\s])(share|copy)\s*\()/i,
+  );
+  return match?.[1]?.trim().replace(/^\./, "") || match?.[2];
+}
+
+function selectRiskEvidence(evidence: ChangeIntentEvidence[], limit: number): ChangeIntentEvidence[] {
+  const unique = uniqueEvidence(evidence);
+  const selected: ChangeIntentEvidence[] = [];
+  const selectedKeys = new Set<string>();
+  const files = uniqueStrings(unique.map((item) => item.file ?? "").filter(Boolean));
+
+  for (const file of files) {
+    const item = unique.find((candidate) => candidate.file === file);
+    if (!item) continue;
+    selected.push(item);
+    selectedKeys.add(evidenceSelectionKey(item));
+    if (selected.length >= limit) return selected;
+  }
+  for (const item of unique) {
+    const key = evidenceSelectionKey(item);
+    if (selectedKeys.has(key)) continue;
+    selected.push(item);
+    if (selected.length >= limit) break;
+  }
+  return selected;
+}
+
+function evidenceSelectionKey(evidence: ChangeIntentEvidence): string {
+  return `${evidence.file ?? ""}:${evidence.side ?? ""}:${evidence.startLine ?? ""}:${evidence.symbol ?? ""}:${evidence.value}`;
 }
 
 function diffRiskEvidence(
@@ -944,6 +1323,19 @@ function collectCodeBehaviorSignalsFromText(
   for (const match of text.matchAll(/(?:@click(?:\.\w+)*|v-on:click(?:\.\w+)*|onClick)\s*=\s*(?:["']|\{)\s*(?:this\.)?([A-Za-z_$][\w$]*)/g)) {
     const symbol = match[1];
     const label = `Trigger ${humanizeIdentifier(symbol)}.`;
+    signals.push({
+      kind: "trigger",
+      label,
+      file,
+      symbol,
+      evidence: codeSignalEvidence(label, file, symbol, hunk, line),
+    });
+  }
+  for (const match of text.matchAll(
+    /\b(?:onClick|onPress|onSubmit|onChange|onEnded)\s*=\s*\{\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)?\s*=>\s*(?:\{[^}\n]*?)?([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\s*\(/g,
+  )) {
+    const symbol = match[1];
+    const label = `Trigger ${humanizeIdentifier(symbol.split(".").at(-1) ?? symbol)}.`;
     signals.push({
       kind: "trigger",
       label,
@@ -1000,7 +1392,7 @@ function collectCodeBehaviorSignalsFromText(
       evidence: codeSignalEvidence(label, file, symbol, hunk, line),
     });
   }
-  for (const match of text.matchAll(/\b([A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)?)\s*\(/g)) {
+  for (const match of text.matchAll(/\b([A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)*)\s*\(/g)) {
     const symbol = match[1];
     const prefix = text.slice(0, match.index ?? 0);
     if (/\b(?:function|class)\s+$/.test(prefix)) {
@@ -1048,21 +1440,24 @@ function codeSignalEvidence(
 
 function lifecycleKindForIdentifier(identifier: string): BehaviorLifecycleStageKind | undefined {
   const value = identifier.toLowerCase();
-  if (/^(?:on|handle)(?:press|click|submit|change|complete|open|response|message|select|toggle)/.test(value)) {
+  const leaf = identifier.split(".").at(-1) ?? identifier;
+  const leafValue = leaf.toLowerCase();
+  if (/^(?:on|handle)(?:press|click|submit|change|complete|open|response|message|select|toggle)/.test(leafValue)) {
     return "trigger";
   }
-  if (/(?:navigate|redirect|router\.(?:push|replace)|openurl|openlink|show|display|preview|render)/.test(value)) {
+  if (/(?:navigate|redirect|router\.(?:push|replace)|openurl|openlink)/.test(value) || /(?:show|display|preview|render)/.test(leafValue)) {
     return "observable-outcome";
   }
-  if (/(?:resync|sync|persist|store|save|update|set[A-Z_]|cache|write|delete|remove|cancel|invalidate)/i.test(identifier)) {
+  if (/(?:sessionstorage|localstorage|asyncstorage)/.test(value) ||
+    /^(?:resync|sync|persist|store|save|update|set[A-Z_]|cache|write|delete|remove|clear|reset|cancel|invalidate|pause)/i.test(leaf)) {
     return "state-change";
   }
-  if (/(?:schedule|notify|notification|request|fetch|mutate|post|send|emit|track|publish|upload|download)/.test(value)) {
+  if (/(?:clipboard)/.test(value) || /(?:schedule|notify|notification|request|fetch|mutate|post|send|emit|track|publish|upload|download|share|copy|play)/.test(leafValue)) {
     return "side-effect";
   }
   if (
-    /(?:permission|authorized|authenticated|enabled|disabled|validate|guard)/i.test(identifier) ||
-    /^(?:is|has|can|should|show|hide)[A-Z_]/.test(identifier)
+    /(?:permission|authorized|authenticated|enabled|disabled|validate|guard)/i.test(leaf) ||
+    /^(?:is|has|can|should|show|hide)[A-Z_]/.test(leaf)
   ) {
     return "condition";
   }
@@ -1224,7 +1619,8 @@ function isBehaviorBearingFile(file: string): boolean {
   return !(
     /(?:^|\/)(?:docs?|test|tests|__tests__|fixtures?|snapshots?|coverage|dist|build)\//i.test(file) ||
     /(?:^|\/)(?:package-lock\.json|pnpm-lock\.yaml|yarn\.lock|CHANGELOG\.md|README\.md)$/i.test(file) ||
-    /\.(?:md|mdx|snap|map)$/i.test(file)
+    /\.(?:md|mdx|snap|map)$/i.test(file) ||
+    /\.(?:avif|bmp|gif|ico|jpe?g|png|webp|svg|mp3|m4a|ogg|wav|woff2?|ttf|otf|eot|pdf|zip|gz|br)$/i.test(file)
   );
 }
 

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -4757,7 +4757,7 @@ function isRoutableSurfaceFile(file: string): boolean {
   return (
     /(?:^|\/)app\/.*(?:^|\/)?page\.[cm]?[jt]sx?$/i.test(file) ||
     /(?:^|\/)pages\/(?!api\/).+\.(?:[cm]?[jt]sx?|vue|svelte)$/i.test(file) ||
-    /(?:^|\/)(?:screens|views)\/.+\.(?:[cm]?[jt]sx?|vue|svelte)$/i.test(file) ||
+    /(?:^|\/)screens\/.+\.(?:[cm]?[jt]sx?|vue|svelte)$/i.test(file) ||
     /(?:^|\/)routes\/(?!api\/).+\.(?:[cm]?[jt]sx?|vue|svelte)$/i.test(file)
   );
 }
@@ -5020,17 +5020,25 @@ function buildFlowCandidates(
     });
   }
 
-  return prioritizeChangeIntentCandidates(changeAnalysis, candidates, projectType);
+  return prioritizeChangeIntentCandidates(changeAnalysis, candidates, projectType, importImpacts);
 }
 
 function prioritizeChangeIntentCandidates(
   analysis: ChangeIntentAnalysis | undefined,
   heuristicCandidates: FlowCandidate[],
   projectType: E2eProjectType,
+  importImpacts: ImportImpact[] = [],
 ): FlowCandidate[] {
   const intentCandidates = (analysis?.intents ?? [])
-    .filter((intent) => intent.confidence !== "low" && intent.files.length > 0)
+    .filter((intent) => intent.files.length > 0 && (
+      intent.confidence !== "low" ||
+      intent.evidence.some((item) =>
+        item.kind === "diff" && item.file && item.startLine !== undefined && item.relation !== "contextual"
+      )
+    ))
     .map((intent): FlowCandidate => {
+      const relatedImportImpacts = importImpacts.filter((impact) => intent.files.includes(impact.changedFile));
+      const impactedSurfaces = relatedImportImpacts.map((impact) => impact.surface);
       const primaryScenario = intent.scenarios.find((scenario) => scenario.kind === "primary") ?? intent.scenarios[0];
       const steps = uniqueStrings([
         ...(primaryScenario?.steps ?? intent.lifecycle.map((stage) => stage.label)),
@@ -5039,8 +5047,13 @@ function prioritizeChangeIntentCandidates(
       return {
         kind: intentFlowKind(intent, projectType),
         title: intent.title,
-        reason: `Commit and diff evidence support this ${intent.confidence}-confidence change intent. ${intent.summary}`,
-        files: intent.files,
+        reason: (intent.confidence === "low"
+          ? `Located diff evidence supports this review-required change intent even though commit text was not behavior-bearing. ${intent.summary}`
+          : `Commit and diff evidence support this ${intent.confidence}-confidence change intent. ${intent.summary}`) +
+            (relatedImportImpacts.length > 0
+              ? ` Reverse imports reach ${relatedImportImpacts.slice(0, 3).map(describeImportChain).join("; ")}.`
+              : ""),
+        files: uniqueStrings([...intent.files, ...impactedSurfaces]),
         steps,
         coverage: intent.scenarios.map((scenario) => ({
           title: scenario.title,
@@ -5191,7 +5204,14 @@ async function buildFlow(
     coverageEvidence: evaluateFlowCoverageEvidence({ title: candidate.title, files, coverage }, testSuiteInventory),
     entrypoints: interactionEvidenceApplies ? await inferFlowEntrypoints(root, files, runner) : [],
     setupHints,
-    fixtureReadiness: await inferFlowFixtureReadiness(root, files, candidate.kind, setupHints, fixtureContext),
+    fixtureReadiness: await inferFlowFixtureReadiness(
+      root,
+      files,
+      candidate.kind,
+      setupHints,
+      fixtureContext,
+      addedDiffText,
+    ),
     selectors,
     missingTestability: interactionEvidenceApplies ? await findFlowTestabilityGaps(root, files, runner, selectors) : [],
     intentId: candidate.intentId,
@@ -5324,6 +5344,7 @@ async function inferFlowSetupHints(
   const changedText = files.map((file) => addedDiffText[file] ?? "").filter(Boolean).join("\n");
   const shouldUseContentSignals = kind !== "config" && kind !== "content" && kind !== "command";
   const signalText = shouldUseContentSignals ? combinedText : filesText;
+  const changedSignalText = `${filesText}\n${changedText}`;
   const matchingFiles = (pattern: RegExp) =>
     uniqueStrings([
       ...files.filter((file) => pattern.test(file)),
@@ -5331,9 +5352,12 @@ async function inferFlowSetupHints(
         ? fileTexts.filter((item) => pattern.test(item.text)).map((item) => item.file)
         : []),
     ]).slice(0, maxFilesPerFlow);
+  const matchingChangedFiles = (pattern: RegExp) =>
+    uniqueStrings(files.filter((file) => pattern.test(file) || pattern.test(addedDiffText[file] ?? "")))
+      .slice(0, maxFilesPerFlow);
 
-  if (/(?:^|\/|[-_])(auth|session|login|logout|permission|permissions|guard|guards|token|jwt)(?:\/|[-_.]|$)/i.test(signalText)) {
-    const authFiles = matchingFiles(/auth|session|login|logout|permission|guard|token|jwt/i);
+  if (/(?:^|\/|[-_])(auth|session|login|logout|permission|permissions|guard|guards|token|jwt)(?:\/|[-_.]|$)/i.test(changedSignalText)) {
+    const authFiles = matchingChangedFiles(/auth|session|login|logout|permission|guard|token|jwt/i);
     hints.push(
       setupHint(
         "auth",
@@ -5346,8 +5370,9 @@ async function inferFlowSetupHints(
   }
 
   const networkEvidence = /(?:fetch\s*\(|axios(?:\.|\s*\()|graphql|trpc|\brpc\b|apiClient|endpoint|msw|nock|\/api\/|(?:^|\/)(?:api|requests?|responses?|clients?|endpoints?)(?:\/|[-_.]|$))/im;
-  if (kind === "api" || networkEvidence.test(signalText)) {
-    const networkFiles = matchingFiles(networkEvidence);
+  const networkSignalText = kind === "api" ? signalText : changedSignalText;
+  if (kind === "api" || networkEvidence.test(networkSignalText)) {
+    const networkFiles = kind === "api" ? matchingFiles(networkEvidence) : matchingChangedFiles(networkEvidence);
     hints.push(
       setupHint(
         "network",
@@ -5359,8 +5384,9 @@ async function inferFlowSetupHints(
     );
   }
 
-  if (/(?:fixture|fixtures|factory|factories|seed|seeds|mock|mocks|faker|test-data|testData)/i.test(signalText)) {
-    const fixtureFiles = matchingFiles(/fixture|factory|seed|mock|faker|test-data|testData/i);
+  const fixtureEvidence = /(?:\b(?:fixture|fixtures|factory|factories|mock|mocks|faker|msw|nock|test-data)\b|\b(?:fixture|mock|seed)(?:Data|Response|Handler|Factory|Record)s?\b)/i;
+  if (fixtureEvidence.test(changedSignalText)) {
+    const fixtureFiles = matchingChangedFiles(fixtureEvidence);
     hints.push(
       setupHint(
         "fixture",
@@ -5372,8 +5398,8 @@ async function inferFlowSetupHints(
     );
   }
 
-  if (/(?:\.env|environment|process\.env|feature-?flag|experiments?|remoteConfig|config|eas\.json|app\.config)/i.test(signalText)) {
-    const environmentFiles = matchingFiles(/\.env|environment|process\.env|feature-?flag|experiment|remoteConfig|config|eas\.json|app\.config/i);
+  if (/(?:\.env|environment|process\.env|feature-?flag|experiments?|remoteConfig|config|eas\.json|app\.config)/i.test(changedSignalText)) {
+    const environmentFiles = matchingChangedFiles(/\.env|environment|process\.env|feature-?flag|experiment|remoteConfig|config|eas\.json|app\.config/i);
     hints.push(
       setupHint(
         "environment",
@@ -5405,8 +5431,8 @@ async function inferFlowSetupHints(
     );
   }
 
-  if (kind === "state" || /(?:store|state|cache|provider|context|atom|selector|reducer|storage|localStorage|AsyncStorage)/i.test(signalText)) {
-    const stateFiles = matchingFiles(/store|state|cache|provider|context|atom|selector|reducer|storage|localStorage|AsyncStorage/i);
+  if (kind === "state" || /(?:store|state|cache|provider|context|atom|selector|reducer|storage|localStorage|AsyncStorage)/i.test(changedSignalText)) {
+    const stateFiles = matchingChangedFiles(/store|state|cache|provider|context|atom|selector|reducer|storage|localStorage|AsyncStorage/i);
     hints.push(
       setupHint(
         "state",
@@ -5488,6 +5514,7 @@ async function inferFlowFixtureReadiness(
   kind: E2eFlowKind,
   setupHints: E2eSetupHint[],
   context: FixtureReadinessContext,
+  addedDiffText: Record<string, string> = {},
 ): Promise<E2eFixtureReadiness> {
   if (kind === "test-evidence" || kind === "documentation" || kind === "generated-artifact") {
     return {
@@ -5538,6 +5565,10 @@ async function inferFlowFixtureReadiness(
   }
 
   const apiSignals = await findApiDependencySignals(root, files, kind, setupHints);
+  const changedApiSignals = files.filter((file) => {
+    const changedText = addedDiffText[file] ?? "";
+    return isApiDependencyPath(file) || (changedText.length > 0 && hasApiDependencyText(changedText));
+  });
   const apiEndpoints = uniqueStrings([
     ...(await findApiEndpointHints(root, uniqueStrings([...files, ...apiSignals]))),
     ...context.changedBackendFiles.flatMap(apiEndpointFromBackendFile),
@@ -5552,6 +5583,23 @@ async function inferFlowFixtureReadiness(
       backendSignals: [],
       mockSignals: [],
       nextActions: [],
+    };
+  }
+
+  const hasChangedResponseBoundary = changedApiSignals.length > 0 ||
+    setupHints.some((hint) => hint.kind === "network" || hint.kind === "payment");
+  if (!hasChangedResponseBoundary) {
+    return {
+      status: "partial",
+      reason: "The surrounding surface has an existing API dependency, but the selected diff does not change its response boundary.",
+      apiSignals,
+      apiEndpoints,
+      backendSignals: [],
+      mockSignals: [],
+      nextActions: [
+        "Use the existing QA environment or fixture only for selected scenarios that actually traverse the unchanged API dependency.",
+        "Do not block local state, navigation, media, sharing, or access-boundary QA on unrelated response fixtures.",
+      ],
     };
   }
 
@@ -5932,7 +5980,45 @@ async function inferFlowSelectors(
       selectors.push(addedText && addedText.includes(selector.value) ? { ...selector, addedInDiff: true } : selector);
     }
   }
-  return uniqueSelectors(selectors).slice(0, 12);
+  return selectRepresentativeSelectors(selectors, 12);
+}
+
+function selectRepresentativeSelectors(selectors: E2eSelector[], limit: number): E2eSelector[] {
+  const byFile = new Map<string, E2eSelector[]>();
+  for (const selector of uniqueSelectors(selectors)) {
+    const fileSelectors = byFile.get(selector.file) ?? [];
+    fileSelectors.push(selector);
+    byFile.set(selector.file, fileSelectors);
+  }
+  for (const fileSelectors of byFile.values()) {
+    fileSelectors.sort((left, right) => selectorEvidenceScore(right) - selectorEvidenceScore(left));
+  }
+
+  const selected: E2eSelector[] = [];
+  let depth = 0;
+  while (selected.length < limit) {
+    let added = false;
+    for (const fileSelectors of byFile.values()) {
+      const selector = fileSelectors[depth];
+      if (!selector) continue;
+      selected.push(selector);
+      added = true;
+      if (selected.length >= limit) break;
+    }
+    if (!added) break;
+    depth += 1;
+  }
+  return selected;
+}
+
+function selectorEvidenceScore(selector: E2eSelector): number {
+  let score = selector.addedInDiff ? 30 : 0;
+  if (/test-id/.test(selector.kind)) score += 40;
+  if (isInputSelector(selector)) score += 25;
+  if (selectorCanDriveInteraction(selector)) score += 20;
+  if (selector.kind === "visible-text") score += isVisibleSuccessOutcome(selector.value) ? 18 : 8;
+  if (/^(?:number|label|chevron|bold|white|_blank|#[0-9a-f]{3,8})$/i.test(selector.value)) score -= 50;
+  return score;
 }
 
 function entrypointsFromPath(file: string, runner: E2eRunnerName): E2eEntrypoint[] {
@@ -6860,6 +6946,13 @@ function shouldUseDomainScenariosForDraft(plan: E2ePlanResult): boolean {
   if (isLowSignalVerificationOnlyChange(files) || isConfigurationOnlyChange(files)) {
     return false;
   }
+  const intentFlows = plan.flows.filter((flow) => Boolean(flow.intentId));
+  if (intentFlows.some((flow) => flow.intentConfidence !== "low")) {
+    return false;
+  }
+  if (intentFlows.some((flow) => (flow.qaScenarios?.length ?? 0) > 4)) {
+    return false;
+  }
   if (plan.changeAnalysis.intents.some((intent) => intent.confidence !== "low")) {
     return false;
   }
@@ -7610,7 +7703,10 @@ function draftExecutionBlockers(
   scenarioAutomation: E2eScenarioAutomationReceipt[] = [],
 ): string[] {
   const verificationOnly = isVerificationOnlyFlow(flow);
-  const blockers = verificationOnly ? [] : [...plan.executionProfile.blockers];
+  const runnerGap = runnerSetupGap(plan, runner);
+  const blockers = verificationOnly
+    ? []
+    : remainingExecutionProfileBlockers(plan.executionProfile.blockers, runnerGap);
   if (!verificationOnly && runner !== "manual" && flow.entrypoints.length === 0) {
     blockers.push("No runnable route, screen, or command entrypoint was inferred for this flow.");
   }
@@ -8238,7 +8334,7 @@ interface PlaywrightRoutedScenarioDraft {
 }
 
 function playwrightRoutedScenarioDrafts(flow: E2eFlow): PlaywrightRoutedScenarioDraft[] {
-  const routeEntrypoint = primaryRouteEntrypoint(flow);
+  const routeEntrypoint = preferredPublicRouteEntrypoint(flow) ?? primaryRouteEntrypoint(flow);
   if (!routeEntrypoint) {
     return [];
   }
@@ -8246,15 +8342,28 @@ function playwrightRoutedScenarioDrafts(flow: E2eFlow): PlaywrightRoutedScenario
   if (routeDraft.params.length > 0) {
     return [];
   }
-  const endpoint = playwrightFailureMockEndpoint(flow);
-  if (!endpoint) {
-    return [];
-  }
 
   const drafts: PlaywrightRoutedScenarioDraft[] = [];
   for (const scenario of flow.qaScenarios ?? []) {
     const selection = routeQaScenario(scenario);
-    if (scenario.kind !== "failure" || selection.decision === "review-only") {
+    if (selection.decision === "review-only") {
+      continue;
+    }
+    const shareDraft = playwrightShareScenarioDraft(flow, scenario, routeDraft);
+    if (shareDraft) {
+      drafts.push(shareDraft);
+      continue;
+    }
+    const mediaDraft = playwrightMediaScenarioDraft(flow, scenario, routeDraft);
+    if (mediaDraft) {
+      drafts.push(mediaDraft);
+      continue;
+    }
+    if (scenario.kind !== "failure") {
+      continue;
+    }
+    const endpoint = playwrightFailureMockEndpoint(flow);
+    if (!endpoint) {
       continue;
     }
     const scenarioText = [scenario.title, ...scenario.steps, ...scenario.edgeCases].join(" ");
@@ -8299,6 +8408,138 @@ function playwrightRoutedScenarioDrafts(flow: E2eFlow): PlaywrightRoutedScenario
     });
   }
   return drafts;
+}
+
+function preferredPublicRouteEntrypoint(flow: E2eFlow): E2eEntrypoint | undefined {
+  return flow.entrypoints.find((entrypoint) =>
+    entrypoint.kind === "route" && /(?:^|\/)public(?:\/|$)/i.test(entrypoint.value)
+  );
+}
+
+function playwrightShareScenarioDraft(
+  flow: E2eFlow,
+  scenario: IntentQaScenario,
+  routeDraft: PlaywrightRouteDraft,
+): PlaywrightRoutedScenarioDraft | undefined {
+  if (!/share completion, cancellation, and fallback/i.test(scenario.title)) {
+    return undefined;
+  }
+  const actionSelector = flow.selectors.find((selector) =>
+    selectorCanDriveInteraction(selector) && /\b(?:share|copy)\b|(?:공유|복사)/i.test(selector.value)
+  );
+  if (!actionSelector) {
+    return undefined;
+  }
+  const locator = playwrightLocator(actionSelector);
+  const testName = `${flow.title}: ${scenario.title}`.replaceAll('"', "'");
+  return {
+    scenarioId: scenario.id,
+    mappedSteps: scenario.steps.length,
+    mappedAssertions: scenario.assertions.length,
+    lines: [
+      `test("${testName}", async ({ page }) => {`,
+      "  await page.addInitScript(() => {",
+      "    (window as any).__qamapShareState = { shared: null, copied: null };",
+      "    Object.defineProperty(navigator, \"share\", {",
+      "      configurable: true,",
+      "      value: async (payload: unknown) => { (window as any).__qamapShareState.shared = payload; },",
+      "    });",
+      "    Object.defineProperty(navigator, \"clipboard\", {",
+      "      configurable: true,",
+      "      value: { writeText: async (value: string) => { (window as any).__qamapShareState.copied = value; } },",
+      "    });",
+      "  });",
+      `  await page.goto(${playwrightRouteExpressionWithQuery(routeDraft, "qamap_probe=share-source")});`,
+      `  await ${locator}.click();`,
+      "  const sharedUrl = await page.evaluate(() => (window as any).__qamapShareState.shared?.url as string | undefined);",
+      "  expect(sharedUrl).toBeTruthy();",
+      "  expect(sharedUrl).not.toContain(\"qamap_probe\");",
+      "",
+      "  await page.evaluate(() => {",
+      "    (window as any).__qamapShareState.shared = null;",
+      "    (window as any).__qamapShareState.copied = null;",
+      "    Object.defineProperty(navigator, \"share\", {",
+      "      configurable: true,",
+      "      value: async () => { throw new DOMException(\"cancelled\", \"AbortError\"); },",
+      "    });",
+      "  });",
+      `  await ${locator}.click();`,
+      "  expect(await page.evaluate(() => (window as any).__qamapShareState.copied)).toBeNull();",
+      "",
+      "  await page.evaluate(() => {",
+      "    (window as any).__qamapShareState.copied = null;",
+      "    Object.defineProperty(navigator, \"share\", { configurable: true, value: undefined });",
+      "  });",
+      `  await ${locator}.click();`,
+      "  const copiedUrl = await page.evaluate(() => (window as any).__qamapShareState.copied as string | null);",
+      "  expect(copiedUrl).toBeTruthy();",
+      "  expect(copiedUrl).not.toContain(\"qamap_probe\");",
+      "});",
+    ],
+  };
+}
+
+function playwrightMediaScenarioDraft(
+  flow: E2eFlow,
+  scenario: IntentQaScenario,
+  routeDraft: PlaywrightRouteDraft,
+): PlaywrightRoutedScenarioDraft | undefined {
+  if (!/media start, stop, completion, and restart state/i.test(scenario.title)) {
+    return undefined;
+  }
+  const labels = uniqueStrings(flow.selectors
+    .filter((selector) =>
+      selector.kind === "role-button" && /\b(?:audio|listen|media|pause|play|stop)\b|(?:듣기|멈춤|재생|정지)/i.test(selector.value)
+    )
+    .map((selector) => selector.value))
+    .slice(0, 4);
+  if (labels.length === 0) {
+    return undefined;
+  }
+  const labelPattern = labels.map((label) => escapeRegExp(label).replaceAll("/", "\\/")).join("|");
+  const testName = `${flow.title}: ${scenario.title}`.replaceAll('"', "'");
+  return {
+    scenarioId: scenario.id,
+    mappedSteps: scenario.steps.length,
+    mappedAssertions: scenario.assertions.length,
+    lines: [
+      `test("${testName}", async ({ page }) => {`,
+      "  await page.addInitScript(() => {",
+      "    const state = { playing: false, playCount: 0, pauseCount: 0 };",
+      "    (window as any).__qamapMediaState = state;",
+      "    Object.defineProperty(HTMLMediaElement.prototype, \"paused\", {",
+      "      configurable: true,",
+      "      get: () => !state.playing,",
+      "    });",
+      "    Object.defineProperty(HTMLMediaElement.prototype, \"play\", {",
+      "      configurable: true,",
+      "      value: async () => { state.playing = true; state.playCount += 1; },",
+      "    });",
+      "    Object.defineProperty(HTMLMediaElement.prototype, \"pause\", {",
+      "      configurable: true,",
+      "      value: () => { state.playing = false; state.pauseCount += 1; },",
+      "    });",
+      "  });",
+      `  await page.goto(${routeDraft.expression});`,
+      `  const mediaControl = page.getByRole("button", { name: /^(?:${labelPattern})$/ });`,
+      "  const initialLabel = (await mediaControl.textContent())?.trim();",
+      "  await mediaControl.click();",
+      "  await expect.poll(() => page.evaluate(() => (window as any).__qamapMediaState.playCount)).toBe(1);",
+      "  await mediaControl.click();",
+      "  await expect.poll(() => page.evaluate(() => (window as any).__qamapMediaState.pauseCount)).toBe(1);",
+      "  if (initialLabel) await expect(mediaControl).toHaveText(initialLabel);",
+      "  await mediaControl.click();",
+      "  await page.evaluate(() => { (window as any).__qamapMediaState.playing = false; });",
+      "  await page.locator(\"audio, video\").first().dispatchEvent(\"ended\");",
+      "  if (initialLabel) await expect(mediaControl).toHaveText(initialLabel);",
+      "});",
+    ],
+  };
+}
+
+function playwrightRouteExpressionWithQuery(routeDraft: PlaywrightRouteDraft, query: string): string {
+  const route = JSON.parse(routeDraft.expression) as string;
+  return JSON.stringify(`${route}${route.includes("?") ? "&" : "?"}${query}`);
 }
 
 function routedScenarioSelector(
@@ -10056,6 +10297,7 @@ function extractSelectorsFromText(file: string, text: string, runner: E2eRunnerN
       ...withoutSelectorValueDuplicates(extractAttributeSelectors(file, text, ["aria-label"], "aria-label"), webInputSelectors),
       ...extractRoleSelectorsFromText(file, text),
       ...extractInteractiveTextSelectors(file, text),
+      ...extractOptionControlSelectors(file, text),
     );
   }
 
@@ -10186,10 +10428,38 @@ function extractInteractiveTextSelectors(file: string, text: string): E2eSelecto
       normalizeRenderedText(body) ?? "",
       ...[...body.matchAll(/\{\{?\s*([A-Za-z_$][\w$]*)\s*\}?\}/g)]
         .flatMap((identifier) => renderedLiteralValues(text, identifier[1])),
+      ...[...body.matchAll(/["'`]([^"'`\n]{2,80})["'`]/g)]
+        .map((literal) => normalizeSelectorValue(literal[1]) ?? ""),
     ]).filter(isUsefulSelector);
     const kind: E2eSelectorKind = isButton ? "role-button" : isLink ? "role-link" : "click-text";
     for (const value of values) {
       selectors.push({ kind, value, file });
+    }
+  }
+  return selectors;
+}
+
+function extractOptionControlSelectors(file: string, text: string): E2eSelector[] {
+  const selectors: E2eSelector[] = [];
+  const names = new Set([...text.matchAll(
+    /<(?:Segmented|Tabs?|TabList|ToggleGroup|RadioGroup)\b[^>]*\boptions\s*=\s*\{\s*([A-Za-z_$][\w$]*)\s*\}/g,
+  )].map((match) => match[1]));
+  for (const declaration of text.matchAll(/\b(?:const|let)\s+([A-Za-z_$][\w$]*)\b/g)) {
+    if (/(?:view|tab|option|mode|segment)s?$/i.test(declaration[1])) {
+      names.add(declaration[1]);
+    }
+  }
+  for (const name of names) {
+    const declaration = new RegExp(
+      `\\b(?:const|let)\\s+${escapeRegExp(name)}\\b[^=]{0,240}=\\s*(?:[^?;]{0,240}\\?\\s*)?\\[([\\s\\S]{0,4000}?)\\]\\s*(?::|;)`,
+      "m",
+    ).exec(text);
+    if (!declaration?.[1]) continue;
+    for (const label of declaration[1].matchAll(/\blabel\s*:\s*(?:"([^"]+)"|'([^']+)'|`([^`]+)`)/g)) {
+      const value = normalizeSelectorValue(label[1] ?? label[2] ?? label[3]);
+      if (value && isUsefulSelector(value)) {
+        selectors.push({ kind: "role-button", value, file });
+      }
     }
   }
   return selectors;

--- a/src/import-graph.ts
+++ b/src/import-graph.ts
@@ -263,8 +263,7 @@ async function readTsconfigPaths(root: string): Promise<TsconfigPaths> {
       continue;
     }
     try {
-      const withoutComments = raw.replace(/\/\/[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "").replace(/,\s*([}\]])/g, "$1");
-      const parsed = JSON.parse(withoutComments) as {
+      const parsed = JSON.parse(stripJsonCommentsAndTrailingCommas(raw)) as {
         compilerOptions?: { baseUrl?: string; paths?: Record<string, string[]> };
       };
       const baseUrl = normalizeRelativePath(parsed.compilerOptions?.baseUrl ?? "");
@@ -283,6 +282,99 @@ async function readTsconfigPaths(root: string): Promise<TsconfigPaths> {
     }
   }
   return empty;
+}
+
+function stripJsonCommentsAndTrailingCommas(raw: string): string {
+  let withoutComments = "";
+  let inString = false;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+
+  for (let index = 0; index < raw.length; index += 1) {
+    const char = raw[index];
+    const next = raw[index + 1];
+    if (lineComment) {
+      if (char === "\n" || char === "\r") {
+        lineComment = false;
+        withoutComments += char;
+      } else {
+        withoutComments += " ";
+      }
+      continue;
+    }
+    if (blockComment) {
+      if (char === "*" && next === "/") {
+        blockComment = false;
+        withoutComments += "  ";
+        index += 1;
+      } else {
+        withoutComments += char === "\n" || char === "\r" ? char : " ";
+      }
+      continue;
+    }
+    if (inString) {
+      withoutComments += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      withoutComments += char;
+      continue;
+    }
+    if (char === "/" && next === "/") {
+      lineComment = true;
+      withoutComments += "  ";
+      index += 1;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      blockComment = true;
+      withoutComments += "  ";
+      index += 1;
+      continue;
+    }
+    withoutComments += char;
+  }
+
+  let result = "";
+  inString = false;
+  escaped = false;
+  for (let index = 0; index < withoutComments.length; index += 1) {
+    const char = withoutComments[index];
+    if (inString) {
+      result += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      result += char;
+      continue;
+    }
+    if (char === ",") {
+      let cursor = index + 1;
+      while (/\s/.test(withoutComments[cursor] ?? "")) cursor += 1;
+      if (withoutComments[cursor] === "}" || withoutComments[cursor] === "]") {
+        continue;
+      }
+    }
+    result += char;
+  }
+  return result;
 }
 
 function resolveImportSpecifier(

--- a/src/qa.ts
+++ b/src/qa.ts
@@ -529,7 +529,15 @@ export function formatMarkdownQaDraft(result: QaDraftResult): string {
       );
     }
   }
-  if (result.readiness.requiredScenarios + result.readiness.recommendedScenarios + result.readiness.reviewOnlyScenarios > 0) {
+  const routedScenarios = result.readiness.requiredScenarios +
+    result.readiness.recommendedScenarios +
+    result.readiness.reviewOnlyScenarios;
+  lines.push(
+    routedScenarios > 0
+      ? `- QA analysis: completed independently of runner setup; ${routedScenarios} diff-backed scenario${routedScenarios === 1 ? "" : "s"} routed for review.`
+      : `- QA analysis: completed independently of runner setup; ${result.flows.length} affected flow${result.flows.length === 1 ? "" : "s"} mapped for review.`,
+  );
+  if (routedScenarios > 0) {
     lines.push(
       `- Scenario routing: ${result.readiness.requiredScenarios} required, ` +
         `${result.readiness.recommendedScenarios} recommended, ${result.readiness.reviewOnlyScenarios} review-only.`,
@@ -548,7 +556,8 @@ export function formatMarkdownQaDraft(result: QaDraftResult): string {
   lines.push(`- Change scope: ${result.includeWorkingTree ? "committed and uncommitted working-tree changes" : "committed branch changes only"}`);
   lines.push(`- Project: ${formatProjectType(result.project)}`);
   lines.push(`- Manifest: ${result.manifestPath ? `\`${escapeMarkdownInline(result.manifestPath)}\`` : "not found; using repo signals and PR diff only"}`);
-  lines.push(`- Stage: ${formatDraftReadinessStage(result.readiness)}`);
+  lines.push(`- Automation stage: ${formatDraftReadinessStage(result.readiness)}`);
+  lines.push("- QA analysis and scenario routing do not require the optional automation runner to be installed.");
   lines.push(`- Draft flows: ${result.flows.length}`);
   lines.push("");
 

--- a/test/change-intent.test.mjs
+++ b/test/change-intent.test.mjs
@@ -4,6 +4,7 @@ import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import ts from "typescript";
 import { analyzeChangeIntents } from "../dist/change-intent.js";
 import { generateE2eDraft, generateE2ePlan } from "../dist/e2e.js";
 import { formatAgentQaDraft, formatMarkdownQaDraft, generateQaDraft } from "../dist/qa.js";
@@ -232,6 +233,150 @@ test("change intent keeps unrelated feature commits separate", async (t) => {
   assert.ok(analysis.intents.every((intent) => intent.files.length === 1));
 });
 
+test("a broad conventional scope does not merge unrelated product intents", async (t) => {
+  const root = await makeRepo(t);
+  await write(root, "src/share.ts", "export const shareState = 'idle';\n");
+  await write(root, "src/preferences.ts", "export const timezone = 'UTC';\n");
+  commit(root, "benchmark baseline");
+  branch(root, "feat/web-bundle");
+
+  await write(root, "src/share.ts", "export function shareReport() { return navigator.share({ url: '/report' }); }\n");
+  commit(root, "feat(web): share the current report");
+  await write(root, "src/preferences.ts", "export function saveTimezone() { return persistTimezone('UTC'); }\n");
+  commit(root, "feat(web): save account timezone preferences");
+
+  const analysis = await analyze(root, ["src/share.ts", "src/preferences.ts"]);
+
+  assert.equal(analysis.intents.length, 2);
+  assert.ok(analysis.intents.some((intent) => /Share the current report/i.test(intent.title)));
+  assert.ok(analysis.intents.some((intent) => /Save account timezone preferences/i.test(intent.title)));
+});
+
+test("a related feature title remains primary when an earlier fix shares its diff", async (t) => {
+  const root = await makeRepo(t);
+  await write(root, "src/review.tsx", "export function Review() { return null; }\n");
+  commit(root, "benchmark baseline");
+  branch(root, "feat/review-view");
+
+  await write(root, "src/review.tsx", "export function Review() { return <main>Ready</main>; }\n");
+  commit(root, "fix(web): prepare review UI artifacts");
+  await write(
+    root,
+    "src/review.tsx",
+    "export function Review() { const [view, setView] = useState('compare'); return <button onClick={() => setView('usage')}>{view}</button>; }\n",
+  );
+  commit(root, "feat(web): add component review view");
+
+  const analysis = await analyze(root, ["src/review.tsx"]);
+
+  assert.equal(analysis.intents.length, 1);
+  assert.match(analysis.intents[0].title, /Add component review view/i);
+  assert.equal(analysis.intents[0].commits.length, 2);
+});
+
+test("behavior hidden in a chore commit remains covered beside a feature intent", async (t) => {
+  const root = await makeRepo(t);
+  await write(root, "src/share.ts", "export const shareState = 'idle';\n");
+  await write(root, "src/pages/public-entry.tsx", "export function PublicEntry() { return null; }\n");
+  commit(root, "benchmark baseline");
+  branch(root, "feat/mixed-release");
+
+  await write(
+    root,
+    "src/share.ts",
+    "export async function shareReport() { await navigator.share({ url: '/report' }); showToast('Shared'); }\n",
+  );
+  commit(root, "feat: share the current report");
+
+  await write(
+    root,
+    "src/pages/public-entry.tsx",
+    [
+      "export function PublicEntry({ router, ready }) {",
+      "  function openPublicEntry() {",
+      "    if (!ready) return;",
+      "    window.sessionStorage.setItem('public-entry', 'opened');",
+      "    router.push('/public/entry');",
+      "    showToast('Public entry opened');",
+      "  }",
+      "  return <button onClick={openPublicEntry}>Open public entry</button>;",
+      "}",
+    ].join("\n"),
+  );
+  commit(root, "chore(web): prepare 3.0.0 release");
+
+  const analysis = await analyze(root, ["src/share.ts", "src/pages/public-entry.tsx"]);
+
+  assert.equal(analysis.source, "commits-and-diff");
+  assert.equal(analysis.intents.length, 2);
+  assert.ok(analysis.intents.some((intent) => intent.commits.length > 0 && intent.files.includes("src/share.ts")));
+  assert.ok(analysis.intents.some((intent) =>
+    intent.commits.length === 0 && intent.files.includes("src/pages/public-entry.tsx")
+  ));
+});
+
+test("static assets do not crowd behavior source out of commit intent evidence", async (t) => {
+  const root = await makeRepo(t);
+  const assetFiles = Array.from({ length: 24 }, (_, index) => `public/preview/asset-${index}.svg`);
+  for (const file of assetFiles) {
+    await write(root, file, `<svg><title>${file}</title></svg>\n`);
+  }
+  await write(root, "src/pages/preview.tsx", "export function Preview() { return null; }\n");
+  commit(root, "benchmark baseline");
+  branch(root, "feat/public-preview");
+  for (const [index, file] of assetFiles.entries()) {
+    await write(root, file, `<svg><title>updated-${index}</title></svg>\n`);
+  }
+  await write(
+    root,
+    "src/pages/preview.tsx",
+    [
+      "export function Preview({ router }) {",
+      "  async function handleShare() { await navigator.share({ url: '/public/preview' }); }",
+      "  function openPreview() { router.push('/public/preview'); showToast('Preview opened'); }",
+      "  return <button onClick={openPreview}>Open preview</button>;",
+      "}",
+    ].join("\n"),
+  );
+  commit(root, "feat: open the public preview after sharing");
+
+  const analysis = await analyze(root, [...assetFiles, "src/pages/preview.tsx"]);
+  const intent = analysis.intents[0];
+
+  assert.ok(intent.files.includes("src/pages/preview.tsx"));
+  assert.equal(intent.files.some((file) => file.endsWith(".svg")), false);
+  assert.ok(intent.evidence.some((item) => item.kind === "diff" && item.file === "src/pages/preview.tsx"));
+});
+
+test("share icons and playground names do not fabricate share or media lifecycle QA", async (t) => {
+  const root = await makeRepo(t);
+  await write(root, "src/playground.tsx", "export function Playground() { return null; }\n");
+  commit(root, "benchmark baseline");
+  branch(root, "feat/component-review");
+  await write(
+    root,
+    "src/playground.tsx",
+    [
+      "import { Share } from './icons';",
+      "export function PlaygroundReview() {",
+      "  const [view, setView] = useState('preview');",
+      "  return <main>",
+      "    <button onClick={() => setView('usage')}>Usage review</button>",
+      "    <IconButton icon={<Share />} aria-label='Share icon preview' />",
+      "    <p>{view}</p>",
+      "  </main>;",
+      "}",
+    ].join("\n"),
+  );
+  commit(root, "feat: add playground component review view");
+
+  const analysis = await analyze(root, ["src/playground.tsx"]);
+  const titles = analysis.intents.flatMap((intent) => intent.scenarios.map((scenario) => scenario.title));
+
+  assert.equal(titles.some((title) => /Share completion/i.test(title)), false);
+  assert.equal(titles.some((title) => /Media start/i.test(title)), false);
+});
+
 test("change intent ignores release-only commit metadata", async (t) => {
   const root = await makeRepo(t);
   await write(root, "package.json", '{"name":"fixture","version":"1.0.0"}\n');
@@ -335,6 +480,177 @@ test("change intent falls back to committed diff signals when commit text is not
   assert.ok(networkScenario);
   assert.equal(routeQaScenario(networkScenario).decision, "recommended");
   assert.equal(intent.scenarios.some((scenario) => /entry payload/i.test(scenario.title)), false);
+});
+
+test("release-shaped web changes recover diff-first sharing, access, time, media, and storage QA", async (t) => {
+  const root = await makeRepo(t);
+  await write(
+    root,
+    "package.json",
+    JSON.stringify({ scripts: { dev: "vite" }, dependencies: { react: "19.0.0", vite: "7.0.0" } }),
+  );
+  await write(root, "src/components/PreviewLanding/index.tsx", "export function PreviewLanding() { return null; }\n");
+  await write(root, "src/lib/availability.ts", "export const isAvailable = () => false;\n");
+  await write(root, "src/lib/scopedContext.ts", "export const captureContext = () => {};\n");
+  await write(root, "src/middleware.ts", "export function middleware() { return requireLogin(); }\n");
+  await write(root, "src/pages/public/preview.tsx", "export function PublicPreview() { return null; }\n");
+  commit(root, "benchmark baseline");
+  branch(root, "chore/web-release");
+
+  await write(
+    root,
+    "src/components/PreviewLanding/index.tsx",
+    [
+      "export function PreviewLanding({ onOpen }) {",
+      "  const audioRef = useRef(null);",
+      "  async function handleShare() {",
+      "    try {",
+      "      await navigator.share({ url: getCanonicalShareUrl(window.location.origin) });",
+      "    } catch {",
+      "      await navigator.clipboard.writeText(getCanonicalShareUrl(window.location.origin));",
+      "    }",
+      "  }",
+      "  async function handlePlayback() {",
+      "    if (audioRef.current?.paused) await audioRef.current.play();",
+      "    else audioRef.current?.pause();",
+      "  }",
+      "  function resetPlayback() { audioRef.current.currentTime = 0; }",
+      "  return <main>",
+      "    <audio ref={audioRef} onEnded={() => resetPlayback()} />",
+      "    <button onClick={handlePlayback}>Preview audio</button>",
+      "    <button onClick={handleShare}>Share preview</button>",
+      "    <button onClick={() => onOpen('preview')}>Open preview</button>",
+      "  </main>;",
+      "}",
+    ].join("\n"),
+  );
+  await write(
+    root,
+    "src/lib/availability.ts",
+    [
+      "export const PREVIEW_WINDOW = {",
+      "  startAt: '2026-08-01T00:00:00Z',",
+      "  endAt: '2026-08-31T23:59:59Z',",
+      "};",
+      "export const isAvailable = (now) => now >= Date.parse(PREVIEW_WINDOW.startAt) && now <= Date.parse(PREVIEW_WINDOW.endAt);",
+    ].join("\n"),
+  );
+  await write(
+    root,
+    "src/lib/scopedContext.ts",
+    [
+      "export function captureContext(id) { window.sessionStorage.setItem('preview-context', id); }",
+      "export function clearContext(id) {",
+      "  if (window.sessionStorage.getItem('preview-context') === id) window.sessionStorage.removeItem('preview-context');",
+      "}",
+    ].join("\n"),
+  );
+  await write(
+    root,
+    "src/middleware.ts",
+    [
+      "const PUBLIC_ASSET_PATHS = ['/preview-assets/'];",
+      "export function middleware(request) {",
+      "  if (PUBLIC_ASSET_PATHS.some((prefix) => request.path.startsWith(prefix))) return NextResponse.next();",
+      "  return requireLogin(request);",
+      "}",
+    ].join("\n"),
+  );
+  await write(
+    root,
+    "src/pages/public/preview.tsx",
+    [
+      "export function PublicPreview({ router }) {",
+      "  function openItem(id) {",
+      "    const params = new URLSearchParams({ source: 'preview' });",
+      "    router.push(`/public/items/${id}?${params.toString()}`);",
+      "  }",
+      "  return <PreviewLanding onOpen={openItem} />;",
+      "}",
+    ].join("\n"),
+  );
+  commit(root, "chore(web): prepare 2.4.0 release");
+
+  const files = [
+    "src/components/PreviewLanding/index.tsx",
+    "src/lib/availability.ts",
+    "src/lib/scopedContext.ts",
+    "src/middleware.ts",
+    "src/pages/public/preview.tsx",
+  ];
+  const analysis = await analyze(root, files);
+  const intent = analysis.intents[0];
+  const titles = intent.scenarios.map((scenario) => scenario.title);
+
+  assert.equal(analysis.source, "diff-only");
+  assert.match(intent.title, /Preview Landing changed behavior/i);
+  assert.ok(titles.some((title) => /Share completion, cancellation, and fallback/i.test(title)));
+  assert.ok(titles.some((title) => /Public and protected entry access/i.test(title)), JSON.stringify(titles));
+  assert.ok(titles.some((title) => /Availability window boundaries/i.test(title)));
+  assert.ok(titles.some((title) => /Media start, stop, completion, and restart state/i.test(title)));
+  assert.ok(titles.some((title) => /Scoped persisted context isolation and cleanup/i.test(title)));
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const flow = plan.flows.find((candidate) => candidate.intentId === intent.id);
+  assert.ok(flow);
+  assert.equal(flow.fixtureReadiness.status, "not-needed");
+  assert.ok(flow.qaScenarios.some((scenario) => /Share completion/i.test(scenario.title)));
+
+  const draft = await generateE2eDraft(root, { base: "main", head: "HEAD", output: ".generated-e2e" });
+  const file = draft.files.find((candidate) => candidate.source === "change-intent");
+  assert.ok(file);
+  const shareReceipt = file.scenarioAutomation.find((receipt) => /Share completion/i.test(receipt.title));
+  const mediaReceipt = file.scenarioAutomation.find((receipt) => /Media start/i.test(receipt.title));
+  assert.equal(shareReceipt?.status, "compiled");
+  assert.equal(mediaReceipt?.status, "compiled");
+  const spec = await readFile(path.join(root, file.path), "utf8");
+  assert.match(spec, /__qamapShareState/);
+  assert.match(spec, /__qamapMediaState/);
+  assert.match(spec, /qamap_probe=share-source/);
+  const transpiled = ts.transpileModule(spec, {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
+    reportDiagnostics: true,
+  });
+  const syntaxErrors = (transpiled.diagnostics ?? []).filter((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error);
+  assert.deepEqual(syntaxErrors, []);
+});
+
+test("release-shaped account changes promote located diff intent without a test runner", async (t) => {
+  const root = await makeRepo(t);
+  await write(
+    root,
+    "package.json",
+    JSON.stringify({ scripts: { dev: "vite" }, dependencies: { react: "19.0.0", vite: "7.0.0" } }),
+  );
+  await write(root, "src/pages/preferences.tsx", "export function Preferences() { return null; }\n");
+  commit(root, "benchmark baseline");
+  branch(root, "chore/account-release");
+  await write(
+    root,
+    "src/pages/preferences.tsx",
+    [
+      "export function Preferences({ router }) {",
+      "  function savePreferences() {",
+      "    window.localStorage.setItem('timezone', 'UTC');",
+      "    showToast('Preferences saved');",
+      "    router.replace('/account?tab=preferences');",
+      "  }",
+      "  return <button onClick={() => savePreferences()}>Save preferences</button>;",
+      "}",
+    ].join("\n"),
+  );
+  commit(root, "chore: prepare account release");
+
+  const analysis = await analyze(root, ["src/pages/preferences.tsx"]);
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const flow = plan.flows.find((candidate) => candidate.intentId === analysis.intents[0]?.id);
+
+  assert.equal(analysis.source, "diff-only");
+  assert.equal(analysis.intents.length, 1);
+  assert.ok(flow);
+  assert.equal(flow.intentConfidence, "low");
+  assert.equal(flow.fixtureReadiness.status, "not-needed");
+  assert.ok(flow.qaScenarios.some((scenario) => /persisted context|re-entry/i.test(scenario.title)));
 });
 
 test("E2E planning promotes commit intent before runner-specific draft generation", async (t) => {
@@ -731,6 +1047,77 @@ test("React conditional UI produces state QA from changed behavior evidence", as
   const spec = await readFile(path.join(root, file.path), "utf8");
   assert.match(spec, /page\.getByRole\("button", \{ name: "Send notification" \}\)\.click\(\)/);
   assert.match(spec, /page\.getByText\("Notification queued"\)/);
+});
+
+test("URL-backed UI modes become restoration QA with representative controls", async (t) => {
+  const root = await makeRepo(t);
+  await write(
+    root,
+    "package.json",
+    JSON.stringify({
+      scripts: { dev: "vite" },
+      dependencies: { react: "19.0.0", vite: "7.0.0" },
+    }),
+  );
+  await write(
+    root,
+    "src/pages/review.tsx",
+    "export function ReviewPage() { return <main><h1>Component review</h1></main>; }\n",
+  );
+  commit(root, "benchmark baseline");
+  branch(root, "feat/review-modes");
+
+  await write(
+    root,
+    "src/pages/review.tsx",
+    [
+      "const isMode = (value) => value === 'preview' || value === 'compare' || value === 'usage';",
+      "const modes = [",
+      "  { value: 'preview', label: 'Preview' },",
+      "  { value: 'compare', label: 'Compare' },",
+      "  { value: 'usage', label: 'Usage' },",
+      "];",
+      "export function ReviewPage() {",
+      "  const [mode, setMode] = useState('preview');",
+      "  useEffect(() => {",
+      "    const params = new URLSearchParams(window.location.search);",
+      "    const requestedMode = params.get('mode');",
+      "    if (isMode(requestedMode)) setMode(requestedMode);",
+      "  }, []);",
+      "  useEffect(() => {",
+      "    const url = new URL(window.location.href);",
+      "    if (mode === 'preview') url.searchParams.delete('mode');",
+      "    else url.searchParams.set('mode', mode);",
+      "    window.history.replaceState(null, '', url);",
+      "  }, [mode]);",
+      "  return <main>",
+      "    <h1>Component review</h1>",
+      "    <Segmented options={modes} value={mode} onChange={setMode} />",
+      "    {mode === 'compare' && <h2>Compare changes</h2>}",
+      "    {mode === 'usage' && <h2>Usage examples</h2>}",
+      "  </main>;",
+      "}",
+    ].join("\n"),
+  );
+  commit(root, "feat: add URL-backed component review modes");
+
+  const analysis = await analyze(root, ["src/pages/review.tsx"]);
+  const urlState = analysis.intents[0].scenarios.find((scenario) => /URL-backed state restoration/i.test(scenario.title));
+  assert.ok(urlState);
+  assert.ok(urlState.evidence.some((item) => /reads query parameter "mode"/i.test(item.value)));
+  assert.ok(urlState.evidence.some((item) => /writes query parameter "mode"/i.test(item.value)));
+  assert.ok(urlState.evidence.some((item) => /removes query parameter "mode"/i.test(item.value)));
+  assert.ok(urlState.evidence.some((item) => /preview, compare, usage/i.test(item.value)));
+  assert.equal(
+    analysis.intents[0].scenarios.some((scenario) => /Destination path and query parameters/i.test(scenario.title)),
+    false,
+  );
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD", runner: "playwright" });
+  const selectors = plan.flows.flatMap((flow) => flow.selectors.map((selector) => selector.value));
+  assert.ok(selectors.includes("Preview"));
+  assert.ok(selectors.includes("Compare"));
+  assert.ok(selectors.includes("Usage"));
 });
 
 test("presentation-only conditions do not become lifecycle QA scenarios", async (t) => {

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -5505,6 +5505,9 @@ test("qa command emits a PR comment draft without requiring a manifest", async (
   assert.match(markdown, /visible text "Order confirmed" appears/);
   assert.match(markdown, /- Evidence found: /);
   assert.match(markdown, /- QA proposal: /);
+  assert.match(markdown, /QA analysis: completed independently of runner setup/);
+  assert.match(markdown, /Automation stage:/);
+  assert.match(markdown, /QA analysis and scenario routing do not require the optional automation runner/);
   assert.match(markdown, /- Repository validation: `/);
   assert.match(markdown, /- QA proposal gap/);
   assert.match(markdown, /Manifest: not found; using repo signals and PR diff only/);
@@ -5665,6 +5668,67 @@ test("generateE2ePlan reaches consuming surfaces when only a shared component ch
   assert.ok(uiFlow.files.includes("components/Button.tsx"));
   assert.match(uiFlow.reason, /through imports: components\/Button\.tsx -> app\/cart\/page\.tsx/);
   assert.ok(uiFlow.entrypoints.some((entrypoint) => entrypoint.value === "/cart"));
+});
+
+test("change-intent views retain reverse-import route entrypoints", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src/views/review"), { recursive: true });
+  await mkdir(path.join(root, "app"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      scripts: { dev: "next dev" },
+      dependencies: { next: "^15.0.0", react: "^19.0.0" },
+    }),
+  );
+  await writeFile(
+    path.join(root, "tsconfig.json"),
+    [
+      "{",
+      "  // Path aliases must remain strings, not look like block comments.",
+      '  "compilerOptions": { "baseUrl": ".", "paths": { "@/*": ["./src/*"], }, },',
+      '  "include": ["**/*.ts", "**/*.tsx"],',
+      "}",
+    ].join("\n"),
+  );
+  await writeFile(
+    path.join(root, "src/views/review/ReviewView.tsx"),
+    "export function ReviewView() { return <main>Preview</main>; }\n",
+  );
+  await writeFile(
+    path.join(root, "src/views/review/index.ts"),
+    "export { ReviewView } from './ReviewView';\n",
+  );
+  await writeFile(
+    path.join(root, "app/page.tsx"),
+    "import { ReviewView } from '@/views/review';\nexport default function Page() { return <ReviewView />; }\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/review-mode"]);
+  await writeFile(
+    path.join(root, "src/views/review/ReviewView.tsx"),
+    [
+      "export function ReviewView() {",
+      "  const [mode, setMode] = useState('compare');",
+      "  return <main><button onClick={() => setMode('usage')}>Usage</button><p>{mode}</p></main>;",
+      "}",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "feat: add component review mode"]);
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD", runner: "playwright" });
+  const flow = plan.flows.find((candidate) => candidate.intentId);
+
+  assert.ok(flow);
+  assert.ok(flow.files.includes("src/views/review/ReviewView.tsx"));
+  assert.ok(flow.files.includes("app/page.tsx"));
+  assert.ok(flow.entrypoints.some((entrypoint) => entrypoint.kind === "route" && entrypoint.value === "/"));
+  assert.match(flow.reason, /Reverse imports reach .*ReviewView\.tsx -> src\/views\/review\/index\.ts -> app\/page\.tsx/);
 });
 
 test("verification manifest flows match when changed files are imported by anchored files", async () => {
@@ -6119,6 +6183,10 @@ test("qa command keeps runner setup opt-in for testless repositories", async () 
 
   assert.equal(qa.testSuite.hasTestSuite, false);
   assert.equal(qa.runner, "playwright");
+  assert.equal(
+    qa.flows.flatMap((flow) => flow.executionBlockers ?? []).some((blocker) => /No Playwright config/i.test(blocker)),
+    false,
+  );
   assert.doesNotMatch(markdown, /## First E2E Draft Bootstrap|Install command/);
   assert.match(markdown, /## Optional Automation/);
   assert.match(markdown, /does not require adopting this adapter/);


### PR DESCRIPTION
## Intent

Make QAMap's first-pass QA judgment depend on the complete behavior-bearing branch diff rather than on release-shaped commit subjects, runner availability, or whichever large file happens to consume the inference budget first.

This change maps each commit to its real files, analyzes residual diff behavior, preserves exact hunk evidence, improves reverse-import routing, and keeps runner-independent QA separate from optional automation setup. It also adds deterministic share and media scenario compilation plus URL-backed UI state QA.

## Agent / Review Risk

The primary risk is broader scenario selection for low-confidence diffs. The implementation keeps these recommendations review-required, requires located evidence, retains negative controls, and protects established runnable drafts through benchmark contracts.

## Validation Evidence

- [x] `pnpm test` (`175` tests passed)
- [x] `pnpm scan` (0 findings)
- [x] `pnpm bench:ci` (15/15 benchmark targets passed)
- [x] Relevant `qamap e2e plan/draft` output reviewed against committed framework-neutral fixtures.
- [x] `pnpm release:check`
- [x] Coverage thresholds passed: 88.48% lines, 85.12% branches, 95.71% functions.
- [x] npm package dry-run completed for `@ivorycanvas/qamap@0.4.4`.

## E2E / Manual Coverage

- Added release-shaped web fixtures covering public/protected access, share completion/cancellation/fallback, availability windows, media transitions, persisted context, and re-entry.
- Added unrelated false-positive controls for icon-only sharing terms, playground naming, static assets, and presentation-only conditions.
- Added React URL-backed mode coverage for direct entry, reload restoration, default cleanup, and invalid-value fallback.
- Confirmed deterministic Playwright share and media drafts pass static TypeScript checks.

## Maintainer Notes

This is the final functional patch intended for the `v0.4.4` release. The changelog, package version, CLI version, npm package, annotated tag, and GitHub Release should remain aligned.

## Collaboration Checklist

- [x] The branch uses an allowed prefix and contains no coding-agent product name.
- [x] The PR title follows `Type: imperative summary`.
- [x] `@ivory-code` is assigned.
- [x] Exactly one `type:` label and only relevant `area:` labels are applied.
- [x] The PR is intended to be squash-merged after required checks pass.
