### PR TITLE
Chore: release v0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.4.8 - 2026-07-27
+
 ### Added
 
 - Added optional JS/TS symbol QA annotations through `@qamapFlow`, `@qamapStage`, `@qamapOutcome`, and `@qamapRisk`. QAMap applies them only when the attached named export overlaps the diff, preserves the changed line as routing evidence, and reports malformed or stale annotations instead of silently trusting them.

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -1,8 +1,8 @@
 # Release Validation
 
-## Unreleased
+## 0.4.8 - 2026-07-27
 
-The next patch candidate adds the first CI-enforced seeded-regression execution contracts. QAMap generates browser artifacts from repeated-action and persisted-state changes, then proves that each artifact fails for its intended assertion when the behavior is broken and passes again when the fixed source is restored:
+QAMap 0.4.8 adds the first CI-enforced seeded-regression execution contracts. QAMap generates browser artifacts from repeated-action and persisted-state changes, then proves that each artifact fails for its intended assertion when the behavior is broken and passes again when the fixed source is restored:
 
 | Gate | Current result |
 | --- | --- |
@@ -11,9 +11,9 @@ The next patch candidate adds the first CI-enforced seeded-regression execution 
 | `pnpm scan` | 0 findings |
 | `pnpm bench:ci` | 22/22 static recommendation contracts passing |
 | `pnpm bench:execution` | 2/2 execution contracts passing; duplicate-request and missing-persistence regressions caught; fixed sources report `2 passed` and `1 passed` |
-| Coverage | Lines 89.29%, branches 85.90%, functions 95.76% |
+| Coverage | Lines 89.29%, branches 85.91%, functions 95.76% |
 | Compact agent handoff | Current branch output is 4,082 bytes, retains three detected flows with one disclosed omission, and keeps execution explicitly `not-run` |
-| Package preview | `pnpm pack --dry-run` passes for `@ivorycanvas/qamap@0.4.7`; version remains unchanged until release approval |
+| Package preview | `pnpm pack --dry-run` passes for `@ivorycanvas/qamap@0.4.8` |
 
 The execution result is intentionally scoped to committed public fixtures. It does not claim that QAMap executed or passed QA in a user's repository. Its value is narrower and measurable: evidence-compiled tests can distinguish known broken implementations from their fixes, and an unrelated setup failure cannot be counted as a caught regression. SHA-256 checks also prevent regeneration from silently changing the test between comparisons.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Local zero-LLM PR QA designer that maps commit intent and diffs to traceable behavior lifecycles, QA scenarios, and optional automation drafts.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const TOOL_NAME = "QAMap";
-export const VERSION = "0.4.7";
+export const VERSION = "0.4.8";


### PR DESCRIPTION
## Intent

Finalize the verified package version, changelog, and release evidence for QAMap v0.4.8.

## Agent / Review Risk

Low. This PR changes release metadata only and preserves the existing CLI, schema, and safety contracts.

## Validation Evidence

- [x] `pnpm test` (250/250)
- [x] `pnpm scan` (0 findings)
- [x] `pnpm bench:execution` (2/2 contracts; 2 seeded regressions caught)
- [x] Relevant QAMap output reviewed through `pnpm release:check`.
- [x] `pnpm bench:ci` (22/22)
- [x] Coverage: lines 89.29%, branches 85.91%, functions 95.76%
- [x] `pnpm pack --dry-run`

## E2E / Manual Coverage

The release gate generated each browser artifact once, caught repeated-action and persisted-state regressions with the unchanged artifacts, and passed both fixed fixtures. No new product behavior is introduced by this metadata-only PR.

## Maintainer Notes

After merge, publish `@ivorycanvas/qamap@0.4.8`, create annotated tag `v0.4.8`, and create a GitHub Release titled exactly `v0.4.8`.

## Collaboration Checklist

- [x] The branch uses an allowed prefix and contains no coding-agent product name.
- [x] The PR title follows `Type: imperative summary`.
- [x] `@ivory-code` is assigned.
- [x] Exactly one `type:` label and only relevant `area:` labels are applied.
- [x] The PR is intended to be squash-merged after required checks pass.