### PR TITLE
Chore: release 0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.4.5 - 2026-07-16
+
 ### Added
 
 - Added stable QA reasoning traces that connect an exact diff source to the affected lifecycle, risk statement, routed scenario, optional draft artifact, and explicit `not-run` execution state.

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -1,8 +1,8 @@
 # Release Validation
 
-## Unreleased (0.4.5 candidate) - 2026-07-16
+## 0.4.5 - 2026-07-16
 
-Validated as a traceable-reasoning, cross-domain precision, and repository-evidence ownership candidate. QAMap now exposes one inspectable path from diff evidence to affected behavior, risk, routed QA scenario, optional artifact, and explicit non-execution. It also keeps QA routing separate from draft-mapping gaps, rejects unrelated package mocks, and maps a diff-added UI action to its observable state result:
+Validated as a traceable-reasoning, cross-domain precision, and repository-evidence ownership release. QAMap now exposes one inspectable path from diff evidence to affected behavior, risk, routed QA scenario, optional artifact, and explicit non-execution. It also keeps QA routing separate from draft-mapping gaps, rejects unrelated package mocks, and maps a diff-added UI action to its observable state result:
 
 | Gate | Current result |
 | --- | --- |
@@ -10,7 +10,7 @@ Validated as a traceable-reasoning, cross-domain precision, and repository-evide
 | `pnpm test` | 180/180 passing |
 | `pnpm scan` | 0 findings |
 | `pnpm bench:ci` | 16/16 synthetic PR targets pass across web, mobile, API, shared-component, configuration, state-transition, and test-only changes; public trace fixtures reject missing scenario paths and untraceable required scenarios |
-| Coverage | Lines 88.64%, branches 85.22%, functions 95.91% |
+| Coverage | Lines 88.64%, branches 85.30%, functions 95.91% |
 | Change Intent coverage | Lines 98.61%, branches 91.41%, functions 99.47% |
 | QA trace coverage | Lines 98.26%, branches 92.13%, functions 96.77% |
 | Reasoning path | Stable IDs connect diff source -> evidence-linked lifecycle -> risk -> routing -> optional draft; partial and review-only paths retain their gaps instead of being promoted |
@@ -19,7 +19,7 @@ Validated as a traceable-reasoning, cross-domain precision, and repository-evide
 | UI state handoff | A diff-added action selector compiles to the interaction step and repository-observed stable state copy becomes the assertion and user-facing success signal |
 | Generated action integrity | Implementation-shaped setter stages cannot compile as a second user interaction; the public record-pinning target requires exactly one mapped action and one observable assertion |
 | Workspace evidence ownership | A domain-neutral multi-app fixture keeps a changed asset and same-workspace endpoint evidence with the owning behavior flow while rejecting an unrelated sibling-app mock and unrelated same-app API client |
-| Package preview | `pnpm pack --dry-run` passes; the package version intentionally remains unchanged until release preparation |
+| Package preview | `pnpm pack --dry-run` and `npm publish --dry-run --access public` pass for `@ivorycanvas/qamap@0.4.5`; 140 files, 863.1 kB packed |
 
 Human Markdown, full JSON, compact agent JSON, and generated Playwright, Maestro, or manual drafts now share the same trace ID. This keeps the reasoning layer separate from the artifact while letting a reviewer move from generated code back to the exact change, inferred consequence, and risk that caused it to exist. A `traceable` result means the reasoning provenance is connected; it never means the target product was launched or the scenario passed.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Local zero-LLM PR QA designer that maps commit intent and diffs to traceable behavior lifecycles, QA scenarios, and optional automation drafts.",
   "type": "module",
   "packageManager": "pnpm@10.32.1",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const TOOL_NAME = "QAMap";
-export const VERSION = "0.4.4";
+export const VERSION = "0.4.5";


### PR DESCRIPTION
## Intent

Prepare the verified QAMap 0.4.5 patch for npm and GitHub release after the QA judgment precision work in #124.

- bump the package and CLI versions to `0.4.5`
- move the verified Unreleased notes into the dated `0.4.5` changelog section
- record the final release gate, coverage, benchmark, and package-preview evidence

## Agent / Review Risk

Low. This PR changes release metadata only. Product behavior was reviewed and validated in #124; the full release gate was rerun after the version bump.

## Validation Evidence

- [x] `pnpm release:check`
- [x] `pnpm test` (180/180 passing)
- [x] `pnpm scan` (0 findings)
- [x] `pnpm bench:ci` (16/16 passing)
- [x] Coverage gate (lines 88.64%, branches 85.30%, functions 95.91%)
- [x] `pnpm pack --dry-run`
- [x] `npm publish --dry-run --access public` (140 files, 863.1 kB packed)
- [x] npm registry confirms `0.4.5` is not already published

## E2E / Manual Coverage

No new behavior is introduced here. The release includes the public state-transition benchmark, exact diff-to-risk-to-proof traces, and a generated Playwright path constrained to one mapped interaction and one repository-observed assertion.

## Maintainer Notes

After merge, publish `@ivorycanvas/qamap@0.4.5`, create the annotated `v0.4.5` tag, and create a GitHub Release titled exactly `v0.4.5`.

## Collaboration Checklist

- [x] The branch uses an allowed prefix and contains no coding-agent product name.
- [x] The PR title follows `Type: imperative summary`.
- [x] `@ivory-code` is assigned.
- [x] Exactly one `type:` label and only relevant `area:` labels are applied.
- [x] The PR is intended to be squash-merged after required checks pass.
