### PR TITLE
Fix: keep analyzer vocabulary out of product QA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Changed
+
+- Repository test planning and changed-file inspection code now stays on the analyzer-verification path when direct product behavior evidence is absent. Supporting utility conditions no longer turn an analyzer-focused change into product automation work.
+
+### Fixed
+
+- Static matcher vocabulary, CI environment variable names, and background-service labels no longer fabricate scheduling, navigation, or conditional UI QA. Actual product scheduling and destination changes remain covered by the existing positive benchmark contracts.
+- Package root or public API exports no longer imply network timeout and retry QA without network behavior evidence.
+- Analyzer-focused changes no longer borrow unrelated mock handlers or fixture endpoints from benchmark and test directories as product E2E guidance.
+
 ## 0.4.7 - 2026-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Static matcher vocabulary, CI environment variable names, and background-service labels no longer fabricate scheduling, navigation, or conditional UI QA. Actual product scheduling and destination changes remain covered by the existing positive benchmark contracts.
 - Package root or public API exports no longer imply network timeout and retry QA without network behavior evidence.
 - Analyzer-focused changes no longer borrow unrelated mock handlers or fixture endpoints from benchmark and test directories as product E2E guidance.
+- Repository and Git context analyzers no longer surface implementation guards such as numeric finiteness checks as affected product lifecycle stages.
+- Repository-validation routes no longer report missing product E2E compilation as a required scenario gap when automation is explicitly not applicable.
+- Analyzer reasoning traces, including emergency 4KB agent output, now retain the concrete false-negative and false-positive risk instead of falling back to a generic product outcome regression.
 
 ## 0.4.7 - 2026-07-22
 

--- a/bench.config.json
+++ b/bench.config.json
@@ -315,7 +315,12 @@
         "minReasoningTraces": 3,
         "maxMissingReasoningTraces": 0,
         "maxUntraceableRequiredScenarios": 0,
-        "mustReachFiles": ["src/rules/rule-engine.ts", "src/cli.ts"],
+        "mustReachFiles": [
+          "src/rules/rule-engine.ts",
+          "src/repository-plan.ts",
+          "src/git-context.ts",
+          "src/cli.ts"
+        ],
         "mustIncludeQaScenarios": [
           "Changed analysis rule positive and negative controls",
           "Changed CLI arguments, output, and exit behavior"

--- a/bench.config.json
+++ b/bench.config.json
@@ -330,6 +330,9 @@
           "Removed guard or validation behavior",
           "Entry payload and destination routing"
         ],
+        "mustNotIncludeLifecycle": [
+          "is finite"
+        ],
         "mustNotFindEvidence": [
           "Network response setup",
           "Fixture data setup",
@@ -338,6 +341,7 @@
         "mustTraceScenarioFiles": ["src/rules/rule-engine.ts", "src/cli.ts"],
         "maxUntracedCriticalScenarios": 0,
         "maxMissingScenarioReceipts": 0,
+        "maxRequiredScenarioGaps": 0,
         "maxBlankActions": 0,
         "maxGenericTitles": 0,
         "maxAgentBytes": 4096

--- a/schema/qamap-agent.schema.json
+++ b/schema/qamap-agent.schema.json
@@ -312,7 +312,11 @@
         "compiled": { "type": "integer", "minimum": 0 },
         "partial": { "type": "integer", "minimum": 0 },
         "notCompiled": { "type": "integer", "minimum": 0 },
-        "requiredGaps": { "type": "integer", "minimum": 0 }
+        "requiredGaps": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Required scenarios missing executable draft mapping. Always 0 when automationApplicable is false because repository validation, not product E2E compilation, is the applicable route."
+        }
       }
     },
     "traceCount": {

--- a/scripts/bench.mjs
+++ b/scripts/bench.mjs
@@ -165,9 +165,7 @@ function scoreTarget(target, plan, qa, durationMs) {
     notCompiledScenarioReceipts: scenarioReceipts.filter((receipt) => receipt.status === "not-compiled").length,
     mappedScenarioSteps: scenarioReceipts.reduce((sum, receipt) => sum + receipt.mappedSteps, 0),
     mappedScenarioAssertions: scenarioReceipts.reduce((sum, receipt) => sum + receipt.mappedAssertions, 0),
-    requiredScenarioGaps: scenarioReceipts.filter(
-      (receipt) => receipt.decision === "required" && receipt.status !== "compiled"
-    ).length,
+    requiredScenarioGaps: qa.readiness.requiredScenarioGaps,
     untracedCriticalScenarios: qaScenarios.filter((scenario) =>
       scenario.priority === "critical" &&
       !scenario.evidence.some((item) =>
@@ -321,6 +319,7 @@ function evaluateContract(expect, result, plan, qa) {
   appendMissingTerms(failures, "intent title", result.intentTitles, expect.mustNameIntents);
   appendUnexpectedTerms(failures, "intent title", result.intentTitles, expect.mustNotNameIntents);
   appendMissingTerms(failures, "intent lifecycle", result.intentLifecycle, expect.mustIncludeLifecycle);
+  appendUnexpectedTerms(failures, "intent lifecycle", result.intentLifecycle, expect.mustNotIncludeLifecycle);
   appendMissingTerms(failures, "intent QA scenario", result.intentScenarios, expect.mustIncludeQaScenarios);
   appendUnexpectedTerms(failures, "intent QA scenario", result.intentScenarios, expect.mustNotIncludeQaScenarios);
   appendMissingTerms(failures, "intent evidence", result.intentEvidence, expect.mustFindIntentEvidence);

--- a/src/change-intent.ts
+++ b/src/change-intent.ts
@@ -883,7 +883,9 @@ function buildIntentQaScenarios(
     /\b(?:is|has|can|should|show|hide)[A-Z_\w]*|eligible|available|loaded|loading|empty|ready|selected/i,
     /color|theme|style|class|layout|size|width|height|dark|light/i,
   );
-  if (changedConditionEvidence.length > 0 && !/toggle|enable|disable|permission|authoriz|auth|guard/.test(searchable)) {
+  const hasUiProductEvidence = productEvidence.some(isUiBehaviorEvidence);
+  if (changedConditionEvidence.length > 0 && hasUiProductEvidence &&
+    !/toggle|enable|disable|permission|authoriz|auth|guard/.test(searchable)) {
     scenarios.push(makeScenario(intentId, "conditional-fallback", "state-transition", "recommended", "Changed conditional state and fallback", [
       "Prepare the changed condition as true and false, including loading, unknown, or empty state when the diff exposes one.",
     ], [
@@ -1019,6 +1021,12 @@ function buildIntentQaScenarios(
     const routingEvidencePattern = explicitOpenDestination
       ? /open|navigat|redirect|route|deep.?link|payload|destination/i
       : /navigat|redirect|route|deep.?link|payload|destination/i;
+    const routingEvidence = scenarioEvidenceFor(
+      productLifecycle,
+      productEvidence,
+      routingEvidencePattern,
+      /navigation\.setoptions/i,
+    );
     scenarios.push(makeScenario(intentId, "entry-routing", "failure", "critical", "Entry payload and destination routing", [
       "Prepare valid, missing, and stale entry payloads.",
     ], [
@@ -1027,15 +1035,16 @@ function buildIntentQaScenarios(
     ], [
       "Verify a valid payload opens the matching destination and state.",
       "Verify invalid context fails safely without opening unrelated data.",
-    ], ["Missing payload", "Stale identifier", "Repeated entry"], scenarioEvidenceFor(
-      productLifecycle,
-      productEvidence,
-      routingEvidencePattern,
-      /navigation\.setoptions/i,
-    )));
+    ], ["Missing payload", "Stale identifier", "Repeated entry"], routingEvidence));
   }
 
-  if (/fetch|request|network|endpoint|api|mutation|response|timeout/.test(searchable)) {
+  const networkSearchable = searchable.replace(/\b(?:export|package|public)\s+(?:root\s+)?api\b/gi, "");
+  const networkEvidence = scenarioEvidenceFor(
+    productLifecycle,
+    productEvidence,
+    /fetch|request|network|endpoint|api|mutation|response|timeout/i,
+  );
+  if (/fetch|request|network|endpoint|api|mutation|response|timeout/.test(networkSearchable)) {
     scenarios.push(makeScenario(intentId, "network-failure", "failure", "recommended", "Failure, timeout, and retry handling", [
       "Prepare success, empty, unauthorized, timeout, and server-error responses.",
     ], [
@@ -1044,7 +1053,7 @@ function buildIntentQaScenarios(
     ], [
       "Verify each response produces the intended visible or persisted state.",
       "Verify retries do not duplicate requests or side effects.",
-    ], ["Unauthorized", "Timeout", "Server error", "Duplicate retry"], scenarioEvidenceFor(productLifecycle, productEvidence, /fetch|request|network|endpoint|api|mutation|response|timeout/i)));
+    ], ["Unauthorized", "Timeout", "Server error", "Duplicate retry"], networkEvidence));
   }
 
   const shareEvidence = scenarioEvidenceFor(
@@ -1117,6 +1126,11 @@ function buildIntentQaScenarios(
     ], ["Mismatched identity", "Malformed storage", "Repeated completion", "Second tab or re-entry"], scopedStorageEvidence));
   }
 
+  const stateReentryEvidence = scenarioEvidenceFor(
+    productLifecycle,
+    productEvidence,
+    /sync|persist|storage|cache|reload|re.?entry|save|store/i,
+  );
   if (/sync|persist|storage|cache|reload|re.?entry|save|store/.test(searchable)) {
     scenarios.push(makeScenario(intentId, "state-reentry", "state-transition", "recommended", "Re-entry and stale state recovery", [
       "Prepare current and stale persisted state.",
@@ -1126,7 +1140,7 @@ function buildIntentQaScenarios(
     ], [
       "Verify the latest state survives or is invalidated intentionally.",
       "Verify stale state cannot overwrite the changed result.",
-    ], ["Stale cache", "App restart", "Repeated synchronization"], scenarioEvidenceFor(productLifecycle, productEvidence, /sync|persist|storage|cache|reload|re.?entry|save|store/i)));
+    ], ["Stale cache", "App restart", "Repeated synchronization"], stateReentryEvidence));
   }
 
   return rankIntentQaScenarios(uniqueScenarios(scenarios)).slice(0, maxQaScenariosPerIntent);
@@ -1371,12 +1385,16 @@ function collectDiffRiskEvidence(addedDiffEvidence: AddedDiffEvidence): ChangeIn
       }
       for (const [side, lines] of [["head", hunk.lines], ["base", hunk.removedLines ?? []]] as const) {
         for (const line of lines) {
+          if (isStaticVocabularyOrMetadataLine(line.text)) {
+            continue;
+          }
           const calendarMatch = line.text.match(
             /(timezone|scheduledAt|\bschedule\w*\b|\breminder\w*\b|\bcalendar\b|\btomorrow\b|\bdaily\b)/i,
           );
           const recordsCurrentTimestamp = /^timezone$/i.test(calendarMatch?.[1] ?? "") &&
             /\btimezone\.now\s*\(/i.test(line.text);
-          if (calendarMatch && !recordsCurrentTimestamp) {
+          const schedulerInfrastructure = /^scheduler$/i.test(calendarMatch?.[1] ?? "");
+          if (calendarMatch && !recordsCurrentTimestamp && !schedulerInfrastructure) {
             evidence.push(diffRiskEvidence(
               file,
               hunk,
@@ -1526,6 +1544,25 @@ function detectFormValidationTimingChange(
     return undefined;
   }
   return { before: before.mode, after: after.mode, line: after.line };
+}
+
+function isStaticVocabularyOrMetadataLine(text: string): boolean {
+  const trimmed = text.trim();
+  if (/^["'`][A-Z][A-Z0-9_]+["'`],?$/.test(trimmed)) {
+    return true;
+  }
+  return /\/(?:\\.|[^/\n]){3,}\/[dgimsuvy]*\.test\s*\(/i.test(trimmed) ||
+    /\b(?:vocabulary|pattern|matcher|regex)\w*\s*=\s*\/(?:\\.|[^/\n]){3,}\/[dgimsuvy]*/i.test(trimmed);
+}
+
+function isUiBehaviorEvidence(evidence: ChangeIntentEvidence): boolean {
+  const file = evidence.file?.replaceAll("\\", "/");
+  if (!file) {
+    return false;
+  }
+  return /\.(?:tsx|jsx|vue|svelte)$/i.test(file) ||
+    /(?:^|\/)(?:components?|pages?|screens?|views?|ui)(?:\/|$)/i.test(file) ||
+    /\.component\.ts$/i.test(file);
 }
 
 function sharingCapabilitySymbol(text: string): string | undefined {

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -2885,15 +2885,18 @@ function isCliCommandFocusedFlow(flow: Omit<E2eFlow, "languageBrief">): boolean 
 }
 
 function isAnalysisRuleFocusedFlow(flow: Omit<E2eFlow, "languageBrief">): boolean {
-  return hasOnlyAnalysisRuleDiffEvidence(flow.intentEvidence);
+  return hasAnalysisRuleFocusedDiffEvidence(flow.intentEvidence);
 }
 
-function hasOnlyAnalysisRuleDiffEvidence(evidence: ChangeIntentEvidence[] | undefined): boolean {
+function hasAnalysisRuleFocusedDiffEvidence(evidence: ChangeIntentEvidence[] | undefined): boolean {
   const locatedEvidence = (evidence ?? []).filter(
     (evidence) => evidence.kind === "diff" && evidence.sourceRole !== undefined,
   );
   return locatedEvidence.some((evidence) => evidence.sourceRole === "analysis-rule") &&
-    locatedEvidence.every((evidence) => evidence.sourceRole === "analysis-rule");
+    locatedEvidence.every((evidence) =>
+      evidence.sourceRole === "analysis-rule" ||
+      (evidence.sourceRole === "product" && evidence.relation !== "direct")
+    );
 }
 
 function inferFlowEdgeCases(flow: Omit<E2eFlow, "languageBrief">): string[] {
@@ -5732,7 +5735,7 @@ async function buildFlow(
   if (files.length === 0) {
     return undefined;
   }
-  const analysisRuleFocused = hasOnlyAnalysisRuleDiffEvidence(candidate.intentEvidence);
+  const analysisRuleFocused = hasAnalysisRuleFocusedDiffEvidence(candidate.intentEvidence);
   const coverage = candidate.coverage ?? buildCoverageTargets(candidate.kind, files, runner);
   const setupHints = analysisRuleFocused
     ? []

--- a/src/qa-trace.ts
+++ b/src/qa-trace.ts
@@ -195,6 +195,12 @@ function traceArtifact(input: QaTraceArtifactInput): QaTraceArtifact {
 
 function riskStatement(intent: ChangeIntent, scenario: IntentQaScenario): string {
   if (scenario.kind === "primary") {
+    if (hasSourceRole(scenario.evidence, intent.evidence, "analysis-rule")) {
+      return "The changed analyzer may miss intended evidence or report unrelated behavior as a finding.";
+    }
+    if (hasSourceRole(scenario.evidence, intent.evidence, "command")) {
+      return "The changed command may accept invalid input or produce incorrect output, artifacts, or exit status.";
+    }
     return `The changed behavior "${intent.title}" may not reach its intended observable outcome.`;
   }
   if (scenario.kind === "failure") {
@@ -204,6 +210,16 @@ function riskStatement(intent: ChangeIntent, scenario: IntentQaScenario): string
     return `${scenario.title} may produce a result outside the intended boundary.`;
   }
   return `${scenario.title} may leave stale or inconsistent state after the change.`;
+}
+
+function hasSourceRole(
+  scenarioEvidence: ChangeIntentEvidence[],
+  intentEvidence: ChangeIntentEvidence[],
+  role: ChangeIntentEvidence["sourceRole"],
+): boolean {
+  const locatedScenarioEvidence = scenarioEvidence.filter((item) => item.kind === "diff" && item.file);
+  const evidence = locatedScenarioEvidence.length > 0 ? locatedScenarioEvidence : intentEvidence;
+  return evidence.some((item) => item.sourceRole === role);
 }
 
 function strongestTraceEvidence(evidence: ChangeIntentEvidence[], limit: number): ChangeIntentEvidence[] {

--- a/src/qa.ts
+++ b/src/qa.ts
@@ -236,6 +236,7 @@ function buildQaReadiness(
   }
   return {
     ...readiness,
+    requiredScenarioGaps: 0,
     basis: "repository-validation",
     automationApplicable: false,
     verificationStatus: suggestedCommands.length > 0 ? "ready-to-run" : "command-needed",
@@ -645,7 +646,10 @@ function serializeAgentSummary(summary: AgentSummaryShape): string {
     risk: trace.risk
       ? {
           kind: trace.risk.kind,
-          statement: compactAgentRiskStatement(trace.risk.kind),
+          statement: truncateForAgent(
+            String(trace.risk.statement ?? compactAgentRiskStatement(trace.risk.kind)),
+            90,
+          ),
         }
       : undefined,
     scenario: trace.scenario

--- a/src/source-role.ts
+++ b/src/source-role.ts
@@ -84,13 +84,16 @@ function isAnalysisRuleSource(file: string, text: string): boolean {
   const vocabularyRuleSignal = /\b(?:analyzeEvidence|collect\w*Evidence|\w+Vocabulary|evidencePattern|rulePattern)\b/i.test(text);
   const ruleStructure = /\bRegExp\b|\.match(?:All)?\s*\(|\.test\s*\(|(?:^|\s)\/(?:\\.|[^/\n]){3,}\/\w*|mustNot|mustFind|pattern/i.test(text);
   const analyzerContractStructure = /\b(?:AddedDiffEvidence|ChangeIntentEvidence|QaReasoningTrace|build\w*(?:Trace|Evidence|Scenario)|collectAddedDiffEvidence|route\w*Scenario|scenarioAutomation|classifyChangeSourceRole|intent\.scenarios|trace\.scenario|routingReason)\b/i.test(text);
+  const qaPlanningStructure = /\b(?:TestPlanResult|TestPlanChangedFile|suggestedCommands|discoverSuggestedCommands|discoverRelevant\w*Tests|automationApplicable|verificationStatus)\b/i.test(text);
+  const repositoryAnalysisStructure = /\b(?:collectChangedFiles|resolveBaseRef|resolveMergeBase|BaseRefResolution|GitChangedFile|ChangedFilesOptions)\b/i.test(text);
   const analyzerSchema = /(?:^|\/)(?:schemas?|contracts?)(?:\/|$)/i.test(file) &&
     /\b(?:analysis-rule|qamap\.qa|reasoning trace|qa scenario)\b/i.test(text);
   if (analyzerSchema) {
     return true;
   }
   return (pathSignal && (staticAnalysisSignal || vocabularyRuleSignal || analyzerContractStructure)) ||
-    (staticAnalysisSignal && (ruleStructure || analyzerContractStructure));
+    (staticAnalysisSignal && (ruleStructure || analyzerContractStructure)) ||
+    (qaPlanningStructure && repositoryAnalysisStructure);
 }
 
 function isConfigurationPath(file: string): boolean {

--- a/src/source-role.ts
+++ b/src/source-role.ts
@@ -86,6 +86,7 @@ function isAnalysisRuleSource(file: string, text: string): boolean {
   const analyzerContractStructure = /\b(?:AddedDiffEvidence|ChangeIntentEvidence|QaReasoningTrace|build\w*(?:Trace|Evidence|Scenario)|collectAddedDiffEvidence|route\w*Scenario|scenarioAutomation|classifyChangeSourceRole|intent\.scenarios|trace\.scenario|routingReason)\b/i.test(text);
   const qaPlanningStructure = /\b(?:TestPlanResult|TestPlanChangedFile|suggestedCommands|discoverSuggestedCommands|discoverRelevant\w*Tests|automationApplicable|verificationStatus)\b/i.test(text);
   const repositoryAnalysisStructure = /\b(?:collectChangedFiles|resolveBaseRef|resolveMergeBase|BaseRefResolution|GitChangedFile|ChangedFilesOptions)\b/i.test(text);
+  const repositoryContextPath = /(?:^|\/)(?:git|repo(?:sitory)?)(?:[-_.](?:context|analysis|diff|history|base|change(?:d)?-?files?))?(?:\.[^/]+)?$/i.test(file);
   const analyzerSchema = /(?:^|\/)(?:schemas?|contracts?)(?:\/|$)/i.test(file) &&
     /\b(?:analysis-rule|qamap\.qa|reasoning trace|qa scenario)\b/i.test(text);
   if (analyzerSchema) {
@@ -93,7 +94,7 @@ function isAnalysisRuleSource(file: string, text: string): boolean {
   }
   return (pathSignal && (staticAnalysisSignal || vocabularyRuleSignal || analyzerContractStructure)) ||
     (staticAnalysisSignal && (ruleStructure || analyzerContractStructure)) ||
-    (qaPlanningStructure && repositoryAnalysisStructure);
+    (repositoryAnalysisStructure && (qaPlanningStructure || repositoryContextPath));
 }
 
 function isConfigurationPath(file: string): boolean {

--- a/test/benchmarks/cli-analysis-rules/base/src/git-context.ts
+++ b/test/benchmarks/cli-analysis-rules/base/src/git-context.ts
@@ -1,0 +1,1 @@
+export const baseVariables = ["GITHUB_BASE_REF"];

--- a/test/benchmarks/cli-analysis-rules/base/src/repository-plan.ts
+++ b/test/benchmarks/cli-analysis-rules/base/src/repository-plan.ts
@@ -1,0 +1,7 @@
+export interface TestPlanResult {
+  suggestedCommands: string[];
+}
+
+export function collectChangedFiles(): string[] {
+  return [];
+}

--- a/test/benchmarks/cli-analysis-rules/base/test/benchmarks/unrelated/src/mocks/handlers.ts
+++ b/test/benchmarks/cli-analysis-rules/base/test/benchmarks/unrelated/src/mocks/handlers.ts
@@ -1,0 +1,3 @@
+export const handlers = [
+  http.get("/api/orders", () => HttpResponse.json({ orders: [] })),
+];

--- a/test/benchmarks/cli-analysis-rules/head/src/git-context.ts
+++ b/test/benchmarks/cli-analysis-rules/head/src/git-context.ts
@@ -1,0 +1,11 @@
+export const baseVariables = [
+  "GITHUB_BASE_REF",
+  "BITBUCKET_PR_DESTINATION_BRANCH",
+];
+
+export function resolveBaseRef(value: string): string {
+  if (!Number.isFinite(value.length)) {
+    throw new Error("invalid ref");
+  }
+  return value;
+}

--- a/test/benchmarks/cli-analysis-rules/head/src/repository-plan.ts
+++ b/test/benchmarks/cli-analysis-rules/head/src/repository-plan.ts
@@ -1,0 +1,13 @@
+export interface TestPlanResult {
+  suggestedCommands: string[];
+  changedFiles: string[];
+}
+
+export function collectChangedFiles(): string[] {
+  return [];
+}
+
+export function discoverSuggestedCommands(serviceName: string): string[] {
+  const backgroundService = /(?:worker|scheduler|consumer)/i.test(serviceName);
+  return backgroundService ? [] : ["test"];
+}

--- a/test/change-intent.test.mjs
+++ b/test/change-intent.test.mjs
@@ -596,6 +596,13 @@ test("source roles distinguish product behavior from commands and analysis rules
   );
   assert.equal(
     classifyChangeSourceRole(
+      "src/repository-plan.ts",
+      "export interface TestPlanResult { suggestedCommands: string[] }\nexport function collectChangedFiles(): GitChangedFile[] { return []; }",
+    ).role,
+    "analysis-rule",
+  );
+  assert.equal(
+    classifyChangeSourceRole(
       "src/qa-trace.ts",
       "export function buildReasoningTrace(intent, evidence) { return routeQaScenario(intent.scenarios[0]); }",
     ).role,
@@ -805,6 +812,82 @@ test("analysis-only changes stay analyzer verification even inside a CLI reposit
   assert.equal(typeof compactSummary.flows[0].reviewQuestion, "string");
   assert.equal(typeof compactSummary.flows[0].successSignal, "string");
   assert.ok(compactSummary.flows[0].steps.length > 0);
+});
+
+test("repository analysis plumbing does not become product boundary QA", async (t) => {
+  const root = await makeRepo(t);
+  await write(
+    root,
+    "package.json",
+    JSON.stringify({ name: "change-inspector", type: "module", bin: { inspect: "dist/cli.js" } }),
+  );
+  await write(
+    root,
+    "src/repository-plan.ts",
+    [
+      "export interface TestPlanResult { suggestedCommands: string[] }",
+      "export function collectChangedFiles(): string[] { return []; }",
+    ].join("\n"),
+  );
+  await write(root, "src/git-context.ts", "export const baseVariables = ['GITHUB_BASE_REF'];\n");
+  commit(root, "benchmark baseline");
+  branch(root, "fix/repository-analysis");
+  await write(
+    root,
+    "src/repository-plan.ts",
+    [
+      "export interface TestPlanResult { suggestedCommands: string[]; changedFiles: string[] }",
+      "export function collectChangedFiles(): string[] { return []; }",
+      "export function discoverSuggestedCommands(serviceName: string): string[] {",
+      "  const backgroundService = /(?:worker|scheduler|consumer)/i.test(serviceName);",
+      "  return backgroundService ? [] : ['test'];",
+      "}",
+    ].join("\n"),
+  );
+  await write(
+    root,
+    "src/git-context.ts",
+    [
+      "export const baseVariables = [",
+      "  'GITHUB_BASE_REF',",
+      "  'BITBUCKET_PR_DESTINATION_BRANCH',",
+      "];",
+      "export function resolveBaseRef(value: string) {",
+      "  if (!Number.isFinite(value.length)) throw new Error('invalid ref');",
+      "  return value;",
+      "}",
+    ].join("\n"),
+  );
+  commit(root, "fix: improve repository analysis command discovery");
+
+  const analysis = await analyze(root, ["src/repository-plan.ts", "src/git-context.ts"]);
+  const titles = analysis.intents.flatMap((intent) => intent.scenarios.map((scenario) => scenario.title));
+
+  assert.ok(analysis.intents.flatMap((intent) => intent.evidence).some((item) => item.sourceRole === "analysis-rule"));
+  assert.ok(titles.some((title) => /analysis rule positive and negative controls/i.test(title)));
+  assert.equal(titles.some((title) => /Scheduling, calendar/i.test(title)), false);
+  assert.equal(titles.some((title) => /Destination path|destination routing/i.test(title)), false);
+  assert.equal(titles.some((title) => /Changed conditional state and fallback/i.test(title)), false);
+  assert.equal(titles.some((title) => /Failure, timeout, and retry handling/i.test(title)), false);
+});
+
+test("package API exports do not imply network failure QA", async (t) => {
+  const root = await makeRepo(t);
+  await write(root, "src/index.ts", "export { parseRecord } from './record.js';\n");
+  commit(root, "benchmark baseline");
+  branch(root, "fix/package-api");
+  await write(
+    root,
+    "src/index.ts",
+    "export { parseRecord, formatRecord } from './record.js';\n",
+  );
+  commit(root, "fix: export package root API");
+
+  const analysis = await analyze(root, ["src/index.ts"]);
+  const titles = analysis.intents.flatMap((intent) => intent.scenarios.map((scenario) => scenario.title));
+
+  assert.ok(analysis.intents.some((intent) => /export package root API/i.test(intent.title)));
+  assert.equal(titles.some((title) => /Failure, timeout, and retry handling/i.test(title)), false);
 });
 
 test("change intent ignores release-only commit metadata", async (t) => {

--- a/test/change-intent.test.mjs
+++ b/test/change-intent.test.mjs
@@ -603,6 +603,13 @@ test("source roles distinguish product behavior from commands and analysis rules
   );
   assert.equal(
     classifyChangeSourceRole(
+      "src/git-context.ts",
+      "export function resolveBaseRef(value: string) { if (!Number.isFinite(value.length)) throw new Error('invalid ref'); return value; }",
+    ).role,
+    "analysis-rule",
+  );
+  assert.equal(
+    classifyChangeSourceRole(
       "src/qa-trace.ts",
       "export function buildReasoningTrace(intent, evidence) { return routeQaScenario(intent.scenarios[0]); }",
     ).role,
@@ -769,6 +776,10 @@ test("analysis-only changes stay analyzer verification even inside a CLI reposit
   assert.equal(qa.readiness.basis, "repository-validation");
   assert.equal(qa.readiness.automationApplicable, false);
   assert.equal(qa.readiness.verificationStatus, "command-needed");
+  assert.equal(qa.readiness.requiredScenarioGaps, 0);
+  assert.ok(qa.traces.some((trace) =>
+    /miss intended evidence or report unrelated behavior/i.test(trace.risk.statement),
+  ));
   assert.equal(qa.flows[0].why.some((reason) => /positive, negative, and neighboring-rule controls/i.test(reason)), true);
   assert.equal(qa.prChecklist.some((item) => /manifest init/i.test(item)), false);
   assert.match(qaMarkdown, /Repository verification stage: validation command needed/);
@@ -804,8 +815,10 @@ test("analysis-only changes stay analyzer verification even inside a CLI reposit
   assert.equal(compactSummary.route.status, "verification-command-needed");
   assert.equal(compactSummary.route.nextAction, "define-repository-command");
   assert.equal(compactSummary.scenarioCoverage.automationApplicable, false);
+  assert.equal(compactSummary.scenarioCoverage.requiredGaps, 0);
   assert.ok(compactSummary.traces.length > 0);
   assert.equal(typeof compactSummary.traces[0].source.file, "string");
+  assert.match(compactSummary.traces[0].risk.statement, /miss intended evidence or report unrelated behavior/i);
   assert.ok(compactSummary.intents[0].scenarios[0].sources.length > 0);
   assert.equal(compactSummary.flows[0].source, qa.flows[0].source);
   assert.ok(compactSummary.flows[0].changedFiles.length > 0);
@@ -862,8 +875,18 @@ test("repository analysis plumbing does not become product boundary QA", async (
 
   const analysis = await analyze(root, ["src/repository-plan.ts", "src/git-context.ts"]);
   const titles = analysis.intents.flatMap((intent) => intent.scenarios.map((scenario) => scenario.title));
+  const lifecycleLabels = analysis.intents.flatMap((intent) =>
+    intent.lifecycle.map((stage) => stage.label),
+  );
+  const gitContextEvidence = analysis.intents
+    .flatMap((intent) => intent.evidence)
+    .filter((item) => item.file === "src/git-context.ts");
 
   assert.ok(analysis.intents.flatMap((intent) => intent.evidence).some((item) => item.sourceRole === "analysis-rule"));
+  assert.ok(gitContextEvidence.length > 0);
+  assert.ok(gitContextEvidence.every((item) => item.sourceRole === "analysis-rule"));
+  assert.equal(lifecycleLabels.some((label) => /\bis finite\b/i.test(label)), false);
+  assert.ok(lifecycleLabels.some((label) => /positive and negative controls/i.test(label)));
   assert.ok(titles.some((title) => /analysis rule positive and negative controls/i.test(title)));
   assert.equal(titles.some((title) => /Scheduling, calendar/i.test(title)), false);
   assert.equal(titles.some((title) => /Destination path|destination routing/i.test(title)), false);


### PR DESCRIPTION
## Intent

Prevent analyzer implementation vocabulary and unrelated repository fixtures from being promoted into product QA. Keep the reasoning path internally consistent when repository validation, rather than product E2E compilation, is the applicable next step.

The same `v0.4.6..v0.4.7` self-analysis now keeps exact diff provenance and `pnpm test` while removing fabricated scheduling, routing, conditional UI, network retry, `/api/orders` fixture guidance, and the implementation-only `Check is finite` lifecycle.

## Agent / Review Risk

Source-role, lifecycle, trace compaction, and repository-validation readiness heuristics changed. The main risk is over-suppressing real product QA or hiding a genuine required automation gap.

Existing web/mobile scheduling, routing, conditional-state, API fixture, and review-only context controls remain covered by the full suite and the 19-target benchmark. The analyzer fixture now explicitly rejects implementation-only lifecycle text and requires zero automation gaps on a repository-validation route.

## Validation Evidence

- [x] `pnpm test` (209 passed)
- [x] `pnpm scan` (0 findings)
- [x] Relevant `qamap qa` output reviewed against the real `v0.4.6..v0.4.7` range
- [x] `pnpm bench:ci` (19/19 contracts)
- [x] `pnpm coverage` (lines 88.84%, branches 85.43%, functions 95.84%)
- [x] `pnpm pack --dry-run`
- [x] `git diff --check`

## E2E / Manual Coverage

No product E2E was run because this is analyzer verification. QAMap was re-run against its real `v0.4.6..v0.4.7` range.

- Scenario count remains reduced from 9 to 5.
- `pnpm test` remains the selected repository validation.
- False product-boundary and unrelated fixture guidance remain absent.
- The leading lifecycle no longer exposes `Number.isFinite` as product behavior.
- `automationApplicable: false` now pairs with `requiredGaps: 0`.
- The compact trace retains the concrete risk that the analyzer may miss intended evidence or report unrelated behavior.

The neutral benchmark retains real scheduling/routing positive controls plus analyzer and unrelated-mock negative controls.

## Maintainer Notes

No private repository names or domain-specific rules are included. Static `qa` remains read-only and reports execution as `not-run`. No release is included in this PR.

## Collaboration Checklist

- [x] The branch uses an allowed prefix and contains no coding-agent product name.
- [x] The PR title follows `Type: imperative summary`.
- [x] `@ivory-code` is assigned, or assignment is left for a maintainer when permissions do not allow it.
- [x] Exactly one `type:` label and only relevant `area:` labels are applied.
- [x] The PR is intended to be squash-merged after required checks pass.
