### PR TITLE
Fix: export package root API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Fixed
 
+- The npm package root now exports the documented programmatic API and TypeScript declarations, so agent tools and local QA orchestrators can import `generateQaDraft` and `formatAgentQaDraft` without relying on an internal `dist` path.
 - Nested page components no longer become fabricated routes, API endpoints no longer become browser navigation targets, API schema parameter names no longer become mobile screens, settlement vocabulary alone no longer creates payment setup, and unchanged success copy is no longer borrowed as a changed-flow assertion.
 - Capturing a current server timestamp with `timezone.now()` no longer creates scheduling and calendar-boundary QA; actual schedule, reminder, and timezone preference changes remain eligible.
 - Python Compose discovery no longer prefers a worker or scheduler over the primary web/API service merely because both services share the same Python image.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,17 @@ npx --yes skills add IvoryCanvas/QAMap --skill qamap-pr-qa
 
 Or run `qamap init --agent` to add the repo instructions and packaged skill. See the [agent format contract](docs/agent-format.md) and [agent skill guide](docs/agent-skill.md).
 
+Tools that embed QAMap can consume the same public contract without launching a shell:
+
+```js
+import { formatAgentQaDraft, generateQaDraft } from "@ivorycanvas/qamap";
+
+const draft = await generateQaDraft(process.cwd(), { base: "origin/main", head: "HEAD" });
+const context = JSON.parse(formatAgentQaDraft(draft));
+```
+
+`context.execution` remains `not-run`; an orchestrator must report any later test execution separately.
+
 ## Why QAMap
 
 - **Evidence over guesses.** Every routed scenario carries commit or line-level diff provenance.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,17 @@
   "version": "0.4.6",
   "description": "Local zero-LLM PR QA designer that maps commit intent and diffs to traceable behavior lifecycles, QA scenarios, and optional automation drafts.",
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "packageManager": "pnpm@10.32.1",
   "bin": {
     "qamap": "dist/cli.js"

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -7205,6 +7205,18 @@ test("package version matches the CLI version constant", async () => {
   assert.equal(VERSION, packageJson.version);
 });
 
+test("package root exports the public QA API and declarations", async () => {
+  const packageJson = JSON.parse(await readFile(path.join(repositoryRoot, "package.json"), "utf8"));
+  const publicApi = await import("@ivorycanvas/qamap");
+
+  assert.equal(packageJson.main, "./dist/index.js");
+  assert.equal(packageJson.types, "./dist/index.d.ts");
+  assert.equal(packageJson.exports["."].import, "./dist/index.js");
+  assert.equal(packageJson.exports["."].types, "./dist/index.d.ts");
+  assert.equal(typeof publicApi.generateQaDraft, "function");
+  assert.equal(typeof publicApi.formatAgentQaDraft, "function");
+});
+
 test("e2e draft can use an external verification manifest for read-only adoption preview", async () => {
   const root = await makeTempRepo();
   const manifestOutputRoot = await mkdtemp(path.join(tmpdir(), "qamap-external-manifest-"));


### PR DESCRIPTION
## Intent

Expose QAMap's documented programmatic QA API from the npm package root. Embedding tools can now import `generateQaDraft` and `formatAgentQaDraft` from `@ivorycanvas/qamap` instead of depending on an internal `dist` path.

The existing CLI and deep `dist/*` imports remain compatible.

## Agent / Review Risk

Low. This changes npm package resolution metadata and adds documentation and a regression test. The packed artifact was installed into a clean temporary consumer project to verify real root resolution.

## Validation Evidence

- [x] `pnpm test`
- [ ] `pnpm scan` (not applicable; scanner and repository policy behavior are unchanged)
- [x] Relevant `qamap qa --format agent` output reviewed against a committed real repository diff
- [x] `pnpm build`
- [x] Packed tarball installed in a clean project; root API import succeeded

## E2E / Manual Coverage

Browser E2E is not applicable to package export metadata. The package-level smoke test covers the user-visible import path, and the full suite passed.

## Maintainer Notes

This is a package contract correction discovered while integrating QAMap into another local QA orchestrator. It contains no private repository or domain rules.

## Collaboration Checklist

- [x] The branch uses an allowed prefix and contains no coding-agent product name.
- [x] The PR title follows `Type: imperative summary`.
- [x] `@ivory-code` is assigned.
- [x] Exactly one `type:` label and only relevant `area:` labels are applied.
- [x] The PR is intended to be squash-merged after required checks pass.
