### PR TITLE
Chore: release 0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+## 0.4.6 - 2026-07-18
+
+### Added
+
+- Added source-role classification for product behavior, commands, analysis rules, configuration, tests, documentation, and generated artifacts before domain vocabulary is interpreted.
+- Added repository-validation readiness for changes that should be checked with existing project commands instead of receiving fabricated product E2E blockers.
+- Added a public CLI and analyzer-rule benchmark with positive, negative, neighboring-rule, compact-agent, and non-product false-positive contracts.
+
+### Changed
+
+- Compact agent output now preserves one located reasoning trace, scenario source, affected file, review question, success signal, evidence gap, and next command even under the emergency 4KB budget.
+- Long-PR intent clustering now requires stronger shared evidence. Broad Conventional Commit scopes and one-word keyword bridges no longer merge unrelated changes into one high-confidence lifecycle.
+- Product QA flows now link directly imported, same-stem, or owner-path-related existing tests and distinguish them from tests changed by the PR itself.
+
+### Fixed
+
+- Analyzer and CLI vocabulary no longer fabricates scheduling, routing, payment, API, selector, fixture, or manifest work without product-behavior evidence.
+- Configuration-only, documentation-only, generated-artifact, and test-only changes no longer appear as blocked product automation when an existing repository validation command is the appropriate next action.
+- Related-test discovery no longer treats similarly named tests in unrelated repository areas as coverage evidence.
+- Safe untracked text changes included through `--include-working-tree` retain head-side file and line provenance instead of disappearing from QA reasoning.
+
 ## 0.4.5 - 2026-07-16
 
 ### Added

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -1,5 +1,34 @@
 # Release Validation
 
+## 0.4.6 - 2026-07-18
+
+Validated as a source-role-aware routing, large-PR evidence, and repository-verification release. QAMap now distinguishes product behavior from analyzer, command, configuration, documentation, generated, and test evidence before selecting QA. It retains an inspectable path through compact agent output, avoids merging unrelated long-PR intents, and points product changes at related existing tests without presenting repository validation as a failed product E2E:
+
+| Gate | Current result |
+| --- | --- |
+| `pnpm release:check` | Passed end to end for the release candidate |
+| `pnpm test` | 186/186 passing |
+| `pnpm scan` | 0 findings |
+| `pnpm bench:ci` | 17/17 synthetic PR targets pass across React, Vue, SvelteKit, Expo, API, shared-component, configuration, test-only, and CLI analyzer changes |
+| Coverage | Lines 88.67%, branches 85.27%, functions 95.77% |
+| Change Intent coverage | Lines 97.85%, branches 90.58%, functions 99.07% |
+| QA trace coverage | Lines 98.27%, branches 92.22%, functions 96.77% |
+| Source-role routing | Analyzer and CLI changes require command-contract and rule-boundary checks while rejecting unrelated product scheduling, routing, payment, API, fixture, selector, and manifest QA |
+| Repository verification | Configuration-only and test-only fixtures report `ready-to-run (repo)` with their existing validation command instead of a blocked product E2E score |
+| Large-PR intent integrity | Broad scopes and one-word keyword bridges cannot transitively collapse unrelated commits; exact commit files remain attached to their own intent |
+| Compact reasoning path | Emergency agent output remains below 4KB while retaining one located trace, scenario source, affected file, review question, success signal, evidence gap, and next command |
+| Related test evidence | Direct imports, matching source/test stems, and owner paths rank relevant tests while unrelated similarly named tests remain excluded |
+| Product execution honesty | Human output says `not run` and `not executed`; agent output carries `execution: { status: "not-run", performed: false, scope: "static-analysis-and-draft-mapping" }` |
+| Package preview | `pnpm pack --dry-run` and `npm publish --dry-run --access public` pass for `@ivorycanvas/qamap@0.4.6`; 143 files, 876.6 kB packed |
+
+Product automation readiness and repository validation readiness are now separate contracts. Product changes can still flow from diff evidence to optional Playwright, Maestro, or manual drafts. Analyzer, configuration, documentation, generated-artifact, and existing-test changes instead identify the repository command and verification mode that match the source role. Neither path claims that QAMap launched the target application or executed the command.
+
+The analyzer benchmark is domain-neutral: it changes a CLI command and a static rule engine, requires positive, negative, and neighboring-rule verification, and rejects product-domain setup inferred from words that happen to occur in analyzer source. Existing web, mobile, API, artifact, and state-transition fixtures remain unchanged and green, guarding against source-role classification suppressing genuine product evidence.
+
+Long-PR tests model independent changes connected only by broad scopes or one shared keyword. Their contracts require separate intents and exact commit-file ownership. Related-test tests similarly place a correctly imported feature test beside an unrelated same-name build test; only the directly relevant evidence may enter the QA checklist and agent handoff.
+
+Machine automation values remain `compiled`, `partial`, `not-compiled`, and `review-only` for the additive v1 contract. The new readiness fields are additive and explain whether those automation values apply or whether the result is repository validation. A `ready-to-run` verification status means QAMap found a suitable command; it never means that command passed.
+
 ## 0.4.5 - 2026-07-16
 
 Validated as a traceable-reasoning, cross-domain precision, and repository-evidence ownership release. QAMap now exposes one inspectable path from diff evidence to affected behavior, risk, routed QA scenario, optional artifact, and explicit non-execution. It also keeps QA routing separate from draft-mapping gaps, rejects unrelated package mocks, and maps a diff-added UI action to its observable state result:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Local zero-LLM PR QA designer that maps commit intent and diffs to traceable behavior lifecycles, QA scenarios, and optional automation drafts.",
   "type": "module",
   "packageManager": "pnpm@10.32.1",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const TOOL_NAME = "QAMap";
-export const VERSION = "0.4.5";
+export const VERSION = "0.4.6";


### PR DESCRIPTION
## Intent

- Set the package and CLI version to `0.4.6`.
- Record the source-role routing, repository-validation readiness, large-PR evidence, and related-test improvements in the changelog.
- Capture the final release gate and package-preview evidence without changing product behavior.

## Agent / Review Risk

- None beyond release metadata. The functional changes were reviewed and merged through #126.
- Publishing and tag creation occur only after this release commit is merged and npm authentication succeeds.

## Validation Evidence

- [x] `pnpm test` - 186/186 passing.
- [x] `pnpm scan` - 0 findings.
- [x] Relevant `qamap qa` and compact agent output reviewed in #126.
- [x] `pnpm bench:ci` - 17/17 passing.
- [x] Coverage - lines 88.67%, branches 85.27%, functions 95.77%.
- [x] `npm publish --dry-run --access public --json` - 143 files, 876.6 kB packed.

## E2E / Manual Coverage

- No new product behavior is introduced by this release-only commit.
- The complete `pnpm release:check` gate passed for `@ivorycanvas/qamap@0.4.6`.

## Maintainer Notes

- Canonical release identifier: `v0.4.6`.
- Git tag, GitHub Release title, npm package, and post-publish smoke checks will be completed after merge.

## Collaboration Checklist

- [x] The branch uses an allowed prefix and contains no coding-agent product name.
- [x] The PR title follows `Type: imperative summary`.
- [x] `@ivory-code` is assigned.
- [x] Exactly one `type:` label and only relevant `area:` labels are applied.
- [x] The PR is intended to be squash-merged after required checks pass.
