### PR TITLE
Fix: Separate QA evidence across product surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Changed
 
+- A single change intent that spans distinct feature, route, or screen surfaces now produces surface-scoped QA flows. Each flow keeps its own files, lifecycle, scenarios, and observable outcome while shared import evidence remains traceable.
+- An existing success message can now ground a flow when it is the only success-shaped outcome on that surface and the same file has direct diff evidence; newly added success copy still takes priority.
 - Working-tree analysis now compares the selected merge base directly with the final worktree, so intermediate files removed later in the branch do not survive as stale changed-file or diff evidence.
 - Draft reporting now says `static-runnable` and `not executed` explicitly; generated tests with skipped placeholders or without observable assertions fail self-check instead of appearing runnable.
 - Specific commit-and-diff-backed intent titles now remain the flow language shown to reviewers; internal handler and serializer symbols only refine broad titles such as generic update or release work.
@@ -25,8 +27,9 @@
 
 ### Fixed
 
+- QA flows created from one broad intent no longer borrow assertions or success signals from neighboring product surfaces, and residual navigation or service changes are relabeled from their own files instead of inheriting a partially consumed UI title.
 - The npm package root now exports the documented programmatic API and TypeScript declarations, so agent tools and local QA orchestrators can import `generateQaDraft` and `formatAgentQaDraft` without relying on an internal `dist` path.
-- Nested page components no longer become fabricated routes, API endpoints no longer become browser navigation targets, API schema parameter names no longer become mobile screens, settlement vocabulary alone no longer creates payment setup, and unchanged success copy is no longer borrowed as a changed-flow assertion.
+- Nested page components no longer become fabricated routes, API endpoints no longer become browser navigation targets, API schema parameter names no longer become mobile screens, settlement vocabulary alone no longer creates payment setup, and unchanged success copy from unrelated or weakly evidenced surfaces is no longer borrowed as a changed-flow assertion.
 - Capturing a current server timestamp with `timezone.now()` no longer creates scheduling and calendar-boundary QA; actual schedule, reminder, and timezone preference changes remain eligible.
 - Python Compose discovery no longer prefers a worker or scheduler over the primary web/API service merely because both services share the same Python image.
 - Repository-validation output no longer requires consumers to reconcile a compatibility-only `blocked` automation level with a `ready-to-run` repository command. The additive route status now expresses the applicable decision directly.

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -668,17 +668,26 @@ export async function generateE2ePlan(rootInput: string, options: E2ePlanOptions
 
 function refineChangeIntentAssertions(changeAnalysis: ChangeIntentAnalysis, flows: E2eFlow[]): void {
   const genericAssertion = "Verify the externally observable result matches the commit intent.";
+  const flowCountByIntent = new Map<string, number>();
+  for (const flow of flows) {
+    if (flow.intentId) {
+      flowCountByIntent.set(flow.intentId, (flowCountByIntent.get(flow.intentId) ?? 0) + 1);
+    }
+  }
   for (const flow of flows) {
     if (!flow.intentId || !/^visible text ".+" appears$/u.test(flow.languageBrief.successSignal)) {
       continue;
     }
     const intent = changeAnalysis.intents.find((candidate) => candidate.id === flow.intentId);
     const primary = intent?.scenarios.find((scenario) => scenario.kind === "primary");
-    if (!primary || primary.assertions.length === 0) {
+    const flowScenario = flow.qaScenarios?.find((scenario) => scenario.kind === "primary");
+    const hasMultipleFlows = (flowCountByIntent.get(flow.intentId) ?? 0) > 1;
+    const assertionSource = hasMultipleFlows ? flowScenario : primary;
+    if (!primary || !assertionSource || assertionSource.assertions.length === 0) {
       continue;
     }
     const concreteAssertion = `Verify ${flow.languageBrief.successSignal}.`;
-    const originalAssertions = [...primary.assertions];
+    const originalAssertions = [...assertionSource.assertions];
     const replaceSingleAssertion = originalAssertions.length === 1;
     const assertions = originalAssertions.map((assertion) =>
       replaceSingleAssertion || assertion === genericAssertion
@@ -688,9 +697,10 @@ function refineChangeIntentAssertions(changeAnalysis: ChangeIntentAnalysis, flow
     if (assertions.every((assertion, index) => assertion === originalAssertions[index])) {
       continue;
     }
-    primary.assertions = assertions;
-    const flowScenario = flow.qaScenarios?.find((scenario) => scenario.id === primary.id);
-    if (flowScenario && flowScenario !== primary) {
+    if (!hasMultipleFlows) {
+      primary.assertions = assertions;
+    }
+    if (flowScenario) {
       flowScenario.assertions = [...assertions];
     }
     const replacedAssertions = new Set(
@@ -2748,12 +2758,13 @@ function inferFlowSuccessSignal(flow: Omit<E2eFlow, "languageBrief">): string {
   if (/\bconfiguration verification\b/i.test(flow.title)) {
     return "the affected build or runtime variant starts cleanly and handles fallback values";
   }
-  const visibleOutcome = flow.selectors.find(
+  const addedVisibleOutcome = flow.selectors.find(
     (selector) =>
       selector.kind === "visible-text" &&
       Boolean(selector.addedInDiff) &&
       (isVisibleSuccessOutcome(selector.value) || isDiffBackedStateMarker(flow, selector)),
   );
+  const visibleOutcome = addedVisibleOutcome ?? repositorySuccessOutcome(flow);
   if (visibleOutcome) {
     return `visible text "${visibleOutcome.value}" appears`;
   }
@@ -2766,6 +2777,25 @@ function inferFlowSuccessSignal(flow: Omit<E2eFlow, "languageBrief">): string {
     return stripTerminalPunctuation(coverageCheck);
   }
   return "the changed journey reaches a visible, stable success state";
+}
+
+function repositorySuccessOutcome(
+  flow: Omit<E2eFlow, "languageBrief">,
+): E2eSelector | undefined {
+  const candidates = flow.selectors.filter(
+    (selector) => selector.kind === "visible-text" && isVisibleSuccessOutcome(selector.value),
+  );
+  if (candidates.length !== 1) {
+    return undefined;
+  }
+  const [candidate] = candidates;
+  const hasDirectSurfaceEvidence = flow.intentEvidence?.some((evidence) =>
+    evidence.kind === "diff" &&
+    evidence.file === candidate.file &&
+    evidence.startLine !== undefined &&
+    evidence.relation !== "contextual"
+  );
+  return hasDirectSurfaceEvidence ? candidate : undefined;
 }
 
 function isVisibleSuccessOutcome(value: string): boolean {
@@ -4847,6 +4877,14 @@ type DraftE2eFlow = E2eFlow & {
   manifestMatch?: VerificationManifestMatch;
   manifestCheckMatches?: VerificationManifestMatch[];
 };
+type AnalyzedChangeIntent = ChangeIntentAnalysis["intents"][number];
+
+interface IntentFlowScope {
+  label?: string;
+  files: string[];
+  importImpacts: ImportImpact[];
+  split: boolean;
+}
 
 async function buildFlows(
   root: string,
@@ -5197,26 +5235,37 @@ function prioritizeChangeIntentCandidates(
         item.kind === "diff" && item.file && item.startLine !== undefined && item.relation !== "contextual"
       )
     ))
-    .map((intent): FlowCandidate => {
-      const relatedImportImpacts = importImpacts.filter((impact) => intent.files.includes(impact.changedFile));
-      const impactedSurfaces = relatedImportImpacts.map((impact) => impact.surface);
-      const primaryScenario = intent.scenarios.find((scenario) => scenario.kind === "primary") ?? intent.scenarios[0];
+    .flatMap((intent) => buildIntentFlowScopes(intent, importImpacts).map((scope) => {
+      const scopedEvidence = scopeIntentEvidence(intent.evidence, scope.files);
+      const scopedLifecycle = scopeIntentLifecycle(intent.lifecycle, scope.files);
+      const scopedScenarios = scopeIntentScenarios(
+        intent.scenarios,
+        scope.files,
+        scopedEvidence,
+        scopedLifecycle,
+        scope.split,
+      );
+      const primaryScenario = scopedScenarios.find((scenario) => scenario.kind === "primary") ?? scopedScenarios[0];
       const steps = uniqueStrings([
-        ...(primaryScenario?.steps ?? intent.lifecycle.map((stage) => stage.label)),
+        ...(primaryScenario?.steps ?? scopedLifecycle.map((stage) => stage.label)),
         ...(primaryScenario?.assertions ?? []),
       ]);
+      const baseTitle = intentFlowDisplayTitle(intent, domainLanguage);
       return {
         kind: intentFlowKind(intent, projectType),
-        title: intentFlowDisplayTitle(intent, domainLanguage),
+        title: scope.split && scope.label ? scopedIntentFlowTitle(baseTitle, scope.label) : baseTitle,
         reason: (intent.confidence === "low"
           ? `Located diff evidence supports this review-required change intent even though commit text was not behavior-bearing. ${intent.summary}`
           : `Commit and diff evidence support this ${intent.confidence}-confidence change intent. ${intent.summary}`) +
-            (relatedImportImpacts.length > 0
-              ? ` Reverse imports reach ${relatedImportImpacts.slice(0, 3).map(describeImportChain).join("; ")}.`
+            (scope.split && scope.label
+              ? ` This flow is scoped to the ${titleCase(scope.label)} user surface so evidence and outcomes from neighboring surfaces stay separate.`
+              : "") +
+            (scope.importImpacts.length > 0
+              ? ` Reverse imports reach ${scope.importImpacts.slice(0, 3).map(describeImportChain).join("; ")}.`
               : ""),
-        files: uniqueStrings([...intent.files, ...impactedSurfaces]),
+        files: scope.files,
         steps,
-        coverage: intent.scenarios.map((scenario) => ({
+        coverage: scopedScenarios.map((scenario) => ({
           title: scenario.title,
           priority: scenario.priority,
           reason: scenario.rationale,
@@ -5224,11 +5273,11 @@ function prioritizeChangeIntentCandidates(
         })),
         intentId: intent.id,
         intentConfidence: intent.confidence,
-        intentEvidence: intent.evidence,
-        lifecycle: intent.lifecycle,
-        qaScenarios: intent.scenarios,
-      };
-    });
+        intentEvidence: scopedEvidence,
+        lifecycle: scopedLifecycle,
+        qaScenarios: scopedScenarios,
+      } satisfies FlowCandidate;
+    }));
   if (intentCandidates.length === 0) {
     return heuristicCandidates;
   }
@@ -5244,10 +5293,249 @@ function prioritizeChangeIntentCandidates(
     ]),
   }));
   const intentFiles = new Set(intentCandidatesWithAssets.flatMap((candidate) => candidate.files));
-  const nonOverlapping = heuristicCandidates.filter((candidate) =>
-    candidate.files.every((file) => !intentFiles.has(file)) || isVerificationOnlyKind(candidate.kind),
-  );
+  const nonOverlapping = heuristicCandidates.flatMap((candidate): FlowCandidate[] => {
+    if (isVerificationOnlyKind(candidate.kind)) {
+      return [candidate];
+    }
+    const remainingFiles = candidate.files.filter((file) => !intentFiles.has(file));
+    return remainingFiles.length > 0
+      ? [scopeResidualHeuristicCandidate(candidate, remainingFiles, domainLanguage)]
+      : [];
+  });
   return [...intentCandidatesWithAssets, ...nonOverlapping].slice(0, 4);
+}
+
+function scopeResidualHeuristicCandidate(
+  candidate: FlowCandidate,
+  files: string[],
+  domainLanguage?: DomainLanguageSummary,
+): FlowCandidate {
+  const subject = summarizeFlowSubject(files, "Changed", domainLanguage);
+  if (candidate.kind === "ui" && !files.some((file) => isUiImplementationFile(file) || isRoutableSurfaceFile(file))) {
+    return {
+      kind: "domain",
+      title: `${subject} behavior smoke flow`,
+      reason: "These changed behavior files are not covered by the surface-scoped intent flows, so they remain an explicit repository-level verification path.",
+      files,
+      steps: [
+        "Identify the route, screen, command, or public API that reaches the changed behavior.",
+        "Exercise the primary successful path through that entry point.",
+        "Verify the resulting navigation, state, output, or side effect.",
+        "Exercise one invalid, unavailable, or fallback path when reachable.",
+      ],
+    };
+  }
+  const title = candidate.kind === "ui"
+    ? `${subject} UI smoke flow`
+    : candidate.kind === "api"
+      ? `${subject} API contract smoke flow`
+      : candidate.kind === "state"
+        ? `${subject} state transition flow`
+        : candidate.kind === "content"
+          ? `${subject} content and theme smoke flow`
+          : candidate.kind === "domain"
+            ? `${subject} workflow smoke flow`
+            : candidate.title;
+  return {
+    ...candidate,
+    title,
+    reason: `${candidate.reason} This candidate is scoped to changed files not already explained by an intent flow.`,
+    files,
+  };
+}
+
+function buildIntentFlowScopes(
+  intent: AnalyzedChangeIntent,
+  importImpacts: ImportImpact[],
+): IntentFlowScope[] {
+  const relatedImportImpacts = importImpacts.filter((impact) => intent.files.includes(impact.changedFile));
+  const groupedFiles = new Map<string, string[]>();
+
+  for (const file of intent.files) {
+    const label = intentSurfaceSeedLabel(file);
+    if (!label) {
+      continue;
+    }
+    groupedFiles.set(label, uniqueStrings([...(groupedFiles.get(label) ?? []), file]));
+  }
+
+  if (groupedFiles.size < 2) {
+    return [{
+      files: uniqueStrings([...intent.files, ...relatedImportImpacts.map((impact) => impact.surface)]),
+      importImpacts: relatedImportImpacts,
+      split: false,
+    }];
+  }
+
+  for (const file of intent.files) {
+    const label = intentSurfaceLabel(file);
+    if (label && groupedFiles.has(label)) {
+      groupedFiles.set(label, uniqueStrings([...(groupedFiles.get(label) ?? []), file]));
+    }
+  }
+
+  return [...groupedFiles.entries()]
+    .map(([label, files]) => {
+      const scopedImpacts = relatedImportImpacts.filter((impact) => intentSurfaceLabel(impact.surface) === label);
+      return {
+        label,
+        files: uniqueStrings([
+          ...files,
+          ...scopedImpacts.flatMap((impact) => [impact.changedFile, impact.surface]),
+        ]),
+        importImpacts: scopedImpacts,
+        split: true,
+      };
+    })
+    .sort((left, right) => right.files.length - left.files.length)
+    .slice(0, 3);
+}
+
+function intentSurfaceLabel(file: string): string | undefined {
+  const domain = domainFromPath(file);
+  if (domain) {
+    return canonicalIntentSurfaceLabel(domain);
+  }
+  if (!isUserFacingFile(file)) {
+    return undefined;
+  }
+  const routeSurface = surfaceFromPath(file);
+  if (routeSurface) {
+    return canonicalIntentSurfaceLabel(routeSurface);
+  }
+  const segments = file.split("/");
+  const areaIndex = segments.findIndex((segment) => /^(?:components?|ui)$/i.test(segment));
+  if (areaIndex >= 0 && segments.length - areaIndex > 2) {
+    return canonicalIntentSurfaceLabel(normalizePathSegment(segments[areaIndex + 1]));
+  }
+  return undefined;
+}
+
+function intentSurfaceSeedLabel(file: string): string | undefined {
+  if (!isUserFacingFile(file)) {
+    return undefined;
+  }
+  const domain = domainFromPath(file);
+  if (domain) {
+    return canonicalIntentSurfaceLabel(domain);
+  }
+  if (/(?:^|\/)(?:app|pages|routes)\//i.test(file) && isRoutableSurfaceFile(file)) {
+    return canonicalIntentSurfaceLabel(surfaceFromPath(file));
+  }
+  const segments = file.split("/");
+  const screensIndex = segments.findIndex((segment) => /^screens$/i.test(segment));
+  return screensIndex >= 0 && segments.length - screensIndex > 2
+    ? canonicalIntentSurfaceLabel(normalizePathSegment(segments[screensIndex + 1]))
+    : undefined;
+}
+
+function canonicalIntentSurfaceLabel(label: string | undefined): string | undefined {
+  if (!label) {
+    return undefined;
+  }
+  const tokens = pathWordTokens(label).filter((token) =>
+    !new Set(["component", "components", "page", "pages", "screen", "screens", "view", "views"]).has(token)
+  );
+  return tokens.length > 0 ? tokens.join("-") : undefined;
+}
+
+function scopedIntentFlowTitle(baseTitle: string, label: string): string {
+  const surfaceTitle = titleCase(label);
+  return baseTitle.toLowerCase().startsWith(surfaceTitle.toLowerCase())
+    ? baseTitle
+    : `${surfaceTitle}: ${baseTitle}`;
+}
+
+function scopeIntentEvidence(
+  evidence: ChangeIntentEvidence[],
+  files: string[],
+): ChangeIntentEvidence[] {
+  const fileSet = new Set(files);
+  return evidence
+    .filter((item) => !item.file && !item.previousFile ||
+      Boolean(item.file && fileSet.has(item.file)) ||
+      Boolean(item.previousFile && fileSet.has(item.previousFile)))
+    .map((item) => ({ ...item }));
+}
+
+function scopeIntentLifecycle(
+  lifecycle: BehaviorLifecycleStage[],
+  files: string[],
+): BehaviorLifecycleStage[] {
+  const fileSet = new Set(files);
+  return lifecycle
+    .filter((stage) => {
+      const evidenceFiles = stage.evidence.flatMap((item) => [item.file, item.previousFile]).filter(Boolean);
+      if (evidenceFiles.length > 0) {
+        return evidenceFiles.some((file) => fileSet.has(file as string));
+      }
+      return stage.files.length === 0 || stage.files.some((file) => fileSet.has(file));
+    })
+    .map((stage) => ({
+      ...stage,
+      evidence: scopeIntentEvidence(stage.evidence, files),
+      files: stage.files.filter((file) => fileSet.has(file)),
+    }));
+}
+
+function scopeIntentScenarios(
+  scenarios: IntentQaScenario[],
+  files: string[],
+  fallbackEvidence: ChangeIntentEvidence[],
+  lifecycle: BehaviorLifecycleStage[],
+  specializePrimary: boolean,
+): IntentQaScenario[] {
+  const fileSet = new Set(files);
+  return scenarios
+    .filter((scenario) => {
+      if (scenario.kind === "primary") {
+        return true;
+      }
+      const evidenceFiles = scenario.evidence.flatMap((item) => [item.file, item.previousFile]).filter(Boolean);
+      return evidenceFiles.length === 0 || evidenceFiles.some((file) => fileSet.has(file as string));
+    })
+    .map((scenario) => {
+      const evidence = scopeIntentEvidence(scenario.evidence, files);
+      const scopedScenario = {
+        ...scenario,
+        setup: [...scenario.setup],
+        steps: [...scenario.steps],
+        assertions: [...scenario.assertions],
+        edgeCases: [...scenario.edgeCases],
+        evidence: evidence.length > 0 ? evidence : fallbackEvidence.map((item) => ({ ...item })),
+      };
+      return specializePrimary && scenario.kind === "primary"
+        ? specializePrimaryScenario(scopedScenario, lifecycle)
+        : scopedScenario;
+    });
+}
+
+function specializePrimaryScenario(
+  scenario: IntentQaScenario,
+  lifecycle: BehaviorLifecycleStage[],
+): IntentQaScenario {
+  const locatedStages = lifecycle.filter((stage) => stage.files.length > 0);
+  const scopedStages = locatedStages.length > 0 ? locatedStages : lifecycle;
+  const outcomeStages = scopedStages.filter((stage) => stage.kind === "observable-outcome");
+  const sideEffectStages = scopedStages.filter((stage) => stage.kind === "side-effect");
+  const assertionStages = outcomeStages.length > 0 ? outcomeStages : sideEffectStages;
+  if (scopedStages.length === 0 || assertionStages.length === 0) {
+    return scenario;
+  }
+  return {
+    ...scenario,
+    steps: uniqueStrings(scopedStages.map((stage) => stage.label)),
+    assertions: uniqueStrings(assertionStages.map(scopedLifecycleAssertion)),
+  };
+}
+
+function scopedLifecycleAssertion(stage: BehaviorLifecycleStage): string {
+  const label = stripTerminalPunctuation(stage.label);
+  const observed = label.match(/^Observe the result of (.+)$/i)?.[1];
+  if (observed) {
+    return `Verify ${observed} is externally observable.`;
+  }
+  return `Verify ${lowercaseFirst(label)}.`;
 }
 
 function intentFlowDisplayTitle(
@@ -7373,9 +7661,12 @@ function dedupeFlows(flows: E2eFlow[]): E2eFlow[] {
     for (const file of newFiles) {
       seenFiles.add(file);
     }
+    const sharesIntentWithEarlierFlow = Boolean(
+      flow.intentId && deduped.some((candidate) => candidate.intentId === flow.intentId),
+    );
     deduped.push({
       ...flow,
-      files: newFiles,
+      files: sharesIntentWithEarlierFlow ? flow.files : newFiles,
     });
   }
   return deduped;

--- a/test/change-intent.test.mjs
+++ b/test/change-intent.test.mjs
@@ -1310,6 +1310,164 @@ test("E2E planning promotes commit intent before runner-specific draft generatio
   assert.ok(boundedAgentSummary.flows.length > 0);
 });
 
+test("one change intent produces separate QA flows for distinct user surfaces", async (t) => {
+  const root = await makeRepo(t);
+  await write(
+    root,
+    "package.json",
+    JSON.stringify({
+      scripts: { dev: "vite", "test:e2e": "playwright test" },
+      dependencies: { react: "19.0.0", vite: "7.0.0", "@playwright/test": "1.56.0" },
+    }),
+  );
+  await write(
+    root,
+    "src/features/account/pages/PlanPage.tsx",
+    [
+      "import { completeTransaction } from '../../transactions/services/transactionService';",
+      "export function PlanPage() { return <p>Free plan</p>; }",
+    ].join("\n") + "\n",
+  );
+  await write(
+    root,
+    "src/features/credits/pages/CreditPage.tsx",
+    [
+      "import { completeTransaction } from '../../transactions/services/transactionService';",
+      "export function CreditPage() { return <p>No credits</p>; }",
+    ].join("\n") + "\n",
+  );
+  await write(
+    root,
+    "src/features/transactions/services/transactionService.ts",
+    "export async function completeTransaction() { return { status: 'idle' }; }\n",
+  );
+  commit(root, "benchmark baseline");
+  branch(root, "feat/transaction-completion");
+
+  await write(
+    root,
+    "src/features/account/pages/PlanPage.tsx",
+    [
+      "import { completeTransaction } from '../../transactions/services/transactionService';",
+      "export function PlanPage() {",
+      "  return <section>",
+      "    <button data-testid=\"plan-confirm\" onClick={completeTransaction}>Confirm plan</button>",
+      "    <p>Plan activated</p>",
+      "  </section>;",
+      "}",
+    ].join("\n") + "\n",
+  );
+  await write(
+    root,
+    "src/features/credits/pages/CreditPage.tsx",
+    [
+      "import { completeTransaction } from '../../transactions/services/transactionService';",
+      "export function CreditPage() {",
+      "  return <section>",
+      "    <button data-testid=\"credits-confirm\" onClick={completeTransaction}>Confirm credits</button>",
+      "    <p>Credits updated</p>",
+      "  </section>;",
+      "}",
+    ].join("\n") + "\n",
+  );
+  await write(
+    root,
+    "src/features/transactions/services/transactionService.ts",
+    "export async function completeTransaction() { return { status: 'completed' }; }\n",
+  );
+  commit(root, "feat: complete a transaction and refresh the affected product state");
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const intent = plan.changeAnalysis.intents[0];
+  const intentFlows = plan.flows.filter((flow) => flow.intentId === intent?.id);
+  const accountFlow = intentFlows.find((flow) =>
+    flow.files.some((file) => file.includes("/account/")),
+  );
+  const creditsFlow = intentFlows.find((flow) =>
+    flow.files.some((file) => file.includes("/credits/")),
+  );
+
+  assert.equal(plan.changeAnalysis.intents.length, 1);
+  assert.equal(intentFlows.length, 2);
+  assert.ok(accountFlow);
+  assert.ok(creditsFlow);
+  assert.match(accountFlow.title, /Account/i);
+  assert.match(creditsFlow.title, /Credits/i);
+  assert.match(accountFlow.languageBrief.successSignal, /Plan activated/i);
+  assert.doesNotMatch(accountFlow.languageBrief.successSignal, /Credits updated/i);
+  assert.match(creditsFlow.languageBrief.successSignal, /Credits updated/i);
+  assert.doesNotMatch(creditsFlow.languageBrief.successSignal, /Plan activated/i);
+  assert.ok(accountFlow.files.some((file) => file.includes("/transactions/")));
+  assert.ok(creditsFlow.files.some((file) => file.includes("/transactions/")));
+  assert.ok(
+    accountFlow.intentEvidence
+      .filter((evidence) => evidence.file)
+      .every((evidence) => !evidence.file.includes("/credits/")),
+  );
+  assert.ok(
+    creditsFlow.intentEvidence
+      .filter((evidence) => evidence.file)
+      .every((evidence) => !evidence.file.includes("/account/")),
+  );
+  const accountPrimary = accountFlow.qaScenarios.find((scenario) => scenario.kind === "primary");
+  const creditsPrimary = creditsFlow.qaScenarios.find((scenario) => scenario.kind === "primary");
+  assert.ok(accountPrimary.assertions.some((assertion) => /Plan activated/i.test(assertion)));
+  assert.ok(creditsPrimary.assertions.some((assertion) => /Credits updated/i.test(assertion)));
+});
+
+test("an unchanged success message can ground QA when the same surface has direct diff evidence", async (t) => {
+  const root = await makeRepo(t);
+  await write(
+    root,
+    "package.json",
+    JSON.stringify({
+      scripts: { dev: "vite", "test:e2e": "playwright test" },
+      dependencies: { react: "19.0.0", vite: "7.0.0", "@playwright/test": "1.56.0" },
+    }),
+  );
+  await write(
+    root,
+    "src/features/jobs/components/JobPanel.tsx",
+    [
+      "export function JobPanel() {",
+      "  function submitJob() { return undefined; }",
+      "  return <section>",
+      "    <button onClick={submitJob}>Submit job</button>",
+      "    <p>Job queued</p>",
+      "  </section>;",
+      "}",
+    ].join("\n") + "\n",
+  );
+  commit(root, "benchmark baseline");
+  branch(root, "feat/job-submission");
+
+  await write(
+    root,
+    "src/features/jobs/components/JobPanel.tsx",
+    [
+      "export function JobPanel() {",
+      "  async function submitJob() {",
+      "    await fetch('/api/jobs', { method: 'POST' });",
+      "  }",
+      "  return <section>",
+      "    <button onClick={submitJob}>Submit job</button>",
+      "    <p>Job queued</p>",
+      "  </section>;",
+      "}",
+    ].join("\n") + "\n",
+  );
+  commit(root, "feat: submit a background job");
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const flow = plan.flows.find((candidate) => candidate.intentId);
+  const successSelector = flow?.selectors.find((selector) => selector.value === "Job queued");
+
+  assert.ok(flow);
+  assert.ok(successSelector, JSON.stringify(flow.selectors));
+  assert.notEqual(successSelector?.addedInDiff, true);
+  assert.match(flow.languageBrief.successSignal, /Job queued/i);
+});
+
 test("evidence-routed failure QA becomes a separate partial Playwright scenario without domain rules", async (t) => {
   const root = await makeRepo(t);
   await write(


### PR DESCRIPTION
## Intent

Separate one broad change intent into evidence-scoped QA flows when a branch changes distinct product surfaces.

- Partition flows at stable feature/domain or route boundaries.
- Keep lifecycle stages, scenarios, assertions, and success signals local to the owning surface.
- Preserve shared reverse-import evidence across sibling flows.
- Reuse an existing success message only when it is unique on the changed surface and direct diff evidence supports that file.
- Relabel residual navigation or service work from its remaining files instead of inheriting a consumed UI title.

## Agent / Review Risk

Flow count, titles, and success criteria can change for large multi-surface PRs. The split is intentionally conservative: root-level mobile screens remain one lifecycle unless a feature/domain or nested screen boundary exists, and existing success copy requires direct same-file evidence.

## Validation Evidence

- [x] `pnpm test`
- [x] `pnpm scan`
- [x] Relevant `qamap verify`, `qamap test-plan`, or `qamap e2e plan/draft` output reviewed.
- [x] `pnpm bench:ci`
- [x] `pnpm coverage`
- [x] `pnpm pack --dry-run`
- [x] `git diff --check`

Coverage: 88.93% lines, 85.58% branches, 95.87% functions. All 207 tests and all benchmark contracts pass.

## E2E / Manual Coverage

- Added a domain-neutral two-surface regression that proves Account and Credits keep separate success criteria while retaining their shared transaction service.
- Added a regression proving unchanged repository success copy can ground QA only with direct same-surface diff evidence.
- Kept the multi-screen mobile reminder lifecycle as one flow to prevent over-partitioning.
- Re-ran the full React, Vue, Svelte, Expo, API, CLI, testless, manifest, and shared-component benchmark matrix.

## Maintainer Notes

This PR does not change the package version or publish a release.

## Collaboration Checklist

- [x] The branch uses an allowed prefix and contains no coding-agent product name.
- [x] The PR title follows `Type: imperative summary`.
- [x] `@ivory-code` is assigned, or assignment is left for a maintainer when permissions do not allow it.
- [x] Exactly one `type:` label and only relevant `area:` labels are applied.
- [x] The PR is intended to be squash-merged after required checks pass.