### PR TITLE
Chore: release 0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.4.7 - 2026-07-22
+
 ### Added
 
 - Added provenance-aware base resolution across QA, review, test-plan, and E2E output. QAMap now reads explicit input, PR CI metadata, repo-local Git configuration, and Git history in order, and discloses long-lived refs that point to the same commit.

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -1,16 +1,16 @@
 # Release Validation
 
-## 0.4.7 candidate - 2026-07-22
+## 0.4.7 - 2026-07-22
 
-Validated as a decision-contract, executable-draft, exact-test-routing, public-regression, compounding-repository-context, and multi-flow agent-handoff candidate. QAMap now exposes one canonical route after it reads a change: either complete an optional automation draft or run a repository validation command. It also connects item-level actions to repository-backed prerequisites, ranks exact changed Python regression tests, adds a provenance-pinned public PR reduction, proves that one reviewed manifest correction improves both the current PR and the next related PR without another prompt, and preserves a second distinct QA flow when a large result must be compacted below the agent payload limit:
+Validated as a decision-contract, executable-draft, exact-test-routing, public-regression, compounding-repository-context, and multi-flow agent-handoff release. QAMap now exposes one canonical route after it reads a change: either complete an optional automation draft or run a repository validation command. It also connects item-level actions to repository-backed prerequisites, ranks exact changed Python regression tests, adds a provenance-pinned public PR reduction, proves that one reviewed manifest correction improves both the current PR and the next related PR without another prompt, and preserves a second distinct QA flow when a large result must be compacted below the agent payload limit:
 
 | Gate | Current result |
 | --- | --- |
-| `pnpm release:check` | Passed end to end without changing the published package version |
+| `pnpm release:check` | Passed end to end for the `0.4.7` release source |
 | `pnpm test` | 207/207 passing |
 | `pnpm scan` | 0 findings |
 | `pnpm bench:ci` | 19/19 targets pass across React, Vue, SvelteKit, Expo, JavaScript and Python API services, shared components, configuration, test-only, CLI/analyzer, and a provenance-pinned public PR reduction |
-| Coverage | Lines 88.91%, branches 85.48%, functions 95.87% |
+| Coverage | Lines 88.89%, branches 85.48%, functions 95.87% |
 | Canonical route | Agent output reports one `route.basis`, unambiguous status, next action, and exact repository command when available; the older readiness score remains compatibility detail |
 | Public PR regression | A behavior-preserving reduction of Cal.com PR #27765 recovers the edit -> validation trigger -> correction -> submit lifecycle, exact diff evidence, and related existing regression test |
 | Executable nested-action draft | In an isolated testless web repository, the generated draft filled the entity input, created the required item, exercised the diff-added item action, asserted the visible outcome, and passed 1/1 in Chromium |
@@ -19,7 +19,7 @@ Validated as a decision-contract, executable-draft, exact-test-routing, public-r
 | Framework-neutral state inference | React Hook Form timing changes are recognized only when both old and new modes occur in form-shaped evidence; an unrelated non-form `mode` change remains a negative control |
 | CLI command contract | CLI-only and mixed analyzer/package-surface changes route to repository validation such as `pnpm test` instead of a blocked product E2E draft |
 | Compact agent handoff | Every benchmark remains below 4KB while preserving the canonical route. An additional read-only large multi-surface canary found four flows and retained two distinct flows, their changed files, review questions, and success signals in 3,670 bytes instead of collapsing to only the first flow; two omitted flows remain disclosed |
-| Package preview | `pnpm pack --dry-run` and `npm pack --dry-run` pass for the unchanged `@ivorycanvas/qamap@0.4.6` candidate source; 146 files, 903.3 kB packed |
+| Package preview | `pnpm pack --dry-run` and `npm publish --dry-run --access public` pass for `@ivorycanvas/qamap@0.4.7`; 146 files, 903.5 kB packed |
 
 The public fixture records its upstream repository, pull request URL, base and head SHAs, license, and reduction method. It is not described as a verbatim repository snapshot. Its contract fails if QAMap loses the changed validation timing, exact source location, related test evidence, or the four observable state boundaries a reviewer needs to reason about the regression.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Local zero-LLM PR QA designer that maps commit intent and diffs to traceable behavior lifecycles, QA scenarios, and optional automation drafts.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const TOOL_NAME = "QAMap";
-export const VERSION = "0.4.6";
+export const VERSION = "0.4.7";


### PR DESCRIPTION
## Intent

- Set the package and CLI version to `0.4.7`.
- Record the change-based QA routing, executable evidence, final-PR context, package API, multi-surface isolation, and compact multi-flow handoff improvements in the changelog.
- Capture the final release gate and package-preview evidence without changing product behavior.

## Agent / Review Risk

- None beyond release metadata. The functional changes were reviewed and merged through #128, #129, #130, #131, and #132.
- Publishing and tag creation occur only after this release commit is merged and npm authentication succeeds.

## Validation Evidence

- [x] `pnpm test` - 207/207 passing.
- [x] `pnpm scan` - 0 findings.
- [x] Relevant `qamap qa`, compact agent output, and read-only multi-surface canary results reviewed.
- [x] `pnpm bench:ci` - 19/19 passing.
- [x] Coverage - lines 88.89%, branches 85.48%, functions 95.87%.
- [x] `npm publish --dry-run --access public --json` - 146 files, 903.5 kB packed.

## E2E / Manual Coverage

- No new product behavior is introduced by this release-only commit.
- The complete `pnpm release:check` gate passed for `@ivorycanvas/qamap@0.4.7`.
- The release evidence includes an isolated generated Playwright draft that passed 1/1 and a read-only large multi-surface handoff canary; neither changes the target-repository safety contract.

## Maintainer Notes

- Canonical release identifier: `v0.4.7`.
- Git tag, GitHub Release title, npm package, and post-publish smoke checks will be completed after merge.

## Collaboration Checklist

- [x] The branch uses an allowed prefix and contains no coding-agent product name.
- [x] The PR title follows `Type: imperative summary`.
- [x] `@ivory-code` is assigned.
- [x] Exactly one `type:` label and only relevant `area:` labels are applied.
- [x] The PR is intended to be squash-merged after required checks pass.
