### PR TITLE
Chore: stop automated dependency pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    # Root package security updates stay enabled, but version-update PRs are manual.
+    # Dependency updates are reviewed and applied manually.
     open-pull-requests-limit: 0
     # These manifests are static analyzer inputs and are never installed.
     exclude-paths:
@@ -14,8 +14,4 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    open-pull-requests-limit: 1
-    groups:
-      github-actions:
-        patterns:
-          - "*"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Intent

- Stop routine Dependabot pull requests for both npm and GitHub Actions.
- Keep dependency updates as an explicit maintainer action.
- Preserve Dependabot alerts so newly disclosed vulnerabilities remain visible without creating automatic branches or PRs.
- Disable repository-level Dependabot security update PRs and dismiss the remaining synthetic benchmark alerts as `not_used`.

## Agent / Review Risk

- Dependency upgrades now require a maintainer to open them manually.
- Dependabot alerts remain enabled; only automatic update PR creation is disabled.
- The excluded benchmark manifests are static analyzer inputs and their dependencies are never installed or executed.

## Validation Evidence

- [x] `pnpm test` - 177/177 passing
- [x] `pnpm scan` - 0 findings
- [x] `.github/dependabot.yml` parses successfully and every version-update limit is `0`
- [x] Repository setting reports Dependabot security updates as disabled
- [x] Open Dependabot alert count is `0`

## E2E / Manual Coverage

No product behavior changes. Verified the repository setting through the GitHub API and the committed configuration locally.

## Maintainer Notes

Dependabot alerts remain available in the Security tab. Future dependency updates are intentionally manual. No package version, tag, or release is included.

## Collaboration Checklist

- [x] The branch uses an allowed prefix and contains no coding-agent product name.
- [x] The PR title follows `Type: imperative summary`.
- [x] `@ivory-code` is assigned.
- [x] Exactly one `type:` label and only relevant `area:` labels are applied.
- [x] The PR is intended to be squash-merged after required checks pass.