### PR TITLE
Fix: align QA evidence with final PR context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Added provenance-aware base resolution across QA, review, test-plan, and E2E output. QAMap now reads explicit input, PR CI metadata, repo-local Git configuration, and Git history in order, and discloses long-lived refs that point to the same commit.
+- Added a three-layer human QA decision view that preserves the complete risk map, separates executable evidence available now, and emits manual or agent contracts for important scenarios that cannot yet compile.
+- Added package-scoped JavaScript validation discovery and related-test Python commands through default or variant Compose files, primary application services, and container-local `uv` or Poetry runners.
 - Added a canonical `route` decision to QA JSON and compact agent output. It tells consumers whether the change needs an optional automation draft or existing repository validation, exposes an unambiguous status, and names the next action without relying on compatibility readiness scores.
 - Added the first provenance-pinned public PR benchmark, reduced from Cal.com PR #27765 under its MIT license. The contract requires QAMap to recover form-validation timing, exact diff evidence, existing regression tests, and edit/blur/correction/submission state-transition QA.
 - Added a repository-local manifest lifecycle regression that proves one human correction sharpens the current PR and is reused by the next PR without another prompt.
@@ -12,6 +15,9 @@
 
 ### Changed
 
+- Working-tree analysis now compares the selected merge base directly with the final worktree, so intermediate files removed later in the branch do not survive as stale changed-file or diff evidence.
+- Draft reporting now says `static-runnable` and `not executed` explicitly; generated tests with skipped placeholders or without observable assertions fail self-check instead of appearing runnable.
+- Specific commit-and-diff-backed intent titles now remain the flow language shown to reviewers; internal handler and serializer symbols only refine broad titles such as generic update or release work.
 - Form validation-mode changes now produce framework-neutral timing QA across initial editing, the configured validation trigger, stale-error correction, and final submission when both the previous and new modes are present in a form-shaped diff.
 - Agent payload compaction now preserves the canonical route decision before lower-priority detail, including under lean and emergency 4KB shapes.
 - Playwright drafts can now prepare an entity before exercising a newly added nested action when the same source exposes strongly related input and creation controls.
@@ -19,6 +25,9 @@
 
 ### Fixed
 
+- Nested page components no longer become fabricated routes, API endpoints no longer become browser navigation targets, API schema parameter names no longer become mobile screens, settlement vocabulary alone no longer creates payment setup, and unchanged success copy is no longer borrowed as a changed-flow assertion.
+- Capturing a current server timestamp with `timezone.now()` no longer creates scheduling and calendar-boundary QA; actual schedule, reminder, and timezone preference changes remain eligible.
+- Python Compose discovery no longer prefers a worker or scheduler over the primary web/API service merely because both services share the same Python image.
 - Repository-validation output no longer requires consumers to reconcile a compatibility-only `blocked` automation level with a `ready-to-run` repository command. The additive route status now expresses the applicable decision directly.
 - CLI command changes now use a `command-contract` verification mode, so mixed analyzer and package-surface diffs route to the discovered repository command instead of appearing as blocked product E2E drafts.
 - Python settings modules are no longer treated as product API behavior, while executable service modules remain eligible for contract impact.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ A manifest and test runner are **not required** for the first run.
 
 `qa` performs static analysis and draft mapping only. It does not launch the target application or claim that product QA passed.
 
+When `--base` is omitted, QAMap checks CI pull-request metadata, repo-local Git configuration, and nearby long-lived branches in that order. The report always shows which base was selected and why. Use `--include-working-tree` to analyze the final net state from that branch to the current worktree; a file added in an earlier commit and removed locally is not reported as a current change.
+
 For repeat use in a JavaScript repository, install QAMap once and add short package scripts:
 
 ```sh
@@ -75,7 +77,11 @@ QAMap keeps QA selection and test generation as two separate decisions:
 | **QA reasoning trace** | Give every scenario a stable ID that connects diff line -> affected lifecycle -> risk -> routing decision -> optional draft, while keeping execution explicitly `not-run`. |
 | **Automation receipt** | Report whether the selected scenario is fully, partially, or not mapped into a draft, including the missing selector, fixture, entrypoint, or assertion evidence. Machine output keeps the compatible values `compiled`, `partial`, and `not-compiled`; none of them means a test ran or passed. |
 
+The human report preserves all important scenarios even when the repository has no test runner. It then separates **Important QA And Risk Map**, **Executable Evidence Available Now**, and **Manual Or Agent QA Contracts**. A `static-runnable` draft passed QAMap's structural self-checks, but the target application was not launched; only explicit execution can produce pass or fail evidence.
+
 Changes limited to analyzer rules, configuration, documentation, generated artifacts, or existing tests are routed to repository validation. QAMap does not mislabel them as blocked product E2E work, and it never claims that a suggested command has already passed.
+
+Suggested repository commands are scoped to affected workspace packages and related tests when the repo exposes enough evidence. Python projects can reuse root Compose variants and their primary application service; background workers are not selected as the default test entrypoint merely because they share an image.
 
 Trimmed real output from the same demo:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,12 @@ One richly evidenced squash commit can reach high confidence. A title without co
 
 The analysis is deterministic and local. It does not execute repository code, contact GitHub, upload source, or call an LLM.
 
+## Base And Net Change Resolution
+
+The analysis range is evidence too. QAMap resolves a base from an explicit option, pull-request CI environment, repo-local Git configuration, or the nearest long-lived branch in Git history. The chosen source and explanation are carried through test-plan, review, E2E, QA, and compact agent output. Local history cannot always prove the hosting platform's PR target, so equivalent refs at the same commit are disclosed instead of being treated as distinct answers.
+
+Committed analysis uses the base/head merge-base range. Working-tree analysis compares that merge base directly with the final tracked worktree and then adds untracked files. This avoids preserving a stale intermediate change that was committed earlier in the branch but removed before review.
+
 ## Change Source Roles
 
 Before changed text can become behavior evidence, `src/source-role.ts` classifies its source as `product`, `command`, `analysis-rule`, `configuration`, `test`, `documentation`, or `generated`. The role is an evidence boundary, not a domain guess: vocabulary inside an analyzer regex, benchmark contract, CLI parser, or documentation example must not silently become product behavior.
@@ -62,6 +68,8 @@ Runner adapters then emit a second receipt for each routed scenario:
 - `review-only`: the scenario or repository has no executable adapter contract.
 
 A compilation receipt is static evidence, not a test result. Human output therefore calls these states `fully mapped`, `partially mapped`, and `not mapped`; the machine values remain stable for compatibility. Every `qa` result also carries an invocation-level `execution` receipt with `status: not-run` and `scope: static-analysis-and-draft-mapping`. Only explicit execution may produce pass or fail evidence. A required scenario that is partial or not compiled remains an execution blocker and prevents the draft from being described as runnable.
+
+Human output groups the same decision into three layers: the complete QA and risk map, executable evidence available now, and manual or agent contracts for the remaining scenarios. Runner absence affects only the latter two layers; it never deletes a risk-backed QA scenario. A draft may be called `static-runnable` only when its structural self-check finds an entrypoint, observable assertion, and no skipped placeholder. The label always includes `not executed` until a separate execution boundary returns evidence.
 
 The additive `route` object is the canonical machine decision above those compatibility values. It separates optional draft preparation from repository validation and names the next action directly: complete or review a draft, run an existing command, or define a missing command. Agent payload compaction preserves this object before lower-priority detail, so a repository-verification result cannot be misread as blocked product E2E work.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -20,11 +20,23 @@ pnpm exec qamap init --scripts .
 
 Use `npx --yes @ivorycanvas/qamap@latest ...` for one-off human runs without installing QAMap into the target repository. Packaged agent skills use an explicit `npm exec --package` form so they do not invoke the target repository's package manager or Corepack metadata flow.
 
+`--base` is optional. QAMap resolves it from an explicit flag, CI pull-request metadata, `branch.<name>.qamap-base` or `qamap.base` Git config, and finally the nearest long-lived branch in local Git history. Reports include the selected source and reason. If multiple long-lived refs point to the same commit, they are reported as equivalent rather than presented as separately proven PR metadata.
+
+`--include-working-tree` compares the selected merge base directly with the final worktree, then adds untracked files. This is a net-state comparison: a committed file that was later removed locally does not remain as stale QA evidence.
+
 ## Reading The Output
 
 Human-facing reports (`text` and `markdown` formats) open with an **At a Glance** section: evidence-backed change intent, behavior lifecycle, affected behavior, the reviewer question to answer before merge, concrete repository evidence, trace coverage, the proposed draft path, and optional automation gaps. The **QA Reasoning Trace** section then gives each selected scenario a stable ID and shows the causal path from a diff source to affected behavior, risk, routing decision, and optional artifact. Runner information appears later as an automation adapter. When printed to an interactive terminal the report is colorized (headings, statuses, priority tags, inline commands); files written with `--output`, pipes, CI logs, and the machine formats (`json`, `agent`, `sarif`) are always plain. The standard `NO_COLOR` and `FORCE_COLOR` environment variables are honored.
 
 Scenario routing and draft mapping answer different questions. Routing explains what the changed behavior should prove before merge. **Draft Mapping And Context Gaps** explains why an optional generated artifact may still need a selector, fixture, runner, or repository fact. Those draft gaps do not invalidate the runner-independent QA judgment and are not automatically PR merge requirements.
+
+Human QA output makes that boundary visible in three layers:
+
+1. **Important QA And Risk Map** keeps every evidence-backed scenario, including cases that require human review.
+2. **Executable Evidence Available Now** lists existing validation commands and structurally self-checked drafts without claiming they ran.
+3. **Manual Or Agent QA Contracts** preserves the exact setup, action, outcome, and missing evidence for scenarios that cannot yet compile deterministically.
+
+`static-runnable` means the generated artifact has an entrypoint, observable assertion, no skipped placeholder, and passing QAMap self-checks. It does not mean the target application or command was executed.
 
 Draft readiness is reported as a **stage on a fixed four-step journey**, for example `Stage: setup needed (1 of 4) — readiness 0/100`. A fresh repository usually starts at stage 1 — that is the expected starting point, not a failure. Each stage maps to a stable compatibility `readiness.level` value in the `json` and `agent` formats:
 
@@ -92,6 +104,8 @@ That means QAMap is most valuable when it becomes the team's verification base: 
 | `qamap init --scripts .` | Add collision-safe `qa`, `qa:local`, and `qa:e2e` package scripts for repeat use in a JavaScript repository. |
 
 For monorepos, pass `--workspace-root` when scanning a package. Package-local checks still use the package directory, while repo-level guardrails such as `AGENTS.md`, `.github/workflows`, `LICENSE`, `SECURITY.md`, and `CONTRIBUTING.md` are read from the workspace root.
+
+Suggested validation commands follow the changed ownership boundary where possible. JavaScript workspaces receive package-scoped commands, and Python repositories can receive related pytest paths through a detected Compose service and container runner. These are commands to run, never pre-recorded pass results.
 
 ### Short Package Scripts
 

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -152,7 +152,7 @@ export interface BehaviorAnalyzerAdapter {
 }
 
 export interface InferredBehaviorEntrypoint {
-  kind: "route" | "screen" | "command";
+  kind: "route" | "screen" | "endpoint" | "command";
   value: string;
   file: string;
   confidence: BehaviorConfidence;
@@ -526,6 +526,9 @@ function surfaceForEntrypoint(kind: InferredBehaviorEntrypoint["kind"]): Behavio
   }
   if (kind === "screen") {
     return "mobile";
+  }
+  if (kind === "endpoint") {
+    return "api";
   }
   return "cli";
 }

--- a/src/change-intent.ts
+++ b/src/change-intent.ts
@@ -1374,7 +1374,9 @@ function collectDiffRiskEvidence(addedDiffEvidence: AddedDiffEvidence): ChangeIn
           const calendarMatch = line.text.match(
             /(timezone|scheduledAt|\bschedule\w*\b|\breminder\w*\b|\bcalendar\b|\btomorrow\b|\bdaily\b)/i,
           );
-          if (calendarMatch) {
+          const recordsCurrentTimestamp = /^timezone$/i.test(calendarMatch?.[1] ?? "") &&
+            /\btimezone\.now\s*\(/i.test(line.text);
+          if (calendarMatch && !recordsCurrentTimestamp) {
             evidence.push(diffRiskEvidence(
               file,
               hunk,

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -70,7 +70,7 @@ export type E2eFlowKind =
   | "command"
   | "domain"
   | "changed-file";
-export type E2eEntrypointKind = "route" | "screen" | "command";
+export type E2eEntrypointKind = "route" | "screen" | "endpoint" | "command";
 export type E2eEntrypointConfidence = "high" | "medium" | "low";
 export type E2eSetupHintKind = "auth" | "network" | "fixture" | "environment" | "payment" | "state";
 export type E2eSetupHintConfidence = "high" | "medium" | "low";
@@ -272,6 +272,7 @@ export interface E2ePlanResult {
   workspaceRoot?: string;
   generatedAt: string;
   base: string;
+  baseResolution: TestPlanResult["baseResolution"];
   head: string;
   includeWorkingTree: boolean;
   project: E2eProjectProfile;
@@ -637,6 +638,7 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
     workspaceRoot: testPlan.workspaceRoot,
     generatedAt: new Date().toISOString(),
     base: testPlan.base,
+    baseResolution: testPlan.baseResolution,
     head: testPlan.head,
     includeWorkingTree: testPlan.includeWorkingTree,
     project,
@@ -2749,6 +2751,7 @@ function inferFlowSuccessSignal(flow: Omit<E2eFlow, "languageBrief">): string {
   const visibleOutcome = flow.selectors.find(
     (selector) =>
       selector.kind === "visible-text" &&
+      Boolean(selector.addedInDiff) &&
       (isVisibleSuccessOutcome(selector.value) || isDiffBackedStateMarker(flow, selector)),
   );
   if (visibleOutcome) {
@@ -2820,6 +2823,7 @@ function isApiContractFocusedFlow(flow: Omit<E2eFlow, "languageBrief">): boolean
     return false;
   }
   return (
+    flow.kind === "api" ||
     /\bapi contract\b/i.test(flow.title) ||
     (flow.coverage.some((target) => target.title === "API contract compatibility") &&
       !hasUserFacingEntrypointOrFile(flow))
@@ -2903,6 +2907,7 @@ export function formatMarkdownE2ePlan(result: E2ePlanResult): string {
     lines.push(`- Workspace root: \`${escapeMarkdownInline(result.workspaceRoot)}\``);
   }
   lines.push(`- Base: \`${escapeMarkdownInline(result.base)}\``);
+  lines.push(`- Base selection: ${escapeMarkdownInline(result.baseResolution.reason)}`);
   lines.push(`- Head: \`${escapeMarkdownInline(result.head)}\``);
   if (result.includeWorkingTree) {
     lines.push("- Includes working tree changes: yes");
@@ -3337,7 +3342,7 @@ export function formatMarkdownE2eDraft(result: E2eDraftResult): string {
   lines.push(
     `Summary: ${result.actionSummary.required} required action${result.actionSummary.required === 1 ? "" : "s"}, ${result.actionSummary.recommended} recommended action${result.actionSummary.recommended === 1 ? "" : "s"}.`,
   );
-  lines.push(`- Runnable candidates: ${result.readinessSummary.runnableCandidates}`);
+  lines.push(`- Static-runnable candidates (not executed): ${result.readinessSummary.runnableCandidates}`);
   lines.push(`- Near-runnable files: ${result.readinessSummary.nearRunnable}`);
   lines.push(`- Review-only files: ${result.readinessSummary.reviewOnly}`);
   lines.push(
@@ -5249,6 +5254,12 @@ function intentFlowDisplayTitle(
   intent: ChangeIntentAnalysis["intents"][number],
   domainLanguage?: DomainLanguageSummary,
 ): string {
+  if (
+    !isBroadIntentDisplayTitle(intent.title) &&
+    ((intent.confidence !== "low" && !intent.reviewRequired) || isSpecificIntentDisplayTitle(intent.title))
+  ) {
+    return intent.title;
+  }
   const actionStages = intent.lifecycle.filter(
     (stage) =>
       (stage.kind === "trigger" || stage.kind === "side-effect") &&
@@ -5271,6 +5282,14 @@ function intentFlowDisplayTitle(
   }
   const subject = summarizeFlowSubject(intent.files, "Changed behavior", domainLanguage);
   return `${subject}: ${actions.map(titleCase).join(" / ")}`;
+}
+
+function isSpecificIntentDisplayTitle(title: string): boolean {
+  return title.trim().split(/\s+/).filter(Boolean).length >= 3;
+}
+
+function isBroadIntentDisplayTitle(title: string): boolean {
+  return /^(?:update|change|adjust|prepare|refactor|refine|improve|polish|fix|work on|misc|cleanup)\b/i.test(title.trim());
 }
 
 function conciseLifecycleAction(label: string): string | undefined {
@@ -5771,15 +5790,18 @@ async function inferFlowSetupHints(
     );
   }
 
-  const paymentPathSignal = /(?:^|\/|[-_])(payment|billing|checkout|purchase|subscription|invoice|settlement)(?:\/|[-_.]|$)/i;
+  const paymentPathSignal = /(?:^|\/|[-_])(payment|billing|checkout|purchase|subscription|invoice)(?:\/|[-_.]|$)/i;
   const paymentProviderSignal = /(?:stripe|\biap\b|in-app-purchase|storekit|revenuecat)/i;
-  const changedPaymentSignal = /(?:payment|billing|checkout|purchase|subscription|invoice|settlement)/i;
+  const paymentActionSignal = /(?:submit|complete|start|confirm|process|create|cancel|declin|refund|renew|retry|restore)[A-Za-z0-9_\s-]{0,48}(?:payment|checkout|purchase|subscription|invoice)|(?:payment|checkout|purchase|subscription)[A-Za-z0-9_\s-]{0,48}(?:submit|complete|start|confirm|process|cancel|declin|refund|renew|retry|restore)/i;
+  const mutatingRequestSignal = /\bmethod\s*:\s*["'](?:POST|PUT|PATCH|DELETE)["']|\.(?:post|put|patch|delete)\s*\(/i;
   if (
-    paymentPathSignal.test(filesText) ||
     paymentProviderSignal.test(signalText) ||
-    changedPaymentSignal.test(changedText)
+    (paymentPathSignal.test(filesText) && (
+      paymentActionSignal.test(changedText) ||
+      mutatingRequestSignal.test(signalText)
+    ))
   ) {
-    const paymentFiles = matchingFiles(/payment|billing|checkout|purchase|subscription|invoice|settlement|stripe|iap|in-app-purchase|storekit|revenuecat/i);
+    const paymentFiles = matchingFiles(/payment|billing|checkout|purchase|subscription|invoice|stripe|iap|in-app-purchase|storekit|revenuecat/i);
     hints.push(
       setupHint(
         "payment",
@@ -6467,7 +6489,7 @@ function entrypointsFromPath(file: string, runner: E2eRunnerName): E2eEntrypoint
   const route = routeEntrypointFromPath(file);
   if (route && runner !== "maestro") {
     entrypoints.push({
-      kind: "route",
+      kind: isApiRouteFile(file) ? "endpoint" : "route",
       value: route.value,
       file,
       confidence: route.confidence,
@@ -6503,7 +6525,7 @@ function entrypointsFromText(file: string, text: string, runner: E2eRunnerName):
     }
   }
 
-  if (runner !== "playwright") {
+  if (runner !== "playwright" && isPotentialScreenEntrypointFile(file)) {
     const screenMatcher = /(?:navigation\.)?navigate\(\s*["']([^"'/]{2,80})["']|name\s*=\s*["']([^"'/]{2,80})["']/g;
     for (const match of text.matchAll(screenMatcher)) {
       const screen = normalizeScreenName(match[1] ?? match[2]);
@@ -6564,7 +6586,29 @@ function screenEntrypointFromPath(
 }
 
 function isPotentialRouteEntrypointFile(file: string): boolean {
-  return isUiImplementationFile(file) || /(?:^|\/)(?:app|pages|routes)\/.*(?:page|route)\.[cm]?[jt]sx?$/i.test(file);
+  if (!isUiImplementationFile(file) && !/(?:^|\/)(?:app|pages|routes)\/.*(?:page|route)\.[cm]?[jt]sx?$/i.test(file)) {
+    return false;
+  }
+  const segments = toPosixPath(file).split("/");
+  const appIndex = lastIndexOfAny(segments, ["app"]);
+  const pageIndex = lastIndexOfAny(segments, ["pages", "routes"]);
+  const routeRootIndex = appIndex >= 0 ? appIndex : pageIndex;
+  if (routeRootIndex < 0) {
+    return false;
+  }
+  const routeSegments = segments.slice(routeRootIndex + 1);
+  if (routeSegments.slice(0, -1).some(isNonRouteImplementationSegment)) {
+    return false;
+  }
+  if (appIndex >= 0) {
+    const basename = stripKnownExtension(path.basename(file));
+    return /^(?:index|page|route)$/i.test(basename);
+  }
+  return true;
+}
+
+function isNonRouteImplementationSegment(segment: string): boolean {
+  return /^(?:components?|composables?|hooks?|lib|services?|stores?|styles?|tests?|utils?)$/i.test(segment);
 }
 
 function isRouteConfigEntrypointFile(file: string): boolean {
@@ -8178,7 +8222,7 @@ function draftExecutionBlockers(
   // Missing validation evidence describes the repository before this draft exists.
   // Keep it as PR guidance, but do not treat it as proof that the generated file cannot execute.
   if (selfCheck?.status === "fail") {
-    blockers.push(...selfCheck.blockers);
+    blockers.push(...rootSelfCheckBlockers(selfCheck.blockers));
   }
   if (!verificationOnly && runner !== "manual") {
     for (const receipt of scenarioAutomation.filter(
@@ -8191,6 +8235,13 @@ function draftExecutionBlockers(
     }
   }
   return uniqueStrings(blockers).slice(0, 8);
+}
+
+function rootSelfCheckBlockers(blockers: string[]): string[] {
+  const hasUncompiledAction = blockers.some((blocker) => blocker.startsWith("Compiled actions:"));
+  return blockers.filter((blocker) =>
+    !(hasUncompiledAction && blocker.startsWith("Skipped tests:"))
+  );
 }
 
 function draftRunnableStatus(
@@ -8291,6 +8342,14 @@ function evaluatePlaywrightDraftSelfCheck(
       ? "No TODO comments remain in the generated draft."
       : `${todoCount} TODO marker${todoCount === 1 ? "" : "s"} remain for reviewer follow-up.`,
   ));
+  const skippedTests = content.match(/\btest\.(?:fixme|skip)\s*\(|\btest\.describe\.skip\s*\(/g)?.length ?? 0;
+  checks.push(draftSelfCheckItem(
+    "Skipped tests",
+    skippedTests === 0 ? "pass" : "fail",
+    skippedTests === 0
+      ? "The generated artifact does not disable or skip its test cases."
+      : `${skippedTests} skipped or fixme test marker${skippedTests === 1 ? "" : "s"} keep this artifact review-only.`,
+  ));
   const weakSmokeAssertions = content.match(/expect\(page\.locator\(["']body["']\)\)\.toBeVisible\(\)/g)?.length ?? 0;
   checks.push(draftSelfCheckItem(
     "Domain assertions",
@@ -8298,6 +8357,14 @@ function evaluatePlaywrightDraftSelfCheck(
     weakSmokeAssertions === 0
       ? "The draft does not rely on body-only smoke assertions."
       : `${weakSmokeAssertions} body-only smoke assertion${weakSmokeAssertions === 1 ? "" : "s"} cannot count as changed-behavior coverage.`,
+  ));
+  const executableAssertions = content.match(/await expect\((?!page\.locator\(["']body["']\))/g)?.length ?? 0;
+  checks.push(draftSelfCheckItem(
+    "Executable assertions",
+    executableAssertions > 0 ? "pass" : "fail",
+    executableAssertions > 0
+      ? `${executableAssertions} observable Playwright assertion${executableAssertions === 1 ? "" : "s"} were generated.`
+      : "No observable changed-behavior assertion was generated; navigation or clicks alone cannot be labeled runnable coverage.",
   ));
   const uncompiledSteps = content.match(/QAMap could not infer a stable locator for this step/g)?.length ?? 0;
   checks.push(draftSelfCheckItem(

--- a/src/git-context.ts
+++ b/src/git-context.ts
@@ -1,0 +1,327 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type BaseRefSource = "explicit" | "environment" | "repository-config" | "git-history";
+
+export interface BaseRefResolution {
+  ref: string;
+  source: BaseRefSource;
+  reason: string;
+  equivalentRefs?: string[];
+}
+
+export interface GitChangedFile {
+  status: string;
+  path: string;
+  previousPath?: string;
+}
+
+export interface ChangedFilesOptions {
+  base: string;
+  head: string;
+  includeWorkingTree?: boolean;
+}
+
+interface BaseCandidateScore {
+  ref: string;
+  commit: string;
+  headDistance: number;
+  targetDistance: number;
+  order: number;
+}
+
+const commonBaseNames = ["develop", "development", "dev", "main", "master", "trunk"];
+const environmentBaseNames = [
+  "QAMAP_BASE_REF",
+  "GITHUB_BASE_REF",
+  "CI_MERGE_REQUEST_TARGET_BRANCH_NAME",
+  "BITBUCKET_PR_DESTINATION_BRANCH",
+  "BUILDKITE_PULL_REQUEST_BASE_BRANCH",
+  "CHANGE_TARGET",
+  "SYSTEM_PULLREQUEST_TARGETBRANCH",
+] as const;
+
+export async function resolveBaseRef(
+  root: string,
+  options: { explicit?: string; head?: string } = {},
+): Promise<BaseRefResolution> {
+  const head = options.head ?? "HEAD";
+  if (options.explicit) {
+    await requireRef(root, options.explicit);
+    return {
+      ref: options.explicit,
+      source: "explicit",
+      reason: `Selected from the explicit --base value (${options.explicit}).`,
+    };
+  }
+
+  const remotes = await listRemotes(root);
+  for (const variable of environmentBaseNames) {
+    const value = process.env[variable]?.trim();
+    if (!value) {
+      continue;
+    }
+    const ref = await resolveNamedRef(root, value, remotes);
+    if (ref) {
+      return {
+        ref,
+        source: "environment",
+        reason: `Selected from ${variable} (${value}).`,
+      };
+    }
+  }
+
+  const currentBranch = await readOptionalGitValue(root, ["branch", "--show-current"]);
+  const configuredBase = currentBranch
+    ? await readOptionalGitValue(root, ["config", "--get", `branch.${currentBranch}.qamap-base`])
+    : undefined;
+  const repositoryBase = configuredBase ?? await readOptionalGitValue(root, ["config", "--get", "qamap.base"]);
+  if (repositoryBase) {
+    const ref = await resolveNamedRef(root, repositoryBase, remotes);
+    if (!ref) {
+      throw new Error(`Configured QAMap base ref does not exist: ${repositoryBase}`);
+    }
+    return {
+      ref,
+      source: "repository-config",
+      reason: configuredBase
+        ? `Selected from branch.${currentBranch}.qamap-base (${repositoryBase}).`
+        : `Selected from qamap.base (${repositoryBase}).`,
+    };
+  }
+
+  const candidates = await collectBaseCandidates(root, remotes);
+  const scored = (
+    await Promise.all(candidates.map((ref, order) => scoreBaseCandidate(root, ref, head, order)))
+  ).filter((candidate): candidate is BaseCandidateScore => candidate !== undefined);
+  scored.sort((left, right) =>
+    left.headDistance - right.headDistance ||
+    left.targetDistance - right.targetDistance ||
+    left.order - right.order
+  );
+
+  const selected = scored[0];
+  if (!selected) {
+    throw new Error(
+      "Could not infer a base ref from CI metadata, repository configuration, or Git history. Pass --base <ref>.",
+    );
+  }
+  const equivalentRefs = scored
+    .filter((candidate) => candidate.ref !== selected.ref && candidate.commit === selected.commit)
+    .map((candidate) => candidate.ref)
+    .slice(0, 6);
+  const equivalenceReason = equivalentRefs.length > 0
+    ? ` ${equivalentRefs.join(", ")} ${equivalentRefs.length === 1 ? "points" : "point"} to the same commit, so the diff is identical.`
+    : "";
+  return {
+    ref: selected.ref,
+    source: "git-history",
+    reason:
+      `Selected the nearest long-lived branch in Git history (${selected.headDistance} head-only commit` +
+      `${selected.headDistance === 1 ? "" : "s"}, ${selected.targetDistance} target-only commit` +
+      `${selected.targetDistance === 1 ? "" : "s"}).${equivalenceReason}`,
+    equivalentRefs: equivalentRefs.length > 0 ? equivalentRefs : undefined,
+  };
+}
+
+export async function collectChangedFiles(
+  root: string,
+  options: ChangedFilesOptions,
+): Promise<GitChangedFile[]> {
+  if (!options.includeWorkingTree) {
+    const { stdout } = await git(root, [
+      "diff",
+      "--find-renames",
+      "--name-status",
+      "--diff-filter=ACDMRTUXB",
+      `${options.base}...${options.head}`,
+    ]);
+    return parseChangedFiles(stdout);
+  }
+
+  const comparisonBase = await resolveMergeBase(root, options.base, options.head);
+  const { stdout: trackedStdout } = await git(root, [
+    "diff",
+    "--find-renames",
+    "--name-status",
+    "--diff-filter=ACDMRTUXB",
+    comparisonBase,
+  ]);
+  const { stdout: untrackedStdout } = await git(root, ["ls-files", "--others", "--exclude-standard"]);
+  return mergeChangedFiles(
+    parseChangedFiles(trackedStdout),
+    untrackedStdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((filePath) => ({ status: "A", path: filePath })),
+  );
+}
+
+export async function resolveMergeBase(root: string, base: string, head: string): Promise<string> {
+  const { stdout } = await git(root, ["merge-base", base, head]);
+  const mergeBase = stdout.trim();
+  if (!mergeBase) {
+    throw new Error(`Could not find a merge base between ${base} and ${head}.`);
+  }
+  return mergeBase;
+}
+
+async function collectBaseCandidates(root: string, remotes: string[]): Promise<string[]> {
+  const candidates: string[] = [];
+  for (const remote of remotes) {
+    const remoteHead = await readOptionalGitValue(root, [
+      "symbolic-ref",
+      "--quiet",
+      "--short",
+      `refs/remotes/${remote}/HEAD`,
+    ]);
+    if (remoteHead) {
+      candidates.push(remoteHead);
+    }
+  }
+  for (const name of commonBaseNames) {
+    for (const remote of remotes) {
+      candidates.push(`${remote}/${name}`);
+    }
+    candidates.push(name);
+  }
+
+  const existing: string[] = [];
+  for (const candidate of uniqueStrings(candidates)) {
+    if (await refExists(root, candidate)) {
+      existing.push(candidate);
+    }
+  }
+  return existing;
+}
+
+async function scoreBaseCandidate(
+  root: string,
+  ref: string,
+  head: string,
+  order: number,
+): Promise<BaseCandidateScore | undefined> {
+  try {
+    const mergeBase = await resolveMergeBase(root, ref, head);
+    const [commit, headDistance, targetDistance] = await Promise.all([
+      resolveCommit(root, ref),
+      countCommits(root, `${mergeBase}..${head}`),
+      countCommits(root, `${mergeBase}..${ref}`),
+    ]);
+    return { ref, commit, headDistance, targetDistance, order };
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolveCommit(root: string, ref: string): Promise<string> {
+  const { stdout } = await git(root, ["rev-parse", `${ref}^{commit}`]);
+  return stdout.trim();
+}
+
+async function countCommits(root: string, range: string): Promise<number> {
+  const { stdout } = await git(root, ["rev-list", "--count", range]);
+  const value = Number.parseInt(stdout.trim(), 10);
+  if (!Number.isFinite(value)) {
+    throw new Error(`Could not count commits for ${range}.`);
+  }
+  return value;
+}
+
+async function resolveNamedRef(root: string, value: string, remotes: string[]): Promise<string | undefined> {
+  const normalized = value
+    .replace(/^refs\/heads\//, "")
+    .replace(/^refs\/remotes\//, "");
+  const matchedRemote = remotes.find((remote) => normalized.startsWith(`${remote}/`));
+  const branchName = matchedRemote ? normalized.slice(matchedRemote.length + 1) : normalized;
+  const candidates = [
+    value,
+    normalized,
+    ...remotes.map((remote) => `${remote}/${branchName}`),
+    branchName,
+  ];
+  for (const candidate of uniqueStrings(candidates)) {
+    if (await refExists(root, candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+async function listRemotes(root: string): Promise<string[]> {
+  const value = await readOptionalGitValue(root, ["remote"]);
+  return value?.split(/\r?\n/).map((item) => item.trim()).filter(Boolean) ?? [];
+}
+
+async function requireRef(root: string, ref: string): Promise<void> {
+  if (!await refExists(root, ref)) {
+    throw new Error(`Base ref does not exist: ${ref}`);
+  }
+}
+
+async function refExists(root: string, ref: string): Promise<boolean> {
+  try {
+    await git(root, ["rev-parse", "--verify", "--quiet", `${ref}^{commit}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readOptionalGitValue(root: string, args: string[]): Promise<string | undefined> {
+  try {
+    const { stdout } = await git(root, args);
+    return stdout.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseChangedFiles(stdout: string): GitChangedFile[] {
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map(parseChangedFile);
+}
+
+function parseChangedFile(line: string): GitChangedFile {
+  const [status, firstPath, secondPath] = line.split(/\t+/);
+  if (!status || !firstPath) {
+    throw new Error(`Could not parse git diff entry: ${line}`);
+  }
+  if (status.startsWith("R") || status.startsWith("C")) {
+    return {
+      status,
+      previousPath: firstPath,
+      path: secondPath ?? firstPath,
+    };
+  }
+  return { status, path: firstPath };
+}
+
+function mergeChangedFiles(...groups: GitChangedFile[][]): GitChangedFile[] {
+  const filesByPath = new Map<string, GitChangedFile>();
+  for (const group of groups) {
+    for (const file of group) {
+      filesByPath.set(file.path, file);
+    }
+  }
+  return [...filesByPath.values()];
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+async function git(root: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  try {
+    return await execFileAsync("git", args, { cwd: root, maxBuffer: 10 * 1024 * 1024 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`git ${args.join(" ")} failed: ${message}`);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,7 @@ export { formatAgentQaDraft, formatMarkdownQaDraft, generateQaDraft } from "./qa
 export { buildQaReasoningTraces, qaTraceIdForScenario } from "./qa-trace.js";
 export { formatMarkdownReviewReport, formatReviewReport, reviewProject } from "./review.js";
 export { isRequiredScenarioEvidence, routeQaScenario } from "./scenario-routing.js";
+export { collectChangedFiles, resolveBaseRef, resolveMergeBase } from "./git-context.js";
 export { classifyChangeSourceRole } from "./source-role.js";
 export { scanProject } from "./scanner.js";
 export {
@@ -128,6 +129,12 @@ export type {
   InferredFlowAdapterOptions,
 } from "./behavior.js";
 export type { ManifestBehaviorAdapterOptions } from "./behavior-manifest.js";
+export type {
+  BaseRefResolution,
+  BaseRefSource,
+  ChangedFilesOptions,
+  GitChangedFile,
+} from "./git-context.js";
 export type { ChangeIntentBehaviorAdapterOptions } from "./behavior-intent.js";
 export type {
   BehaviorLifecycleStage,

--- a/src/qa.ts
+++ b/src/qa.ts
@@ -27,6 +27,7 @@ export interface QaDraftResult {
   root: string;
   generatedAt: string;
   base: string;
+  baseResolution: E2eDraftResult["plan"]["baseResolution"];
   head: string;
   includeWorkingTree: boolean;
   project: E2eProjectType;
@@ -161,6 +162,7 @@ export async function generateQaDraft(rootInput: string, options: QaDraftOptions
     root,
     generatedAt: new Date().toISOString(),
     base: draft.plan.base,
+    baseResolution: draft.plan.baseResolution,
     head: draft.plan.head,
     includeWorkingTree: draft.plan.includeWorkingTree,
     project: draft.plan.project.type,
@@ -297,6 +299,7 @@ export function formatAgentQaDraft(result: QaDraftResult): string {
   const summary = {
     schema: { name: "qamap.qa", version: 1 },
     base: result.base,
+    baseSource: result.baseResolution.source,
     head: result.head,
     project: result.project,
     runner: result.runner,
@@ -1110,6 +1113,7 @@ export function formatMarkdownQaDraft(result: QaDraftResult): string {
   lines.push("");
   lines.push(`- Root: \`${escapeMarkdownInline(result.root)}\``);
   lines.push(`- Base: \`${escapeMarkdownInline(result.base)}\``);
+  lines.push(`- Base selection: ${escapeMarkdownInline(result.baseResolution.reason)}`);
   lines.push(`- Head: \`${escapeMarkdownInline(result.head)}\``);
   lines.push(`- Change scope: ${result.includeWorkingTree ? "committed and uncommitted working-tree changes" : "committed branch changes only"}`);
   lines.push(`- Project: ${formatProjectType(result.project)}`);
@@ -1123,6 +1127,8 @@ export function formatMarkdownQaDraft(result: QaDraftResult): string {
   lines.push("- QA analysis and scenario routing do not require the optional automation runner to be installed.");
   lines.push(`- Draft flows: ${result.flows.length}`);
   lines.push("");
+
+  appendQaDecisionLayers(lines, result, nextCommand);
 
   appendQaReasoningTraceMarkdown(lines, result);
 
@@ -1222,11 +1228,85 @@ export function formatMarkdownQaDraft(result: QaDraftResult): string {
     if (result.runnerSetup.status === "proposed" && result.runnerSetup.setupCommand) {
       lines.push(`- If the team accepts this adapter, inspect its setup proposal: \`${escapeMarkdownInline(result.runnerSetup.setupCommand)}\``);
     }
-    lines.push("- Treat generated code as review-only until its scenario sources, assertions, fixtures, and selectors are confirmed.");
+    const primaryStatus = result.flows[0]?.runnableStatus;
+    lines.push(
+      primaryStatus === "runnable-candidate"
+        ? "- Static checks passed for this candidate, but QAMap did not run the target application. Run the repository command before claiming the scenario passed."
+        : "- Keep generated code review-only until its scenario sources, assertions, fixtures, and selectors are confirmed.",
+    );
     lines.push("");
   }
 
   return lines.join("\n");
+}
+
+function appendQaDecisionLayers(
+  lines: string[],
+  result: QaDraftResult,
+  nextCommand: string | undefined,
+): void {
+  const scenarios = result.changeAnalysis.intents.flatMap((intent) => intent.scenarios);
+  const automationByScenario = new Map(
+    result.flows.flatMap((flow) =>
+      flow.scenarioAutomation.map((receipt) => [receipt.scenarioId, { receipt, flow }] as const)
+    ),
+  );
+  const staticRunnableFlows = result.flows.filter((flow) => flow.runnableStatus === "runnable-candidate");
+  const contractScenarios = scenarios.filter((scenario) => {
+    const automation = automationByScenario.get(scenario.id)?.receipt;
+    return !automation || automation.status !== "compiled";
+  });
+
+  lines.push("## QA Decision Layers");
+  lines.push("");
+  lines.push("### 1. Important QA And Risk Map");
+  lines.push("");
+  lines.push(
+    scenarios.length > 0
+      ? `- ${scenarios.length} diff-backed scenario${scenarios.length === 1 ? "" : "s"} remain in the review scope regardless of current automation readiness.`
+      : "- No diff-backed scenario was inferred; heuristic suggestions remain review-only.",
+  );
+  lines.push("- Runner, selector, fixture, or environment gaps do not remove an important risk from this layer.");
+  lines.push("");
+
+  lines.push("### 2. Executable Evidence Available Now");
+  lines.push("");
+  if (nextCommand) {
+    lines.push(`- Repository command: \`${escapeMarkdownInline(nextCommand)}\` (selected but not run by QAMap).`);
+  }
+  for (const flow of staticRunnableFlows.slice(0, 4)) {
+    lines.push(
+      `- Static-runnable draft: \`${escapeMarkdownInline(flow.draftPath)}\` for ${escapeMarkdownInline(flow.title)}; self-checks passed, target application not executed.`,
+    );
+  }
+  if (!nextCommand && staticRunnableFlows.length === 0) {
+    lines.push("- None yet. QAMap is not claiming executable coverage for this change.");
+  }
+  lines.push("");
+
+  lines.push("### 3. Manual Or Agent QA Contracts");
+  lines.push("");
+  if (contractScenarios.length === 0) {
+    lines.push("- No unmapped scenario contract remains.");
+  } else {
+    for (const scenario of contractScenarios.slice(0, 6)) {
+      const automation = automationByScenario.get(scenario.id)?.receipt;
+      lines.push(`- [${scenario.priority}] ${escapeMarkdownInline(scenario.title)}`);
+      if (scenario.setup[0]) {
+        lines.push(`  - Setup: ${escapeMarkdownInline(scenario.setup[0])}`);
+      }
+      if (scenario.steps[0]) {
+        lines.push(`  - Action: ${escapeMarkdownInline(scenario.steps[0])}`);
+      }
+      if (scenario.assertions[0]) {
+        lines.push(`  - Proof: ${escapeMarkdownInline(scenario.assertions[0])}`);
+      }
+      if (automation?.blockers[0]) {
+        lines.push(`  - Automation gap: ${escapeMarkdownInline(automation.blockers[0])}`);
+      }
+    }
+  }
+  lines.push("");
 }
 
 function summarizeTraceRouting(traces: QaReasoningTrace[]): {
@@ -1715,10 +1795,10 @@ function formatDraftSource(source: E2eDraftFile["source"]): string {
 
 function formatRunnableStatus(status: E2eDraftFile["runnableStatus"]): string {
   if (status === "runnable-candidate") {
-    return "runnable candidate";
+    return "static-runnable candidate; not executed";
   }
   if (status === "near-runnable") {
-    return "near runnable";
+    return "partially mapped; not executed";
   }
   return "review only";
 }

--- a/src/review.ts
+++ b/src/review.ts
@@ -3,6 +3,8 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
+import { collectChangedFiles, resolveBaseRef } from "./git-context.js";
+import type { BaseRefResolution } from "./git-context.js";
 import { scanProject } from "./scanner.js";
 import type { Finding, ScanOptions, ScanResult, Severity } from "./types.js";
 
@@ -32,6 +34,7 @@ export interface ReviewResult {
   root: string;
   scannedAt: string;
   base: string;
+  baseResolution: BaseRefResolution;
   head: string;
   changedFiles: ChangedFile[];
   newFindings: Finding[];
@@ -51,10 +54,14 @@ export async function reviewProject(rootInput: string, options: ReviewOptions = 
     throw new Error(`Review path must be inside workspace root: ${root}`);
   }
 
-  const base = options.base ?? (await defaultBaseRef(root));
   const head = options.head ?? "HEAD";
   const diffRoot = workspaceRoot ?? root;
-  const changedFiles = scopeChangedFiles(await getChangedFiles(diffRoot, base, head), relativeScanRoot);
+  const baseResolution = await resolveBaseRef(diffRoot, { explicit: options.base, head });
+  const base = baseResolution.ref;
+  const changedFiles = scopeChangedFiles(
+    await collectChangedFiles(diffRoot, { base, head }),
+    relativeScanRoot,
+  );
   const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qamap-review-"));
 
   try {
@@ -98,6 +105,7 @@ export async function reviewProject(rootInput: string, options: ReviewOptions = 
       root,
       scannedAt: headResult.scannedAt,
       base,
+      baseResolution,
       head,
       changedFiles,
       newFindings,
@@ -115,6 +123,7 @@ export function formatReviewReport(result: ReviewResult): string {
   lines.push(`${result.tool.name} Review`);
   lines.push(`Root: ${result.root}`);
   lines.push(`Base: ${result.base}`);
+  lines.push(`Base selection: ${result.baseResolution.reason}`);
   lines.push(`Head: ${result.head}`);
   lines.push(`Changed files: ${result.changedFiles.length}`);
   lines.push(
@@ -192,6 +201,7 @@ export function formatMarkdownReviewReport(result: ReviewResult): string {
   lines.push("");
   lines.push(`- Root: \`${escapeMarkdownInline(result.root)}\``);
   lines.push(`- Base: \`${escapeMarkdownInline(result.base)}\``);
+  lines.push(`- Base selection: ${escapeMarkdownInline(result.baseResolution.reason)}`);
   lines.push(`- Head: \`${escapeMarkdownInline(result.head)}\``);
   lines.push(`- Changed files: ${result.changedFiles.length}`);
   lines.push(`- Changed risky files: ${result.changedRiskyFindings.length}`);
@@ -268,45 +278,6 @@ export function formatMarkdownReviewReport(result: ReviewResult): string {
   }
 
   return lines.join("\n");
-}
-
-async function defaultBaseRef(root: string): Promise<string> {
-  for (const candidate of ["origin/main", "main", "origin/master", "master"]) {
-    try {
-      await git(root, ["rev-parse", "--verify", "--quiet", candidate]);
-      return candidate;
-    } catch {
-      // Try the next common default branch name.
-    }
-  }
-  throw new Error("Could not infer a base ref. Pass --base <ref>.");
-}
-
-async function getChangedFiles(root: string, base: string, head: string): Promise<ChangedFile[]> {
-  const { stdout } = await git(root, ["diff", "--name-status", "--diff-filter=ACMRTUXB", `${base}...${head}`]);
-  return stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map(parseChangedFile);
-}
-
-function parseChangedFile(line: string): ChangedFile {
-  const [status, firstPath, secondPath] = line.split(/\t+/);
-  if (!status || !firstPath) {
-    throw new Error(`Could not parse git diff entry: ${line}`);
-  }
-  if (status.startsWith("R") || status.startsWith("C")) {
-    return {
-      status,
-      previousPath: firstPath,
-      path: secondPath ?? firstPath,
-    };
-  }
-  return {
-    status,
-    path: firstPath,
-  };
 }
 
 function scopeChangedFiles(changedFiles: ChangedFile[], relativeScanRoot: string): ChangedFile[] {

--- a/src/test-plan.ts
+++ b/src/test-plan.ts
@@ -2,6 +2,10 @@ import { execFile } from "node:child_process";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
+import YAML from "yaml";
+import { collectProjectFiles } from "./fs.js";
+import { collectChangedFiles, resolveBaseRef, resolveMergeBase } from "./git-context.js";
+import type { BaseRefResolution } from "./git-context.js";
 import { TOOL_NAME, VERSION } from "./version.js";
 
 const execFileAsync = promisify(execFile);
@@ -36,6 +40,7 @@ export interface TestPlanResult {
   workspaceRoot?: string;
   generatedAt: string;
   base: string;
+  baseResolution: BaseRefResolution;
   head: string;
   includeWorkingTree: boolean;
   changedFiles: TestPlanChangedFile[];
@@ -54,10 +59,14 @@ export async function generateTestPlan(rootInput: string, options: TestPlanOptio
     throw new Error(`Test plan path must be inside workspace root: ${root}`);
   }
 
-  const base = options.base ?? (await defaultBaseRef(gitRoot));
   const head = options.head ?? "HEAD";
+  const baseResolution = await resolveBaseRef(gitRoot, { explicit: options.base, head });
+  const base = baseResolution.ref;
   const includeWorkingTree = options.includeWorkingTree ?? false;
-  const changedFiles = scopeChangedFiles(await getChangedFiles(gitRoot, base, head, includeWorkingTree), relativeRoot);
+  const changedFiles = scopeChangedFiles(
+    await collectChangedFiles(gitRoot, { base, head, includeWorkingTree }),
+    relativeRoot,
+  );
   const suggestedCommands = uniqueCommands([
     ...normalizeValidationCommands(options.validationCommands),
     ...commandsForChangedTestEvidence(changedFiles),
@@ -74,6 +83,7 @@ export async function generateTestPlan(rootInput: string, options: TestPlanOptio
     workspaceRoot,
     generatedAt: new Date().toISOString(),
     base,
+    baseResolution,
     head,
     includeWorkingTree,
     changedFiles,
@@ -91,6 +101,7 @@ export function formatMarkdownTestPlan(result: TestPlanResult): string {
     lines.push(`- Workspace root: \`${escapeMarkdownInline(result.workspaceRoot)}\``);
   }
   lines.push(`- Base: \`${escapeMarkdownInline(result.base)}\``);
+  lines.push(`- Base selection: ${escapeMarkdownInline(result.baseResolution.reason)}`);
   lines.push(`- Head: \`${escapeMarkdownInline(result.head)}\``);
   if (result.includeWorkingTree) {
     lines.push("- Includes working tree changes: yes");
@@ -326,7 +337,7 @@ async function discoverSuggestedCommands(
 ): Promise<string[]> {
   const commandGroups = await Promise.all([
     discoverJavaScriptCommands(root, workspaceRoot, changedFiles),
-    discoverPythonCommands(root),
+    discoverPythonCommands(root, changedFiles),
     discoverGoCommands(root),
     discoverRustCommands(root),
     discoverJvmCommands(root),
@@ -340,19 +351,112 @@ async function discoverJavaScriptCommands(
   changedFiles: TestPlanChangedFile[],
 ): Promise<string[]> {
   const packageJsonPath = path.join(root, "package.json");
-  let parsed: { packageManager?: string; scripts?: Record<string, string> };
+  let parsed: { packageManager?: string; scripts?: Record<string, string>; workspaces?: unknown };
   try {
     parsed = JSON.parse(await fs.readFile(packageJsonPath, "utf8")) as {
       packageManager?: string;
       scripts?: Record<string, string>;
+      workspaces?: unknown;
     };
   } catch {
     return [];
   }
 
   const packageManager = await detectPackageManager(root, parsed.packageManager, workspaceRoot);
+  const affectedPackages = await isJavaScriptWorkspaceRoot(root, parsed.workspaces)
+    ? await discoverAffectedJavaScriptPackages(root, changedFiles)
+    : [];
+  if (affectedPackages.length > 0) {
+    return affectedPackages.flatMap((affectedPackage) => {
+      const platformBuildScripts = discoverPlatformBuildScripts(
+        affectedPackage.scripts,
+        affectedPackage.changedFiles,
+      );
+      return preferredJavaScriptScripts(affectedPackage.scripts, platformBuildScripts)
+        .map((script) => workspaceScriptCommand(
+          packageManager,
+          affectedPackage.name ?? `./${affectedPackage.path}`,
+          script,
+        ));
+    });
+  }
+
   const platformBuildScripts = discoverPlatformBuildScripts(parsed.scripts ?? {}, changedFiles.map((file) => file.path));
-  const preferredScripts = uniqueCommands([
+  return preferredJavaScriptScripts(parsed.scripts ?? {}, platformBuildScripts)
+    .map((script) => (script === "test" ? `${packageManager} test` : `${packageManager} run ${script}`));
+}
+
+async function isJavaScriptWorkspaceRoot(root: string, workspaces: unknown): Promise<boolean> {
+  const hasPackageWorkspaces = Array.isArray(workspaces) || (
+    isRecord(workspaces) && Array.isArray(workspaces.packages)
+  );
+  return hasPackageWorkspaces || await hasAnyFile(root, [
+    "pnpm-workspace.yaml",
+    "pnpm-workspace.yml",
+    "lerna.json",
+    "rush.json",
+  ]);
+}
+
+interface AffectedJavaScriptPackage {
+  path: string;
+  name?: string;
+  scripts: Record<string, string>;
+  changedFiles: string[];
+}
+
+async function discoverAffectedJavaScriptPackages(
+  root: string,
+  changedFiles: TestPlanChangedFile[],
+): Promise<AffectedJavaScriptPackage[]> {
+  const packages = new Map<string, AffectedJavaScriptPackage>();
+  for (const changedFile of changedFiles) {
+    let directory = path.posix.dirname(toPosixPath(changedFile.path));
+    while (directory !== "." && directory !== "/") {
+      const packageJsonPath = path.join(root, directory, "package.json");
+      const packageJson = await readJavaScriptPackage(packageJsonPath);
+      if (packageJson) {
+        const existing = packages.get(directory);
+        if (existing) {
+          existing.changedFiles.push(changedFile.path);
+        } else {
+          packages.set(directory, {
+            path: directory,
+            name: packageJson.name,
+            scripts: packageJson.scripts ?? {},
+            changedFiles: [changedFile.path],
+          });
+        }
+        break;
+      }
+      const parent = path.posix.dirname(directory);
+      if (parent === directory) {
+        break;
+      }
+      directory = parent;
+    }
+  }
+  return [...packages.values()].sort((left, right) => left.path.localeCompare(right.path));
+}
+
+async function readJavaScriptPackage(
+  packageJsonPath: string,
+): Promise<{ name?: string; scripts?: Record<string, string> } | undefined> {
+  try {
+    return JSON.parse(await fs.readFile(packageJsonPath, "utf8")) as {
+      name?: string;
+      scripts?: Record<string, string>;
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function preferredJavaScriptScripts(
+  scripts: Record<string, string>,
+  platformBuildScripts: string[],
+): string[] {
+  return uniqueCommands([
     ...platformBuildScripts,
     "test",
     "typecheck",
@@ -360,10 +464,34 @@ async function discoverJavaScriptCommands(
     "build",
     "test:e2e",
     "e2e",
-  ]);
-  return preferredScripts
-    .filter((script) => isUsableScript(parsed.scripts?.[script]))
-    .map((script) => (script === "test" ? `${packageManager} test` : `${packageManager} run ${script}`));
+  ]).filter((script) => isUsableScript(scripts[script]));
+}
+
+function workspaceScriptCommand(packageManager: string, target: string, script: string): string {
+  const scopedTarget = shellArgument(target);
+  if (packageManager === "pnpm") {
+    return script === "test"
+      ? `pnpm --filter ${scopedTarget} test`
+      : `pnpm --filter ${scopedTarget} run ${script}`;
+  }
+  if (packageManager === "yarn") {
+    return `yarn workspace ${scopedTarget} ${script}`;
+  }
+  if (packageManager === "bun") {
+    return script === "test"
+      ? `bun --filter ${scopedTarget} test`
+      : `bun --filter ${scopedTarget} run ${script}`;
+  }
+  return script === "test"
+    ? `npm test --workspace ${scopedTarget}`
+    : `npm run ${script} --workspace ${scopedTarget}`;
+}
+
+function shellArgument(value: string): string {
+  if (/^[A-Za-z0-9_./:@=-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 function discoverPlatformBuildScripts(scripts: Record<string, string>, changedFiles: string[]): string[] {
@@ -403,7 +531,7 @@ function platformScriptRank(name: string): number {
   return 2;
 }
 
-async function discoverPythonCommands(root: string): Promise<string[]> {
+async function discoverPythonCommands(root: string, changedFiles: TestPlanChangedFile[]): Promise<string[]> {
   const pyproject = await readTextIfExists(path.join(root, "pyproject.toml"));
   const hasPythonMarker =
     Boolean(pyproject) ||
@@ -422,6 +550,8 @@ async function discoverPythonCommands(root: string): Promise<string[]> {
   }
 
   const runner = await detectPythonRunner(root, pyproject);
+  const dockerTarget = await detectPythonComposeTarget(root);
+  const pytestTargets = await discoverRelevantPythonTests(root, changedFiles);
   const commands: string[] = [];
   const hasToxSignal = await exists(path.join(root, "tox.ini"));
   const hasPytestSignal =
@@ -432,19 +562,238 @@ async function discoverPythonCommands(root: string): Promise<string[]> {
   const hasMypySignal = /\[tool\.mypy/i.test(pyproject ?? "") || (await hasAnyFile(root, ["mypy.ini", ".mypy.ini"]));
 
   if (hasToxSignal) {
-    commands.push(withRunner(runner, "tox"));
+    commands.push(withPythonEnvironment(runner, dockerTarget, "tox"));
   }
   if (hasPytestSignal) {
-    commands.push(withRunner(runner, "pytest"));
+    const targetSuffix = pytestTargets.length > 0
+      ? ` ${pytestTargets.map(shellArgument).join(" ")}`
+      : "";
+    commands.push(withPythonEnvironment(runner, dockerTarget, `pytest${targetSuffix}`));
   }
   if (hasRuffSignal) {
-    commands.push(withRunner(runner, "ruff check ."));
+    commands.push(withPythonEnvironment(runner, dockerTarget, "ruff check ."));
   }
   if (hasMypySignal) {
-    commands.push(withRunner(runner, "mypy ."));
+    commands.push(withPythonEnvironment(runner, dockerTarget, "mypy ."));
   }
 
   return commands;
+}
+
+function withPythonEnvironment(
+  runner: string | undefined,
+  dockerTarget: PythonComposeTarget | undefined,
+  command: string,
+): string {
+  if (dockerTarget) {
+    const usesDefaultComposeFile = [
+      "compose.yml",
+      "compose.yaml",
+      "docker-compose.yml",
+      "docker-compose.yaml",
+    ].includes(dockerTarget.composeFile);
+    const composeOption = usesDefaultComposeFile ? "" : ` -f ${shellArgument(dockerTarget.composeFile)}`;
+    const containerCommand = dockerTarget.runner ? `${dockerTarget.runner} ${command}` : command;
+    return `docker compose${composeOption} run --rm ${shellArgument(dockerTarget.service)} ${containerCommand}`;
+  }
+  return withRunner(runner, command);
+}
+
+interface PythonComposeTarget {
+  composeFile: string;
+  service: string;
+  runner?: string;
+}
+
+async function detectPythonComposeTarget(root: string): Promise<PythonComposeTarget | undefined> {
+  const composeFiles = await discoverComposeFiles(root);
+  const candidates: Array<PythonComposeTarget & { score: number }> = [];
+  for (const composeFile of composeFiles) {
+    let parsed: unknown;
+    try {
+      parsed = YAML.parse(await fs.readFile(path.join(root, composeFile), "utf8"));
+    } catch {
+      continue;
+    }
+    if (!isRecord(parsed) || !isRecord(parsed.services)) {
+      continue;
+    }
+
+    for (const [serviceName, service] of Object.entries(parsed.services)) {
+      if (!isRecord(service)) {
+        continue;
+      }
+      const serialized = JSON.stringify(service);
+      const build = service.build;
+      const buildsRoot = build === "." || (
+        isRecord(build) && (build.context === undefined || build.context === ".")
+      );
+      const dockerfile = isRecord(build) && typeof build.dockerfile === "string"
+        ? build.dockerfile
+        : "Dockerfile";
+      const dockerfileText = buildsRoot
+        ? await readTextIfExists(path.join(root, dockerfile))
+        : undefined;
+      const dockerfileUsesPython = /^\s*FROM\s+[^\n]*python/im.test(dockerfileText ?? "");
+      const explicitPython = /python|pytest|django|flask|fastapi|gunicorn|uvicorn|celery/i.test(serialized);
+      if (!explicitPython && !dockerfileUsesPython) {
+        continue;
+      }
+      const runner = detectContainerPythonRunner(dockerfileText);
+      const primaryService = /^(?:app|api|web|backend|server)$/i.test(serviceName);
+      const backgroundService = /(?:^|[-_])(?:worker|beat|scheduler|consumer|queue)(?:$|[-_])/i.test(serviceName);
+      candidates.push({
+        composeFile,
+        service: serviceName,
+        runner,
+        score:
+          (explicitPython ? 2 : 0) +
+          (dockerfileUsesPython ? 4 : 0) +
+          (primaryService ? 5 : 0) +
+          (backgroundService ? -4 : 0) +
+          (Array.isArray(service.ports) && service.ports.length > 0 ? 2 : 0) +
+          (Array.isArray(service.volumes) && service.volumes.some((volume) => String(volume).startsWith(".:")) ? 1 : 0) +
+          composeFilePreference(composeFile),
+      });
+    }
+  }
+  const selected = candidates.sort((left, right) =>
+    right.score - left.score || left.composeFile.localeCompare(right.composeFile) || left.service.localeCompare(right.service)
+  )[0];
+  if (!selected) {
+    return undefined;
+  }
+  return {
+    composeFile: selected.composeFile,
+    service: selected.service,
+    runner: selected.runner,
+  };
+}
+
+function detectContainerPythonRunner(dockerfileText: string | undefined): string | undefined {
+  const normalized = (dockerfileText ?? "").replace(/[\"',\[\]]+/g, " ");
+  if (/\buv\s+run\b/i.test(normalized)) {
+    return "uv run";
+  }
+  if (/\bpoetry\s+run\b/i.test(normalized)) {
+    return "poetry run";
+  }
+  return undefined;
+}
+
+async function discoverComposeFiles(root: string): Promise<string[]> {
+  try {
+    return (await fs.readdir(root))
+      .filter((file) => /^(?:docker-)?compose(?:[._-][A-Za-z0-9_-]+)*\.ya?ml$/i.test(file))
+      .sort((left, right) => composeFilePreference(right) - composeFilePreference(left) || left.localeCompare(right));
+  } catch {
+    return [];
+  }
+}
+
+function composeFilePreference(file: string): number {
+  if (/^(?:docker-)?compose\.ya?ml$/i.test(file)) return 5;
+  if (/(?:^|[._-])local(?:[._-]|\.)/i.test(file)) return 4;
+  if (/(?:^|[._-])dev(?:[._-]|\.)/i.test(file)) return 3;
+  if (/(?:^|[._-])test(?:[._-]|\.)/i.test(file)) return 2;
+  if (/(?:^|[._-])prod(?:[._-]|\.)/i.test(file)) return -3;
+  return 0;
+}
+
+async function discoverRelevantPythonTests(
+  root: string,
+  changedFiles: TestPlanChangedFile[],
+): Promise<string[]> {
+  const directlyChangedTests = changedFiles
+    .map((file) => file.path)
+    .filter(isPythonTestFile);
+  if (directlyChangedTests.length > 0) {
+    return uniqueCommands(directlyChangedTests).slice(0, 6);
+  }
+
+  const changedSources = changedFiles
+    .map((file) => file.path)
+    .filter((file) => file.endsWith(".py") && !isPythonTestFile(file));
+  if (changedSources.length === 0) {
+    return [];
+  }
+
+  let projectFiles: Awaited<ReturnType<typeof collectProjectFiles>>;
+  try {
+    projectFiles = await collectProjectFiles(root, 4_000);
+  } catch {
+    return [];
+  }
+  const testFiles = projectFiles.map((file) => file.path).filter(isPythonTestFile);
+  const ranked = testFiles
+    .map((testFile) => ({
+      file: testFile,
+      score: Math.max(...changedSources.map((sourceFile) => pythonTestRelevance(sourceFile, testFile))),
+    }))
+    .filter((candidate) => candidate.score >= 4)
+    .sort((left, right) => right.score - left.score || left.file.localeCompare(right.file));
+  return ranked.slice(0, 6).map((candidate) => candidate.file);
+}
+
+const ignoredPythonPathTokens = new Set([
+  "app",
+  "apps",
+  "src",
+  "lib",
+  "project",
+  "service",
+  "services",
+  "test",
+  "tests",
+  "unit",
+  "integration",
+  "python",
+]);
+const genericPythonFileStems = new Set([
+  "api",
+  "client",
+  "handler",
+  "index",
+  "model",
+  "models",
+  "service",
+  "utils",
+  "view",
+  "views",
+]);
+
+function pythonTestRelevance(sourceFile: string, testFile: string): number {
+  const sourceBase = pythonFileStem(sourceFile);
+  const testBase = pythonFileStem(testFile).replace(/^test_/, "").replace(/_test$/, "");
+  const sourceTokens = meaningfulPythonPathTokens(sourceFile);
+  const testTokens = new Set(meaningfulPythonPathTokens(testFile));
+  const sharedTokens = sourceTokens.filter((token) => testTokens.has(token));
+  const basenameScore = sourceBase === testBase
+    ? (genericPythonFileStems.has(sourceBase) ? 2 : 6)
+    : 0;
+  return basenameScore + Math.min(6, sharedTokens.length * 2);
+}
+
+function meaningfulPythonPathTokens(filePath: string): string[] {
+  return uniqueCommands(
+    toPosixPath(filePath)
+      .replace(/\.py$/i, "")
+      .split(/[\/_-]+/)
+      .map((token) => token.toLowerCase())
+      .filter((token) => token.length >= 3 && !ignoredPythonPathTokens.has(token)),
+  );
+}
+
+function pythonFileStem(filePath: string): string {
+  return path.posix.basename(toPosixPath(filePath)).replace(/\.py$/i, "").toLowerCase();
+}
+
+function isPythonTestFile(filePath: string): boolean {
+  return /(?:^|\/)test_[^/]+\.py$|(?:^|\/)[^/]+_test\.py$/i.test(filePath);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 async function detectPythonRunner(root: string, pyproject: string | undefined): Promise<string | undefined> {
@@ -666,18 +1015,6 @@ function stripScopedPath(filePath: string, relativeRoot: string, prefix: string)
   return undefined;
 }
 
-async function defaultBaseRef(root: string): Promise<string> {
-  for (const candidate of ["origin/main", "main", "origin/master", "master"]) {
-    try {
-      await git(root, ["rev-parse", "--verify", "--quiet", candidate]);
-      return candidate;
-    } catch {
-      // Try the next common default branch name.
-    }
-  }
-  throw new Error("Could not infer a base ref. Pass --base <ref>.");
-}
-
 export interface AddedDiffTextOptions {
   base: string;
   head: string;
@@ -724,23 +1061,18 @@ export async function collectAddedDiffEvidence(
   const relativeRoot = workspaceRoot ? toPosixPath(path.relative(workspaceRoot, root)) : "";
   const byFile: AddedDiffEvidence = {};
   try {
+    const diffTarget = options.includeWorkingTree
+      ? await resolveMergeBase(gitRoot, options.base, options.head)
+      : `${options.base}...${options.head}`;
     const { stdout } = await git(gitRoot, [
       "diff",
       "--no-color",
       "--find-renames",
       "--unified=0",
-      `${options.base}...${options.head}`,
+      diffTarget,
     ]);
     mergeAddedDiffEvidence(byFile, stdout, relativeRoot);
     if (options.includeWorkingTree) {
-      const { stdout: workingTree } = await git(gitRoot, [
-        "diff",
-        "--no-color",
-        "--find-renames",
-        "--unified=0",
-        "HEAD",
-      ]);
-      mergeAddedDiffEvidence(byFile, workingTree, relativeRoot);
       await mergeUntrackedDiffEvidence(byFile, gitRoot, relativeRoot);
     }
   } catch {
@@ -936,70 +1268,6 @@ function mergeAddedDiffEvidence(byFile: AddedDiffEvidence, diffText: string, rel
     }
   }
   flushHunk();
-}
-
-async function getChangedFiles(
-  root: string,
-  base: string,
-  head: string,
-  includeWorkingTree: boolean,
-): Promise<TestPlanChangedFile[]> {
-  const { stdout } = await git(root, ["diff", "--name-status", "--diff-filter=ACDMRTUXB", `${base}...${head}`]);
-  const committedChanges = parseChangedFiles(stdout);
-  if (!includeWorkingTree) {
-    return committedChanges;
-  }
-
-  return mergeChangedFiles(committedChanges, await getWorkingTreeChangedFiles(root));
-}
-
-async function getWorkingTreeChangedFiles(root: string): Promise<TestPlanChangedFile[]> {
-  const { stdout: trackedStdout } = await git(root, ["diff", "--name-status", "--diff-filter=ACDMRTUXB", "HEAD"]);
-  const { stdout: untrackedStdout } = await git(root, ["ls-files", "--others", "--exclude-standard"]);
-  return [
-    ...parseChangedFiles(trackedStdout),
-    ...untrackedStdout
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .map((filePath) => ({ status: "A", path: filePath })),
-  ];
-}
-
-function parseChangedFiles(stdout: string): TestPlanChangedFile[] {
-  return stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map(parseChangedFile);
-}
-
-function mergeChangedFiles(...groups: TestPlanChangedFile[][]): TestPlanChangedFile[] {
-  const filesByPath = new Map<string, TestPlanChangedFile>();
-  for (const group of groups) {
-    for (const file of group) {
-      filesByPath.set(file.path, file);
-    }
-  }
-  return [...filesByPath.values()];
-}
-
-function parseChangedFile(line: string): TestPlanChangedFile {
-  const [status, firstPath, secondPath] = line.split(/\t+/);
-  if (!status || !firstPath) {
-    throw new Error(`Could not parse git diff entry: ${line}`);
-  }
-  if (status.startsWith("R") || status.startsWith("C")) {
-    return {
-      status,
-      previousPath: firstPath,
-      path: secondPath ?? firstPath,
-    };
-  }
-  return {
-    status,
-    path: firstPath,
-  };
 }
 
 async function git(root: string, args: string[]): Promise<{ stdout: string; stderr: string }> {

--- a/test/change-intent.test.mjs
+++ b/test/change-intent.test.mjs
@@ -869,6 +869,25 @@ test("persisted record date validation does not fabricate scheduling QA", async 
   assert.equal(lifecycleLabels.some((label) => /na n/i.test(label)), false);
 });
 
+test("recording the current server timestamp does not fabricate scheduling QA", async (t) => {
+  const root = await makeRepo(t);
+  await write(root, "src/audit.py", "def record_consent():\n    return None\n");
+  commit(root, "benchmark baseline");
+  branch(root, "feat/consent-audit");
+  await write(
+    root,
+    "src/audit.py",
+    "def record_consent():\n    consent_agreed_at = timezone.now()\n    return consent_agreed_at\n",
+  );
+  commit(root, "feat: record consent audit timestamp");
+
+  const analysis = await analyze(root, ["src/audit.py"]);
+  const scenarioTitles = analysis.intents.flatMap((intent) => intent.scenarios.map((scenario) => scenario.title));
+
+  assert.equal(analysis.intents.length, 1);
+  assert.equal(scenarioTitles.some((title) => /Scheduling, calendar/i.test(title)), false);
+});
+
 test("change intent marks connected working-tree signals as review-required diff evidence", async (t) => {
   const root = await makeRepo(t);
   await write(root, "src/form.tsx", "export function Form() { return null; }\n");

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdtemp, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 import {
   analyzeVerificationManifestContext,
   buildDoctorResult,
+  collectAddedDiffEvidence,
   explainVerificationManifest,
   evaluateChangeReadiness,
   formatVerificationManifestContextResult,
@@ -383,6 +384,335 @@ test("generateTestPlan suggests domain-focused checks from changed files", async
   assert.deepEqual(plan.suggestedCommands, ["pnpm test", "pnpm run typecheck"]);
   assert.match(markdown, /# QAMap Test Plan/);
   assert.match(markdown, /Verify loading, empty, error, and success states/);
+});
+
+test("generateTestPlan selects the nearest long-lived branch as the PR base", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src/catalog"), { recursive: true });
+  await writeFile(path.join(root, "package.json"), JSON.stringify({ scripts: { test: "node --test" } }));
+  await writeFile(path.join(root, "src/catalog/list.ts"), "export const listCatalog = () => [];\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "develop"]);
+  await writeFile(path.join(root, "src/catalog/list.ts"), "export const listCatalog = () => ['active'];\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "develop catalog baseline"]);
+
+  await git(root, ["switch", "-c", "feature/catalog-filter"]);
+  await writeFile(path.join(root, "src/catalog/list.ts"), "export const listCatalog = () => ['active', 'archived'];\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "feat: add archived catalog filter"]);
+
+  const plan = await generateTestPlan(root);
+  const markdown = formatMarkdownTestPlan(plan);
+
+  assert.equal(plan.base, "develop");
+  assert.equal(plan.baseResolution.source, "git-history");
+  assert.match(plan.baseResolution.reason, /nearest long-lived branch/i);
+  assert.deepEqual(plan.changedFiles.map((file) => file.path), ["src/catalog/list.ts"]);
+  assert.match(markdown, /Base selection: Selected the nearest long-lived branch/);
+});
+
+test("generateTestPlan reports equivalent long-lived base refs without pretending to know PR metadata", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await writeFile(path.join(root, "package.json"), JSON.stringify({ scripts: { test: "node --test" } }));
+  await writeFile(path.join(root, "feature.ts"), "export const enabled = false;\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+  await git(root, ["branch", "develop"]);
+
+  await git(root, ["switch", "-c", "feature/equivalent-base"]);
+  await writeFile(path.join(root, "feature.ts"), "export const enabled = true;\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "feat: enable feature"]);
+
+  const plan = await generateTestPlan(root);
+
+  assert.equal(plan.base, "develop");
+  assert.deepEqual(plan.baseResolution.equivalentRefs, ["main"]);
+  assert.match(plan.baseResolution.reason, /main points to the same commit, so the diff is identical/);
+});
+
+test("generateTestPlan resolves CI branch refs through non-origin remote tracking refs", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await writeFile(path.join(root, "package.json"), JSON.stringify({ scripts: { test: "node --test" } }));
+  await writeFile(path.join(root, "feature.ts"), "export const value = 'main';\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "develop"]);
+  await writeFile(path.join(root, "feature.ts"), "export const value = 'develop';\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "develop baseline"]);
+  await git(root, ["update-ref", "refs/remotes/upstream/develop", "develop"]);
+  await git(root, ["remote", "add", "upstream", root]);
+
+  await git(root, ["switch", "-c", "feature/ci-base"]);
+  await writeFile(path.join(root, "feature.ts"), "export const value = 'feature';\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "feat: update feature value"]);
+  await git(root, ["branch", "-D", "develop"]);
+
+  const previous = process.env.QAMAP_BASE_REF;
+  process.env.QAMAP_BASE_REF = "refs/heads/develop";
+  try {
+    const plan = await generateTestPlan(root);
+    assert.equal(plan.base, "upstream/develop");
+    assert.equal(plan.baseResolution.source, "environment");
+    assert.match(plan.baseResolution.reason, /QAMAP_BASE_REF/);
+    assert.deepEqual(plan.changedFiles.map((file) => file.path), ["feature.ts"]);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.QAMAP_BASE_REF;
+    } else {
+      process.env.QAMAP_BASE_REF = previous;
+    }
+  }
+});
+
+test("working-tree analysis uses the final net diff instead of stale committed changes", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src/profile"), { recursive: true });
+  await writeFile(path.join(root, "package.json"), JSON.stringify({ scripts: { test: "node --test" } }));
+  await writeFile(path.join(root, "src/profile/save.ts"), "export const saveProfile = () => 'idle';\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/profile-save"]);
+  await writeFile(path.join(root, "src/profile/save.ts"), "export const saveProfile = () => 'saving';\n");
+  await writeFile(
+    path.join(root, "src/profile/temporary-banner.ts"),
+    "export const temporaryBanner = 'Profile saved';\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "feat: save profile with temporary banner"]);
+
+  await rm(path.join(root, "src/profile/temporary-banner.ts"));
+  await writeFile(path.join(root, "src/profile/save.ts"), "export const saveProfile = () => 'saved';\n");
+
+  const plan = await generateTestPlan(root, { base: "main", includeWorkingTree: true });
+  const evidence = await collectAddedDiffEvidence(root, {
+    base: "main",
+    head: "HEAD",
+    includeWorkingTree: true,
+  });
+  const e2e = await generateE2ePlan(root, { base: "main", includeWorkingTree: true });
+
+  assert.deepEqual(plan.changedFiles.map((file) => file.path), ["src/profile/save.ts"]);
+  assert.equal(evidence["src/profile/temporary-banner.ts"], undefined);
+  assert.equal(
+    e2e.changeAnalysis.intents.some((intent) => intent.files.includes("src/profile/temporary-banner.ts")),
+    false,
+  );
+});
+
+test("generateTestPlan scopes monorepo validation commands to affected packages", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "services/catalog/src"), { recursive: true });
+  await mkdir(path.join(root, "services/identity/src"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      private: true,
+      packageManager: "pnpm@10.32.1",
+      scripts: { typecheck: "tsc --noEmit" },
+    }),
+  );
+  await writeFile(path.join(root, "pnpm-workspace.yaml"), "packages:\n  - services/*\n");
+  await writeFile(
+    path.join(root, "services/catalog/package.json"),
+    JSON.stringify({
+      name: "@example/catalog",
+      scripts: { test: "node --test", typecheck: "tsc --noEmit" },
+    }),
+  );
+  await writeFile(
+    path.join(root, "services/identity/package.json"),
+    JSON.stringify({
+      name: "@example/identity",
+      scripts: { test: "node --test", lint: "eslint ." },
+    }),
+  );
+  await writeFile(path.join(root, "services/catalog/src/list.ts"), "export const list = () => [];\n");
+  await writeFile(path.join(root, "services/identity/src/session.ts"), "export const session = true;\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/catalog-sort"]);
+  await writeFile(path.join(root, "services/catalog/src/list.ts"), "export const list = () => ['newest'];\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "feat: sort catalog entries"]);
+
+  const plan = await generateTestPlan(root, { base: "main" });
+
+  assert.deepEqual(plan.suggestedCommands, [
+    "pnpm --filter @example/catalog test",
+    "pnpm --filter @example/catalog run typecheck",
+  ]);
+  assert.equal(plan.suggestedCommands.some((command) => command === "pnpm run typecheck"), false);
+  assert.equal(plan.suggestedCommands.some((command) => /identity/.test(command)), false);
+});
+
+test("generateTestPlan does not invent workspace filters for unrelated nested packages", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "examples/widget/src"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      packageManager: "pnpm@10.32.1",
+      scripts: { test: "node --test", typecheck: "tsc --noEmit" },
+    }),
+  );
+  await writeFile(
+    path.join(root, "examples/widget/package.json"),
+    JSON.stringify({ name: "example-widget", scripts: { test: "node --test" } }),
+  );
+  await writeFile(path.join(root, "examples/widget/src/index.ts"), "export const widget = 'base';\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/widget-example"]);
+  await writeFile(path.join(root, "examples/widget/src/index.ts"), "export const widget = 'changed';\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "docs: update widget example"]);
+
+  const plan = await generateTestPlan(root, { base: "main" });
+
+  assert.deepEqual(plan.suggestedCommands, ["pnpm test", "pnpm run typecheck"]);
+  assert.equal(plan.suggestedCommands.some((command) => command.includes("--filter")), false);
+});
+
+test("generateTestPlan uses a Python compose service and narrows pytest to related tests", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "app/orders"), { recursive: true });
+  await mkdir(path.join(root, "tests/orders"), { recursive: true });
+  await mkdir(path.join(root, "tests/identity"), { recursive: true });
+  await writeFile(
+    path.join(root, "pyproject.toml"),
+    [
+      "[project]",
+      'name = "example-api"',
+      "",
+      "[tool.pytest.ini_options]",
+      'testpaths = ["tests"]',
+    ].join("\n"),
+  );
+  await writeFile(path.join(root, "Dockerfile"), "FROM python:3.12-slim\nWORKDIR /workspace\n");
+  await writeFile(
+    path.join(root, "compose.yml"),
+    [
+      "services:",
+      "  db:",
+      "    image: postgres:17",
+      "  api:",
+      "    build: .",
+      "    command: python -m app",
+      "    volumes:",
+      "      - .:/workspace",
+    ].join("\n"),
+  );
+  await writeFile(path.join(root, "app/orders/service.py"), "def submit_order():\n    return 'queued'\n");
+  await writeFile(
+    path.join(root, "tests/orders/test_service.py"),
+    "def test_submit_order():\n    assert True\n",
+  );
+  await writeFile(
+    path.join(root, "tests/identity/test_service.py"),
+    "def test_identity_service():\n    assert True\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/order-retry"]);
+  await writeFile(path.join(root, "app/orders/service.py"), "def submit_order():\n    return 'retrying'\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "fix: retry queued orders"]);
+
+  const plan = await generateTestPlan(root, { base: "main" });
+
+  assert.deepEqual(plan.suggestedCommands, [
+    "docker compose run --rm api pytest tests/orders/test_service.py",
+  ]);
+});
+
+test("generateTestPlan supports variant compose files and container Python runners", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src/billing"), { recursive: true });
+  await mkdir(path.join(root, "tests/billing"), { recursive: true });
+  await writeFile(
+    path.join(root, "pyproject.toml"),
+    [
+      "[project]",
+      'name = "example-service"',
+      "",
+      "[tool.pytest.ini_options]",
+      'testpaths = ["tests"]',
+    ].join("\n"),
+  );
+  await writeFile(
+    path.join(root, "Dockerfile.dev"),
+    [
+      "FROM python:3.12-slim",
+      "WORKDIR /workspace",
+      "RUN pip install uv",
+      'CMD ["uv", "run", "python", "-m", "src"]',
+    ].join("\n"),
+  );
+  await writeFile(
+    path.join(root, "docker-compose.dev.yml"),
+    [
+      "services:",
+      "  database:",
+      "    image: postgres:17",
+      "  backend:",
+      "    build:",
+      "      context: .",
+      "      dockerfile: Dockerfile.dev",
+      "    ports:",
+      '      - "8080:8080"',
+      "    volumes:",
+      "      - .:/workspace",
+      "  task-worker:",
+      "    build:",
+      "      context: .",
+      "      dockerfile: Dockerfile.dev",
+      "    command: uv run celery -A src worker",
+      "    volumes:",
+      "      - .:/workspace",
+    ].join("\n"),
+  );
+  await writeFile(path.join(root, "src/billing/service.py"), "def capture():\n    return 'pending'\n");
+  await writeFile(path.join(root, "tests/billing/test_service.py"), "def test_capture():\n    assert True\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/capture-status"]);
+  await writeFile(path.join(root, "src/billing/service.py"), "def capture():\n    return 'completed'\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "feat: expose capture completion"]);
+
+  const plan = await generateTestPlan(root, { base: "main" });
+
+  assert.deepEqual(plan.suggestedCommands, [
+    "docker compose -f docker-compose.dev.yml run --rm backend uv run pytest tests/billing/test_service.py",
+  ]);
 });
 
 test("generateTestPlan scopes monorepo changes to the requested package", async () => {
@@ -1692,6 +2022,10 @@ test("generateE2ePlan detects Django service apps from a workspace root", async 
     ["Django==5.0.0", "djangorestframework==3.15.0", "pytest==8.0.0"].join("\n"),
   );
   await writeFile(path.join(appRoot, "admin.py"), "class ListingAdmin:\n    list_display = ['id']\n");
+  await writeFile(
+    path.join(appRoot, "schema.py"),
+    "status = OpenApiParameter(name='status', type=str)\n",
+  );
   await writeFile(path.join(appRoot, "tests/test_admin.py"), "def test_admin():\n    assert True\n");
   await git(workspaceRoot, ["add", "."]);
   await git(workspaceRoot, ["commit", "-m", "base"]);
@@ -1699,6 +2033,13 @@ test("generateE2ePlan detects Django service apps from a workspace root", async 
 
   await git(workspaceRoot, ["switch", "-c", "feature/listing-admin-contract"]);
   await writeFile(path.join(appRoot, "admin.py"), "class ListingAdmin:\n    list_display = ['id', 'status']\n");
+  await writeFile(
+    path.join(appRoot, "schema.py"),
+    [
+      "status = OpenApiParameter(name='status', type=str)",
+      "commission = OpenApiParameter(name='commission_percentage', type=float)",
+    ].join("\n"),
+  );
   await writeFile(path.join(appRoot, "tests/test_admin.py"), "def test_admin_status():\n    assert True\n");
   await git(workspaceRoot, ["add", "."]);
   await git(workspaceRoot, ["commit", "-m", "update listing admin"]);
@@ -1719,6 +2060,46 @@ test("generateE2ePlan detects Django service apps from a workspace root", async 
   assert.equal(flow.title, "Admin API contract smoke checklist");
   assert.equal(flow.languageBrief.actor, "API consumer or upstream service");
   assert.ok(flow.fixtureReadiness.backendSignals.includes("admin.py"));
+  assert.equal(plan.flows.flatMap((item) => item.entrypoints).some((entrypoint) => entrypoint.kind === "screen"), false);
+});
+
+test("generateE2ePlan keeps specific API intent in product language", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await writeFile(path.join(root, "manage.py"), "import django\n");
+  await writeFile(path.join(root, "requirements.txt"), "Django==5.0.0\ndjangorestframework==3.15.0\n");
+  await writeFile(
+    path.join(root, "views.py"),
+    "class OrderView:\n    request_serializer_class = LegacyOrderSerializer\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/expedited-order"]);
+  await writeFile(
+    path.join(root, "views.py"),
+    [
+      "class OrderView:",
+      "    request_serializer_class = ExpeditedOrderSerializer",
+      "    def post(self, request):",
+      "        serializer = self.request_serializer_class(data=request.data)",
+      "        serializer.is_valid(raise_exception=True)",
+      "        return Response(serializer.data, status=201)",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "feat: add expedited order contract"]);
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const flow = plan.flows.find((item) => item.intentId);
+
+  assert.ok(flow);
+  assert.equal(flow.title, "Add expedited order contract");
+  assert.equal(flow.kind, "api");
+  assert.equal(flow.languageBrief.actor, "API consumer or upstream service");
+  assert.match(flow.languageBrief.successSignal, /expected status, response shape, auth behavior/);
+  assert.equal(flow.entrypoints.some((entrypoint) => entrypoint.kind === "screen"), false);
 });
 
 test("generateE2ePlan names versioned API service paths with domain language", async () => {
@@ -3318,11 +3699,21 @@ test("generateE2ePlan captures Playwright execution profile and self-check block
     draftFile.selfCheck?.checks.find((check) => check.name === "Compiled actions")?.status,
     "fail",
   );
+  assert.equal(
+    draftFile.selfCheck?.checks.find((check) => check.name === "Skipped tests")?.status,
+    "fail",
+  );
+  assert.equal(
+    draftFile.selfCheck?.checks.find((check) => check.name === "Executable assertions")?.status,
+    "fail",
+  );
   assert.equal(draftFile.selfCheck?.blockers.some((blocker) => /Unresolved placeholders/.test(blocker)), false);
   assert.equal(draft.readinessSummary.reviewOnly > 0, true);
   assert.equal(draft.readinessSummary.selfCheckFail > 0, true);
   assert.equal(draft.readinessSummary.topBlockers.some((blocker) => /Unresolved placeholders/.test(blocker)), false);
   assert.deepEqual(draftFile.executionBlockers?.filter((blocker) => /Playwright|baseURL|start command/i.test(blocker)), []);
+  assert.equal(draftFile.executionBlockers?.some((blocker) => /Compiled actions/.test(blocker)), true);
+  assert.equal(draftFile.executionBlockers?.some((blocker) => /Skipped tests/.test(blocker)), false);
   assert.equal((draftFile.blockingValidationGapCount ?? 0) > 0, true);
   assert.deepEqual(draftFile.executionBlockers?.filter((blocker) => /validation gap/i.test(blocker)), []);
   assert.match(formatMarkdownE2eDraft(draft), /Review-only files: 1/);
@@ -3673,11 +4064,20 @@ test("generateE2eDraft emits runnable Playwright role and input actions", async 
   assert.equal(draftFile.selfCheck?.status, "pass");
   assert.equal(draftFile.selfCheck?.summary, "Playwright draft passed static runner checks.");
   assert.equal(draftFile.runnableStatus, "runnable-candidate");
+  assert.equal(
+    draftFile.selfCheck?.checks.find((check) => check.name === "Skipped tests")?.status,
+    "pass",
+  );
+  assert.equal(
+    draftFile.selfCheck?.checks.find((check) => check.name === "Executable assertions")?.status,
+    "pass",
+  );
   assert.equal(draft.readinessSummary.runnableCandidates, 1);
   assert.equal(draft.readinessSummary.selfCheckPass, 1);
   assert.equal(draft.readinessSummary.totalTodos, 0);
   assert.match(formatMarkdownE2eDraft(draft), /Draft Self Checks/);
   assert.match(formatMarkdownE2eDraft(draft), /Self-checks: 1 pass, 0 warning, 0 fail/);
+  assert.match(formatMarkdownE2eDraft(draft), /Static-runnable candidates \(not executed\): 1/);
   assert.doesNotMatch(formatMarkdownE2eDraft(draft), /Replace starter smoke assertions with domain assertions/);
   assert.doesNotMatch(spec, /page\.getByLabel\("Profile email"\)/);
   assert.doesNotMatch(spec, /\/\/ TODO: Fill profile email/);
@@ -4177,6 +4577,115 @@ test("generateE2ePlan skips access route folders when naming scenarios", async (
   assert.ok(plan.domainLanguage.scenarios.some((scenario) => scenario.title === "Bundle Apply Now"));
   assert.ok(!plan.domainLanguage.terms.some((term) => term.term === "Public"));
   assert.ok(!plan.domainLanguage.scenarios.some((scenario) => scenario.title === "Public primary journey"));
+});
+
+test("generateE2ePlan does not turn nested UI components or settlement vocabulary into payment routes", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src/pages/operations/components"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      scripts: { test: "playwright test" },
+      dependencies: { "@playwright/test": "^1.56.0", vue: "^3.5.0" },
+    }),
+  );
+  await writeFile(
+    path.join(root, "src/pages/operations/components/SettlementSummaryPanel.vue"),
+    "<template><section>Settlement summary</section></template>\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/settlement-summary"]);
+  await writeFile(
+    path.join(root, "src/pages/operations/components/SettlementSummaryPanel.vue"),
+    "<template><section>Review settlement batch summary</section></template>\n",
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "feat: show settlement batch summary"]);
+
+  const plan = await generateE2ePlan(root, { base: "main" });
+  const relevantFlows = plan.flows.filter((flow) =>
+    flow.files.includes("src/pages/operations/components/SettlementSummaryPanel.vue")
+  );
+
+  assert.ok(relevantFlows.length > 0);
+  assert.equal(
+    relevantFlows.some((flow) => flow.entrypoints.some((entrypoint) => entrypoint.kind === "route")),
+    false,
+  );
+  assert.equal(
+    relevantFlows.some((flow) => flow.setupHints.some((hint) => hint.kind === "payment")),
+    false,
+  );
+});
+
+test("generateE2ePlan does not navigate to API routes or reuse unchanged success copy", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src/app/api/catalog"), { recursive: true });
+  await mkdir(path.join(root, "src/pages/profile"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      scripts: { test: "playwright test" },
+      dependencies: { "@playwright/test": "^1.56.0", next: "^15.0.0", react: "^19.0.0" },
+    }),
+  );
+  await writeFile(
+    path.join(root, "src/app/api/catalog/route.ts"),
+    "export async function GET() { return Response.json({ items: [] }); }\n",
+  );
+  await writeFile(
+    path.join(root, "src/pages/profile/ProfilePage.tsx"),
+    [
+      "export function ProfilePage() {",
+      "  return <main>",
+      "    <p>Settings saved</p>",
+      "    <button>Save profile</button>",
+      "  </main>;",
+      "}",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/catalog-profile"]);
+  await writeFile(
+    path.join(root, "src/app/api/catalog/route.ts"),
+    "export async function GET() { return Response.json({ items: ['new'] }); }\n",
+  );
+  await writeFile(
+    path.join(root, "src/pages/profile/ProfilePage.tsx"),
+    [
+      "export function ProfilePage() {",
+      "  return <main>",
+      "    <p>Settings saved</p>",
+      "    <button data-testid=\"profile-save\">Save profile</button>",
+      "  </main>;",
+      "}",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "feat: update catalog and profile save"]);
+
+  const plan = await generateE2ePlan(root, { base: "main" });
+  const apiFlows = plan.flows.filter((flow) => flow.files.includes("src/app/api/catalog/route.ts"));
+  const profileFlows = plan.flows.filter((flow) => flow.files.includes("src/pages/profile/ProfilePage.tsx"));
+
+  assert.ok(apiFlows.length > 0);
+  assert.equal(
+    apiFlows.some((flow) => flow.entrypoints.some((entrypoint) => entrypoint.kind === "route" && entrypoint.value === "/api/catalog")),
+    false,
+  );
+  assert.ok(profileFlows.length > 0);
+  assert.equal(
+    profileFlows.some((flow) => flow.languageBrief.successSignal === 'visible text "Settings saved" appears'),
+    false,
+  );
 });
 
 test("generateE2ePlan matches workspace core flows for package scans", async () => {
@@ -5751,6 +6260,10 @@ test("qa command emits a PR comment draft without requiring a manifest", async (
   assert.match(markdown, /- QA proposal: /);
   assert.match(markdown, /QA analysis: completed independently of runner setup/);
   assert.match(markdown, /Automation stage:/);
+  assert.match(markdown, /## QA Decision Layers/);
+  assert.match(markdown, /### 1\. Important QA And Risk Map/);
+  assert.match(markdown, /### 2\. Executable Evidence Available Now/);
+  assert.match(markdown, /### 3\. Manual Or Agent QA Contracts/);
   assert.match(markdown, /QA analysis and scenario routing do not require the optional automation runner/);
   assert.match(markdown, /- Repository validation: `/);
   assert.match(markdown, /- Optional automation gap/);

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -406,7 +406,7 @@ test("generateTestPlan selects the nearest long-lived branch as the PR base", as
   await git(root, ["add", "."]);
   await git(root, ["commit", "-m", "feat: add archived catalog filter"]);
 
-  const plan = await generateTestPlan(root);
+  const plan = await withoutBaseRefEnvironment(() => generateTestPlan(root));
   const markdown = formatMarkdownTestPlan(plan);
 
   assert.equal(plan.base, "develop");
@@ -431,7 +431,7 @@ test("generateTestPlan reports equivalent long-lived base refs without pretendin
   await git(root, ["add", "."]);
   await git(root, ["commit", "-m", "feat: enable feature"]);
 
-  const plan = await generateTestPlan(root);
+  const plan = await withoutBaseRefEnvironment(() => generateTestPlan(root));
 
   assert.equal(plan.base, "develop");
   assert.deepEqual(plan.baseResolution.equivalentRefs, ["main"]);
@@ -8220,6 +8220,33 @@ async function initGitRepo(root) {
   await git(root, ["init"]);
   await git(root, ["config", "user.email", "qamap@example.invalid"]);
   await git(root, ["config", "user.name", "QAMap Test"]);
+}
+
+async function withoutBaseRefEnvironment(callback) {
+  const names = [
+    "QAMAP_BASE_REF",
+    "GITHUB_BASE_REF",
+    "CI_MERGE_REQUEST_TARGET_BRANCH_NAME",
+    "BITBUCKET_PR_DESTINATION_BRANCH",
+    "BUILDKITE_PULL_REQUEST_BASE_BRANCH",
+    "CHANGE_TARGET",
+    "SYSTEM_PULLREQUEST_TARGETBRANCH",
+  ];
+  const previous = new Map(names.map((name) => [name, process.env[name]]));
+  for (const name of names) {
+    delete process.env[name];
+  }
+  try {
+    return await callback();
+  } finally {
+    for (const [name, value] of previous) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  }
 }
 
 async function writeWorkspaceGuardrails(root) {


### PR DESCRIPTION
## Intent

- Resolve the comparison base from explicit input, pull-request CI metadata, repository configuration, or the nearest long-lived Git branch, and explain the selected evidence.
- Analyze the final net worktree state so locally removed committed changes do not survive as stale QA evidence.
- Keep important QA risks independent from automation readiness, then separate static-runnable evidence from manual or agent contracts.
- Scope JavaScript and Python validation commands to affected packages, related tests, and the primary Compose service.
- Reduce false routes, payment setup, mobile screens, scheduling flows, and unchanged success assertions without adding product-specific rules.

## Agent / Review Risk

This changes inferred base selection and user-facing QA output. Explicit `--base` behavior remains authoritative, and inferred choices now expose their source and reason. The new static-runnable label means structural checks passed; it never claims the target application ran.

## Validation Evidence

- [x] `pnpm test` (204 tests passed)
- [ ] `pnpm scan` (scanner and repository-policy behavior are unchanged)
- [x] Relevant QAMap plan and draft output reviewed through the public benchmark suite
- [x] `pnpm bench:ci` (19 public benchmark targets passed)
- [x] `pnpm coverage` (88.95% lines, 85.39% branches, 96.05% functions)
- [x] `pnpm pack --dry-run`
- [x] `git diff --check`

## E2E / Manual Coverage

Synthetic cross-domain fixtures cover React, Vue, SvelteKit, Expo, API services, CLI projects, JavaScript workspaces, and Python Compose services. The suite verifies base provenance, final net diffs, scenario retention without a runner, static-runnable honesty, route boundaries, API endpoints, assertions, and false-positive controls. No target product application was executed or claimed as passed.

## Maintainer Notes

The package version remains `0.4.6`; this PR prepares the unreleased `0.4.7` line without publishing or tagging it. Public code, fixtures, and this PR body contain no private repository rules or local smoke-test output.

## Collaboration Checklist

- [x] The branch uses an allowed prefix and contains no coding-agent product name.
- [x] The PR title follows `Type: imperative summary`.
- [x] `@ivory-code` is assigned, or assignment is left for a maintainer when permissions do not allow it.
- [x] Exactly one `type:` label and only relevant `area:` labels are applied.
- [x] The PR is intended to be squash-merged after required checks pass.
