### PR TITLE
Feat: ship the agent plugin contract

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "qamap",
+  "version": "0.4.8",
+  "description": "Turn PR changes into traceable local QA decisions and optional automation handoffs without an LLM call.",
+  "author": {
+    "name": "IvoryCanvas",
+    "url": "https://github.com/IvoryCanvas"
+  },
+  "homepage": "https://github.com/IvoryCanvas/QAMap#readme",
+  "repository": "https://github.com/IvoryCanvas/QAMap",
+  "license": "MIT",
+  "keywords": [
+    "qa",
+    "pull-request",
+    "local-first",
+    "agent-skill",
+    "e2e"
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,32 @@
+{
+  "name": "qamap",
+  "version": "0.4.8",
+  "description": "Turn PR changes into traceable local QA decisions and optional automation handoffs without an LLM call.",
+  "author": {
+    "name": "IvoryCanvas",
+    "url": "https://github.com/IvoryCanvas"
+  },
+  "homepage": "https://github.com/IvoryCanvas/QAMap#readme",
+  "repository": "https://github.com/IvoryCanvas/QAMap",
+  "license": "MIT",
+  "keywords": [
+    "qa",
+    "pull-request",
+    "local-first",
+    "agent-skill",
+    "e2e"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "QAMap",
+    "shortDescription": "Find what a PR needs to prove before merge.",
+    "longDescription": "Map commit and diff evidence to affected behavior, routed QA scenarios, and optional local automation without uploading source code.",
+    "developerName": "IvoryCanvas",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive"
+    ],
+    "websiteURL": "https://github.com/IvoryCanvas/QAMap",
+    "defaultPrompt": "Analyze the current PR with QAMap and carry out the safest evidence-backed QA action."
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,17 @@
 
 - Added an evidence-gated validation-recovery compiler. When a diff-backed form timing change connects to a route, validated input, visible error, submit action, and visible success result, QAMap now compiles both a valid submission path and an invalid-input, correction, and stale-error recovery scenario.
 - Added a third seeded-regression execution contract that requires the byte-identical generated browser artifact to fail when corrected input leaves stale validation feedback and pass when first-touch revalidation is restored.
+- Added native Codex and Claude Code plugin manifests that expose the existing vendor-neutral `qamap-pr-qa` skill without duplicating the local analysis engine.
+- Added Codex skill presentation metadata and a plugin contract test that keeps both host manifests, the npm package, and the shared skill version aligned.
 
 ### Changed
 
 - Form validation timing detection now reads the changed hunk and uses word-bounded form context, preserving framework-neutral React and Vue cases without treating unrelated format-mode vocabulary as product validation QA.
+- The agent skill now converts `route.nextAction` into exactly one immediate action and reports later command execution separately from QAMap's static `not-run` receipt.
+- `qamap init --agent` now installs the complete skill bundle, including optional host metadata, while continuing to preserve locally modified skill files unless `--force` is explicit.
+- QA handoffs now prefer test contracts changed by the current PR over broader historical filename or keyword matches, while keeping unrelated changed tests out of individual flow evidence.
+- Changed-test contract extraction now ignores test-like source strings embedded inside fixture builders instead of reporting them as executable repository tests.
+- Compact agent handoffs now retain one repository test-evidence path for secondary affected flows instead of dropping that trace during the 4KB payload reduction.
 
 ## 0.4.8 - 2026-07-27
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,7 @@ git tag -a v0.4.1 -m v0.4.1
 ```
 
 Do not add a product name, subtitle, or alternate version tag. Package versions, the CLI version constant, the changelog, Git tag, and GitHub Release must agree.
+The native `.codex-plugin/plugin.json` and `.claude-plugin/plugin.json` versions must match the npm package version as well.
 
 ## Good First Contributions
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ npx --yes skills add IvoryCanvas/QAMap --skill qamap-pr-qa
 
 Or run `qamap init --agent` to add the repo instructions and install the same packaged skill for `.agents/skills` consumers and Claude Code. See the [agent format contract](docs/agent-format.md) and [agent skill guide](docs/agent-skill.md).
 
+QAMap also ships native Codex and Claude Code plugin manifests. Both expose the same `qamap-pr-qa` skill and call the same local CLI; there is no second prompt or analysis engine. The manifests are ready for source-checkout validation while public marketplace distribution remains a separate release step.
+
 Tools that embed QAMap can consume the same public contract without launching a shell:
 
 ```js

--- a/docs/agent-skill.md
+++ b/docs/agent-skill.md
@@ -25,6 +25,8 @@ It performs four idempotent steps:
 
 Both skill copies preserve local changes unless you explicitly pass `--force`. After setup, agents that read `AGENTS.md` or either project-skill location can discover the same QA workflow without receiving a different prompt contract. The rest of this document explains what that pass does and how to wire it manually on other agent surfaces.
 
+The installed skill bundle also carries optional Codex presentation metadata. QAMap keeps that metadata beside the same `SKILL.md`; it does not create a second workflow for another host.
+
 ## Recommended Agent Step
 
 Run this before writing a PR body or asking for review. Agents should prefer the compact agent format — one minified JSON object (about 2 KB for a typical small PR) instead of a long report:
@@ -75,11 +77,19 @@ cat skills/qamap-pr-qa/SKILL.md
 
 If your agent supports symlinked skills, point its skill directory at `skills/qamap-pr-qa`. If it only supports instruction text, copy the contents of `SKILL.md` into that system's reusable instruction format.
 
-## Plugin Boundary
+## Native Plugin Boundary
 
-The local skill is the integration contract. It invokes the installed or one-off QAMap CLI, consumes the versioned agent JSON, and asks the host LLM to inspect only the evidence it still needs. QAMap itself does not call an LLM or upload repository source.
+The repository now includes native `.codex-plugin/plugin.json` and `.claude-plugin/plugin.json` manifests. Both discover the same `skills/qamap-pr-qa/SKILL.md`, which invokes the installed or one-off QAMap CLI and consumes the versioned agent JSON. QAMap itself does not call an LLM or upload repository source.
 
-A future installable plugin should package this same skill without creating a second QA prompt or analysis engine. It does not need an MCP server merely to execute QAMap: the CLI already runs inside the checked-out repository. An MCP layer is justified only if a separate host cannot launch local commands, and it must preserve the same `qamap.qa` schema and local-first boundary.
+These manifests are thin distribution wrappers, not another QA implementation. They intentionally add no MCP server, background monitor, or automatic hook: the CLI already runs inside the checked-out repository, and an agent must not silently install a runner or claim product QA passed.
+
+From a source checkout, validate the Claude Code manifest without invoking a model:
+
+```sh
+claude plugin validate .
+```
+
+For a local Claude Code session, the same checkout can be loaded with `claude --plugin-dir .`. Codex plugin validation and marketplace packaging use `.codex-plugin/plugin.json`. Public marketplace availability is not implied by the presence of either manifest; until a listing is published, `qamap init --agent` and the portable skill install remain the stable onboarding paths.
 
 ## What The Agent Should Do With The Output
 
@@ -95,6 +105,8 @@ Use `Change Intent Evidence` and the `PR Comment Draft` as review context:
 - missing fixture, selector, or assertion evidence
 - optional automation adapter selected only after QA design
 - PR checklist items
+
+The host agent must choose one `route.nextAction`, verify the strongest source first, and report any command it actually ran as a separate execution receipt. Static QAMap output always begins as `not-run`.
 
 If the command says a generated recommendation is wrong, do not keep re-prompting the agent with the same context. Update the repo-local manifest after human review:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -65,11 +65,15 @@ The tarball must include runtime output, public documentation, schemas, and pack
 - `dist`
 - `docs`
 - `skills`
+- `.codex-plugin`
+- `.claude-plugin`
 - `schema`
 - `README.md`
 - `CHANGELOG.md`
 - `LICENSE`
 - `package.json`
+
+The package version, CLI version constant, and both native plugin manifest versions must match before publication.
 
 The tarball should not include local run history, generated temporary output, private smoke artifacts, or dependency folders.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,7 +47,8 @@ There is no fixed end date or patch count for `0.4.x`. QAMap will remain on comp
 - Expose one canonical machine route that survives payload compaction and tells agents whether to complete a draft, run an existing command, or define missing repository validation. Compatibility scores must never be the only applicable decision.
 - Make `qa` the primary product surface. Its first screen and `--format agent` payload must agree on change intent, lifecycle, QA scenarios, affected behavior, repository evidence, draft path, and missing trust requirements.
 - Keep `qa --format agent` below 4KB without dropping the highest-priority intent, routed scenarios, primary affected flow, a compact second flow for multi-surface changes, and omitted counts needed for an agent handoff.
-- Keep one vendor-neutral QAMap skill source, install it through the open `.agents/skills` project path plus explicit compatibility paths, and make any future plugin a thin distribution wrapper around the same local CLI and `qamap.qa` contract.
+- Keep one vendor-neutral QAMap skill source, install it through the open `.agents/skills` project path plus explicit compatibility paths, and keep native Codex and Claude Code plugin manifests as thin distribution wrappers around the same local CLI and `qamap.qa` contract.
+- Measure the complete agent handoff: skill discovery, invocation, schema parsing, strongest-source verification, one canonical next action, and an execution receipt that remains separate from static analysis.
 - Improve changed-file impact mapping from shared symbols and components to consuming routes, screens, API contracts, and manifest flows.
 - Keep directly changed routes and screens ahead of reverse-import consumers, so a shared type edit cannot replace the touched product surface with unrelated pages.
 - Automatically use one changed declared workspace package for `qa`, while retaining repository-wide analysis for cross-package, root-spanning, undeclared, or unknown-package changes. Expose that decision to humans and agents instead of requiring a second manual discovery pass.
@@ -79,7 +80,7 @@ There is no fixed end date or patch count for `0.4.x`. QAMap will remain on comp
 - Add stronger deterministic draft adapters for Playwright and Maestro while keeping `manual` output for API, CLI, token, and catalog repositories; runner detection itself is not a product success metric.
 - Expand the public benchmark corpus with package-scoped monorepos, auth/session changes, dynamic routes, API failure fixtures, and non-JavaScript services.
 - Keep the `--format agent` output a stable, versioned contract that skills and MCP wrappers can rely on.
-- Continue expanding agent surface detection across popular coding-agent tools without making the public workflow depend on a single vendor.
+- Continue expanding agent surface detection and real-host compatibility across popular coding-agent tools without making the public workflow depend on a single vendor.
 
 These items do not imply that the next completed item triggers a minor release. Analyzer improvements, new deterministic scenarios, stronger adapters, and additional benchmark fixtures continue as `0.4.x` patches when they preserve the public CLI, schema, and safety contracts. A `0.5.0` candidate should be considered only when policy-controlled execution is useful across unrelated repositories, the target repository remains unmodified by default, and normalized evidence is stable enough to document as a new public capability.
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "qamap": "dist/cli.js"
   },
   "files": [
+    ".codex-plugin",
+    ".claude-plugin",
     "dist",
     "docs",
     "skills",

--- a/skills/qamap-pr-qa/SKILL.md
+++ b/skills/qamap-pr-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qamap-pr-qa
-description: Local zero-LLM PR QA workflow. Use when an agent is preparing, updating, or reviewing a pull request and needs to derive commit-backed change intent, behavior lifecycle, runner-independent QA scenarios, affected flows, automation drafts, missing evidence, and optional manifest repair guidance without calling a cloud service or LLM.
+description: Local zero-LLM PR QA workflow. Use when an agent is preparing, updating, finalizing, or reviewing a pull request, asks what the PR should test, or needs commit-backed change intent, affected behavior, QA scenarios, evidence, validation commands, optional automation drafts, and manifest repair guidance.
 ---
 
 # QAMap PR QA
@@ -47,14 +47,27 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
    - `automation` — an optional adapter handoff. It is not required to use the QA judgment.
    - `prChecklist[]` and `commands[]` — checklist lines and validation commands for the handoff.
 
-5. Only after a human or team accepts the scenario and automation adapter, create or preview executable coverage:
+5. Follow the `route.nextAction` contract:
+   - `run-repository-command` — run the exact existing `route.command` from the selected analysis scope when permissions allow.
+   - `define-repository-command` — do not invent a passing command. Report the missing repository validation contract.
+   - `review-and-run-draft` — preview the printed `automation.draftCommand` first. Write or execute the draft only after the scenario and adapter are accepted.
+   - `complete-draft-evidence` — report the first required evidence gap. Do not install a runner or fabricate a selector, fixture, action, or assertion.
+6. Only after a human or team accepts the scenario and automation adapter, create or preview executable coverage:
 
    ```sh
-   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@latest -- qamap e2e draft . --base <base> --head HEAD
+   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@latest -- qamap e2e draft . --base <base> --head HEAD --dry-run
    ```
 
    If the selected adapter is absent, inspect and explicitly accept the `automation.setupCommand` proposal. Never install a runner merely because QAMap detected a web or mobile surface.
-6. Include the useful parts in the PR body, review note, or handoff summary.
+7. Include the useful parts in the PR body, review note, or handoff summary.
+
+## Agent Action Contract
+
+- Choose exactly one immediate next action from `route.nextAction`. Do not dump every possible command on the user.
+- Verify the strongest scenario source before acting. If it has no exact diff location or is marked `reviewRequired`, ask one precise question instead of generating code.
+- Treat QAMap's `execution.status: "not-run"` as authoritative. Only a command that this agent actually ran can produce a pass, fail, blocked, or not-verifiable receipt.
+- Report QAMap analysis and later command execution as separate facts. A generated or structurally runnable draft is not a passing test.
+- Never modify a shared manifest automatically. Present the proposed correction target and require human approval.
 
 ## Output Rules
 
@@ -91,6 +104,8 @@ QAMap QA
 - Affected flow:
 - Suggested E2E/checklist:
 - Missing evidence:
-- Validation command:
+- Selected next action:
+- Action taken:
+- Execution receipt: not run | passed | failed | blocked | not verifiable
 - Manifest repair needed:
 ```

--- a/skills/qamap-pr-qa/agents/openai.yaml
+++ b/skills/qamap-pr-qa/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: QAMap PR QA
+  short_description: Find what the current PR needs to prove before merge.
+  brand_color: "#0E7490"
+  default_prompt: Analyze the current PR with QAMap, verify its evidence, and carry out the safest next QA action.
+policy:
+  allow_implicit_invocation: true

--- a/src/agent-init.ts
+++ b/src/agent-init.ts
@@ -21,10 +21,14 @@ export interface AgentInitResult {
 
 const SECTION_START = "<!-- qamap:agent:start -->";
 const SECTION_END = "<!-- qamap:agent:end -->";
-const SKILL_RELATIVE_PATH = path.join("skills", "qamap-pr-qa", "SKILL.md");
+const SKILL_RELATIVE_ROOT = path.join("skills", "qamap-pr-qa");
+const SKILL_BUNDLE_FILES = [
+  "SKILL.md",
+  path.join("agents", "openai.yaml"),
+];
 const SKILL_TARGET_RELATIVE_PATHS = [
-  path.join(".agents", "skills", "qamap-pr-qa", "SKILL.md"),
-  path.join(".claude", "skills", "qamap-pr-qa", "SKILL.md"),
+  path.join(".agents", "skills", "qamap-pr-qa"),
+  path.join(".claude", "skills", "qamap-pr-qa"),
 ];
 
 export async function initAgentSetup(rootInput: string, options: { force?: boolean } = {}): Promise<AgentInitResult> {
@@ -96,27 +100,52 @@ async function copyPackagedSkill(
   targetRelativePath: string,
   force: boolean,
 ): Promise<AgentInitFile> {
-  const sourcePath = path.join(packageRoot(), SKILL_RELATIVE_PATH);
-  const targetPath = path.join(root, targetRelativePath);
-  const relativePath = targetRelativePath;
+  const sourceRoot = path.join(packageRoot(), SKILL_RELATIVE_ROOT);
+  const targetRoot = path.join(root, targetRelativePath);
+  const packagedFiles = await Promise.all(SKILL_BUNDLE_FILES.map(async (relativePath) => ({
+    relativePath,
+    content: await fs.readFile(path.join(sourceRoot, relativePath), "utf8"),
+  })));
+  const existingFiles = await Promise.all(packagedFiles.map(async (file) => {
+    const targetPath = path.join(targetRoot, file.relativePath);
+    const exists = await pathExists(targetPath);
+    return {
+      ...file,
+      targetPath,
+      exists,
+      existing: exists ? await fs.readFile(targetPath, "utf8") : undefined,
+    };
+  }));
+  const targetExisted = existingFiles.some((file) => file.exists);
+  const hasLocalChanges = existingFiles.some((file) => file.exists && file.existing !== file.content);
 
-  const skillContent = await fs.readFile(sourcePath, "utf8");
-
-  if (await pathExists(targetPath)) {
-    const existing = await fs.readFile(targetPath, "utf8");
-    if (existing === skillContent) {
-      return { path: relativePath, status: "unchanged", detail: "packaged skill already installed" };
-    }
-    if (!force) {
-      return { path: relativePath, status: "skipped", detail: "differs from the packaged skill; pass --force to replace it" };
-    }
-    await fs.writeFile(targetPath, skillContent, "utf8");
-    return { path: relativePath, status: "updated", detail: "replaced with the packaged skill (--force)" };
+  if (hasLocalChanges && !force) {
+    return {
+      path: targetRelativePath,
+      status: "skipped",
+      detail: "skill bundle contains local changes; pass --force to replace packaged files",
+    };
   }
-
-  await fs.mkdir(path.dirname(targetPath), { recursive: true });
-  await fs.writeFile(targetPath, skillContent, "utf8");
-  return { path: relativePath, status: "created", detail: "installed the packaged QAMap PR QA skill" };
+  let changed = false;
+  for (const file of existingFiles) {
+    if (file.existing === file.content) {
+      continue;
+    }
+    await fs.mkdir(path.dirname(file.targetPath), { recursive: true });
+    await fs.writeFile(file.targetPath, file.content, "utf8");
+    changed = true;
+  }
+  if (!changed) {
+    return { path: targetRelativePath, status: "unchanged", detail: "packaged skill bundle already installed" };
+  }
+  if (!targetExisted) {
+    return { path: targetRelativePath, status: "created", detail: "installed the packaged QAMap PR QA skill bundle" };
+  }
+  return {
+    path: targetRelativePath,
+    status: "updated",
+    detail: force ? "replaced packaged skill files (--force)" : "installed missing packaged skill metadata",
+  };
 }
 
 async function ensureDefaultConfig(root: string): Promise<AgentInitFile> {

--- a/src/qa.ts
+++ b/src/qa.ts
@@ -205,7 +205,10 @@ export async function generateQaDraft(rootInput: string, options: QaDraftOptions
   });
   const changedTestContracts = collectChangedTestContracts(addedDiffEvidence);
   const qaFiles = draft.plan.changedFiles.length > 0 ? draft.files : [];
-  const flows = qaFiles.map((file) => qaFlowFromDraftFile(file));
+  const flows = preferChangedTestEvidence(
+    qaFiles.map((file) => qaFlowFromDraftFile(file)),
+    changedTestContracts,
+  );
   const changedFiles = draft.plan.changedFiles.map((file) => file.path);
   const preferredVerificationCommand = buildChangedTestVerificationCommand(
     flows,
@@ -1337,6 +1340,9 @@ function secondaryAgentFlow(
     focus: compactAgentFlowFocus(flow.focus, Math.min(limits.question ?? 90, limits.success ?? 90)),
     steps: [],
     selectors: [],
+    existingEvidence: flow.existingEvidence
+      ?.slice(0, 1)
+      .map((file) => truncateForAgent(file, limits.file ?? 70)),
     evidence: [],
   };
 }
@@ -2178,6 +2184,108 @@ function qaFlowFromDraftFile(file: E2eDraftFile): QaDraftFlow {
   };
 }
 
+function preferChangedTestEvidence(
+  flows: QaDraftFlow[],
+  changedTestContracts: ChangedTestContract[],
+): QaDraftFlow[] {
+  if (changedTestContracts.length === 0) {
+    return flows;
+  }
+
+  return flows.map((flow) => {
+    const scored = changedTestContracts
+      .map((contract) => ({
+        contract,
+        score: changedTestContractScore(flow, contract),
+      }))
+      .filter((candidate) => candidate.score > 0)
+      .sort((left, right) =>
+        right.score - left.score ||
+        left.contract.file.localeCompare(right.contract.file) ||
+        left.contract.line - right.contract.line
+      );
+    const strongestScore = scored[0]?.score ?? 0;
+    const evidencePaths = uniqueStrings(
+      scored
+        .filter((candidate) => candidate.score >= Math.max(3, strongestScore - 2))
+        .map((candidate) => candidate.contract.file),
+    );
+    if (evidencePaths.length === 0) {
+      return flow;
+    }
+    return {
+      ...flow,
+      // A changed repository-authored contract is stronger evidence than a broad filename or keyword match.
+      existingEvidencePaths: evidencePaths,
+    };
+  });
+}
+
+function changedTestContractScore(flow: QaDraftFlow, contract: ChangedTestContract): number {
+  const flowTitleTokens = qaEvidenceTokens(flow.title);
+  const flowFileTokens = qaEvidenceTokens(flow.changedFiles.join("\n"));
+  const flowTokens = new Set([...flowTitleTokens, ...flowFileTokens]);
+  const contractTitleTokens = qaEvidenceTokens(contract.title);
+  const contractFileTokens = qaEvidenceTokens(contract.file);
+  const contractTokens = new Set([...contractTitleTokens, ...contractFileTokens]);
+  const shared = [...flowTokens].filter((token) => contractTokens.has(token));
+  if (shared.length === 0) {
+    return 0;
+  }
+
+  const titleOverlap = flowTitleTokens.filter((token) => contractTitleTokens.includes(token)).length;
+  const fileOverlap = flowFileTokens.filter((token) => contractTokens.has(token)).length;
+  return shared.length * 3 + titleOverlap * 2 + fileOverlap * 2;
+}
+
+function qaEvidenceTokens(value: string): string[] {
+  const ignored = new Set([
+    "assert",
+    "assertion",
+    "behavior",
+    "changed",
+    "check",
+    "checklist",
+    "cli",
+    "command",
+    "contract",
+    "draft",
+    "evidence",
+    "existing",
+    "expected",
+    "file",
+    "flow",
+    "input",
+    "invalid",
+    "json",
+    "keeps",
+    "manifest",
+    "native",
+    "output",
+    "path",
+    "primary",
+    "qamap",
+    "related",
+    "repository",
+    "result",
+    "run",
+    "shared",
+    "success",
+    "test",
+    "valid",
+    "verification",
+    "yaml",
+  ]);
+  return uniqueStrings(
+    value
+      .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+      .split(/[^a-zA-Z0-9]+/)
+      .map((part) => part.toLowerCase())
+      .map((part) => part.length > 4 && part.endsWith("s") ? part.slice(0, -1) : part)
+      .filter((part) => (part.length > 2 || part === "qa" || part === "e2e") && !ignored.has(part)),
+  );
+}
+
 function buildFlowReasons(file: E2eDraftFile): string[] {
   const verificationMode = verificationModeForDraftFile(file);
   if (verificationMode === "command-contract") {
@@ -2250,11 +2358,15 @@ function buildPrChecklist(
   changedTestContracts: ChangedTestContract[],
   suggestedCommands: string[],
 ): string[] {
-  const testEvidenceLabel = flows[0]?.verificationMode === "existing-test-evidence"
+  const changedEvidencePaths = uniqueStrings(changedTestContracts.map((contract) => contract.file));
+  const testEvidencePaths = changedEvidencePaths.length > 0
+    ? changedEvidencePaths
+    : flows[0]?.existingEvidencePaths ?? [];
+  const testEvidenceLabel = changedEvidencePaths.length > 0 || flows[0]?.verificationMode === "existing-test-evidence"
     ? "changed test evidence"
     : "related test evidence";
-  const evidenceChecklist = flows[0]?.existingEvidencePaths.length
-      ? `Run the ${testEvidenceLabel}: ${flows[0].existingEvidencePaths.slice(0, 4).join(", ")}.`
+  const evidenceChecklist = testEvidencePaths.length
+      ? `Run the ${testEvidenceLabel}: ${testEvidencePaths.slice(0, 4).join(", ")}.`
       : flows[0]?.verificationMode
         ? `Run ${formatVerificationMode(flows[0].verificationMode)} with ${suggestedCommands[0] ?? "the nearest repository validation command"}.`
       : draft.plan.changeAnalysis.intents[0]
@@ -2291,14 +2403,18 @@ function buildAgentHandoff(
   missingEvidence: QaDraftMissingEvidence[],
   suggestedCommands: string[],
 ): string[] {
-  const testEvidenceLabel = flows[0]?.verificationMode === "existing-test-evidence"
+  const changedEvidencePaths = uniqueStrings(changedTestContracts.map((contract) => contract.file));
+  const testEvidencePaths = changedEvidencePaths.length > 0
+    ? changedEvidencePaths
+    : flows[0]?.existingEvidencePaths ?? [];
+  const testEvidenceLabel = changedEvidencePaths.length > 0 || flows[0]?.verificationMode === "existing-test-evidence"
     ? "changed test evidence"
     : "related test evidence";
   const handoff = [
     "Use this as a local PR QA skill result, not as proof that browser or device QA already passed.",
     draft.dryRun ? "No files were written because this command previews QA work only." : undefined,
-    flows[0]?.existingEvidencePaths.length
-      ? `Run the ${testEvidenceLabel} (${flows[0].existingEvidencePaths.slice(0, 3).join(", ")}) and record the result before handoff.`
+    testEvidencePaths.length
+      ? `Run the ${testEvidenceLabel} (${testEvidencePaths.slice(0, 3).join(", ")}) and record the result before handoff.`
       : flows[0]?.verificationMode
         ? `Run ${formatVerificationMode(flows[0].verificationMode)} with ${suggestedCommands[0] ?? "the nearest repository command"} and record the result before handoff; do not invent a product-journey E2E for this diff alone.`
       : draft.plan.changeAnalysis.intents[0]

--- a/src/test-evidence.ts
+++ b/src/test-evidence.ts
@@ -368,7 +368,7 @@ function changedTestContractsFromLine(
   }
 
   if (/(?:\.|-)(?:test|spec)\.[cm]?[jt]sx?$/i.test(file)) {
-    const matcher = /\b(?:it|test)\s*(?:\.\w+)?\s*\(\s*(["'`])([^"'`]+)\1/g;
+    const matcher = /^\s*(?:it|test)\s*(?:\.\w+)?\s*\(\s*(["'`])([^"'`]+)\1/g;
     for (const match of text.matchAll(matcher)) {
       contracts.push({
         file,

--- a/test/agent-plugin.test.mjs
+++ b/test/agent-plugin.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+async function readJson(relativePath) {
+  return JSON.parse(await readFile(path.join(repositoryRoot, relativePath), "utf8"));
+}
+
+test("native agent plugin manifests expose one shared QAMap skill", async () => {
+  const [packageJson, codexPlugin, claudePlugin, skill, metadata] = await Promise.all([
+    readJson("package.json"),
+    readJson(".codex-plugin/plugin.json"),
+    readJson(".claude-plugin/plugin.json"),
+    readFile(path.join(repositoryRoot, "skills/qamap-pr-qa/SKILL.md"), "utf8"),
+    readFile(path.join(repositoryRoot, "skills/qamap-pr-qa/agents/openai.yaml"), "utf8"),
+  ]);
+
+  assert.equal(codexPlugin.name, "qamap");
+  assert.equal(claudePlugin.name, "qamap");
+  assert.equal(codexPlugin.version, packageJson.version);
+  assert.equal(claudePlugin.version, packageJson.version);
+  assert.equal(codexPlugin.skills, "./skills/");
+  assert.match(skill, /^name: qamap-pr-qa$/m);
+  assert.match(skill, /preparing, updating, finalizing, or reviewing a pull request/i);
+  assert.match(skill, /## Agent Action Contract/);
+  assert.match(skill, /Execution receipt/);
+
+  const openaiMetadata = parseYaml(metadata);
+  assert.equal(openaiMetadata.interface.display_name, "QAMap PR QA");
+  assert.equal(openaiMetadata.policy.allow_implicit_invocation, true);
+  assert.match(openaiMetadata.interface.default_prompt, /safest next QA action/i);
+});
+
+test("the npm package keeps native plugin discovery metadata", async () => {
+  const packageJson = await readJson("package.json");
+
+  assert.ok(packageJson.files.includes(".codex-plugin"));
+  assert.ok(packageJson.files.includes(".claude-plugin"));
+  assert.ok(packageJson.files.includes("skills"));
+});

--- a/test/change-intent.test.mjs
+++ b/test/change-intent.test.mjs
@@ -1490,6 +1490,7 @@ test("E2E planning promotes commit intent before runner-specific draft generatio
     changedFiles: Array.from({ length: 12 }, (__, fileIndex) => `src/${"nested/".repeat(20)}file-${fileIndex}.tsx`),
     draftSteps: Array.from({ length: 12 }, (__, stepIndex) => `Step ${stepIndex} ${"detail ".repeat(50)}`),
     selectorHints: Array.from({ length: 12 }, (__, selectorIndex) => `[data-testid="${"selector".repeat(20)}-${selectorIndex}"]`),
+    existingEvidencePaths: [`test/flow-${index}.test.ts`],
   }));
   const compactAgentOutput = formatAgentQaDraft(oversizedQa);
   const compactAgentSummary = JSON.parse(compactAgentOutput);
@@ -1502,6 +1503,10 @@ test("E2E planning promotes commit intent before runner-specific draft generatio
   assert.ok(compactAgentSummary.flows.length > 0);
   assert.equal(typeof compactAgentSummary.flows[0].source, "string");
   assert.ok(Array.isArray(compactAgentSummary.flows[0].steps));
+  assert.deepEqual(compactAgentSummary.flows[0].existingEvidence, ["test/flow-0.test.ts"]);
+  if (compactAgentSummary.flows.length > 1) {
+    assert.deepEqual(compactAgentSummary.flows[1].existingEvidence, ["test/flow-1.test.ts"]);
+  }
   assert.ok(compactAgentSummary.compaction);
 
   const pathologicalQa = structuredClone(oversizedQa);

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -75,10 +75,11 @@ test("collectChangedTestContracts preserves non-Latin pytest contracts from diff
     "tests/e2e/visibility.spec.ts": [{
       file: "tests/e2e/visibility.spec.ts",
       startLine: 8,
-      endLine: 9,
-      hunkHeader: "@@ -7,0 +8,2 @@",
+      endLine: 10,
+      hunkHeader: "@@ -7,0 +8,3 @@",
       lines: [
         { line: 8, text: "test('unlisted record stays directly accessible', async () => {" },
+        { line: 9, text: "  const fixture = \"test('embedded fixture is not a contract', () => {})\";" },
       ],
     }],
   });
@@ -1410,6 +1411,78 @@ test("generateE2ePlan detects CLI packages and suggests command verification che
     command: "npm test",
   });
   assert.equal(agentSummary.readiness.automationApplicable, false);
+});
+
+test("generateQaDraft prefers changed repository test contracts over broad historical evidence", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src"), { recursive: true });
+  await mkdir(path.join(root, "test"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      name: "reporting-cli",
+      bin: {
+        reporting: "./dist/cli.js",
+      },
+      scripts: {
+        test: "node --test",
+      },
+    }),
+  );
+  await writeFile(
+    path.join(root, "src/report-command.ts"),
+    "export function createReport() { return { status: 'ready' }; }\n",
+  );
+  await writeFile(
+    path.join(root, "test/historical-rules.test.mjs"),
+    [
+      "import test from 'node:test';",
+      "test('command verification reports successful output and metadata', () => {});",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "feature/report-summary"]);
+  await writeFile(
+    path.join(root, "src/report-command.ts"),
+    "export function createReport() { return { status: 'ready', summary: 'Weekly report' }; }\n",
+  );
+  await writeFile(
+    path.join(root, "test/report-command.test.mjs"),
+    [
+      "import test from 'node:test';",
+      "test('report command includes the generated summary', () => {});",
+    ].join("\n"),
+  );
+  await writeFile(
+    path.join(root, "test/cache-policy.test.mjs"),
+    [
+      "import test from 'node:test';",
+      "test('cache cleanup expires stale entries', () => {});",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "add generated report summary"]);
+
+  const qa = await generateQaDraft(root, { base: "main", head: "HEAD" });
+  const reportFlow = qa.flows.find((flow) => flow.changedFiles.includes("src/report-command.ts"));
+  const markdown = formatMarkdownQaDraft(qa);
+
+  assert.ok(reportFlow);
+  assert.deepEqual(reportFlow.existingEvidencePaths, ["test/report-command.test.mjs"]);
+  assert.equal(reportFlow.existingEvidencePaths.includes("test/historical-rules.test.mjs"), false);
+  assert.equal(reportFlow.existingEvidencePaths.includes("test/cache-policy.test.mjs"), false);
+  assert.ok(
+    qa.prChecklist.some((item) =>
+      /changed test evidence: test\/cache-policy\.test\.mjs, test\/report-command\.test\.mjs/.test(item)
+    ),
+  );
+  assert.equal(qa.prChecklist.some((item) => /historical-rules/.test(item)), false);
+  assert.match(markdown, /Existing test evidence: `test\/report-command\.test\.mjs`/);
+  assert.doesNotMatch(markdown, /Run existing test evidence: `test\/historical-rules\.test\.mjs`/);
 });
 
 test("generateE2ePlan detects design token packages and suggests artifact validation", async () => {
@@ -8925,8 +8998,18 @@ test("initAgentSetup creates AGENTS.md, installs portable agent skills, and stay
     path.join(root, ".claude", "skills", "qamap-pr-qa", "SKILL.md"),
     "utf8",
   );
+  const portableMetadata = await readFile(
+    path.join(root, ".agents", "skills", "qamap-pr-qa", "agents", "openai.yaml"),
+    "utf8",
+  );
+  const claudeMetadata = await readFile(
+    path.join(root, ".claude", "skills", "qamap-pr-qa", "agents", "openai.yaml"),
+    "utf8",
+  );
   assert.match(portableSkill, /name: qamap-pr-qa/);
   assert.equal(claudeSkill, portableSkill);
+  assert.match(portableMetadata, /display_name: QAMap PR QA/);
+  assert.equal(claudeMetadata, portableMetadata);
   await stat(path.join(root, "qamap.config.json"));
 
   const second = await initAgentSetup(root);
@@ -8971,6 +9054,37 @@ test("initAgentSetup appends to an existing AGENTS.md and refreshes only its own
   assert.equal(forced.files[2].status, "updated");
   const skill = await readFile(path.join(root, ".claude", "skills", "qamap-pr-qa", "SKILL.md"), "utf8");
   assert.match(skill, /name: qamap-pr-qa/);
+  const metadata = await readFile(
+    path.join(root, ".claude", "skills", "qamap-pr-qa", "agents", "openai.yaml"),
+    "utf8",
+  );
+  assert.match(metadata, /allow_implicit_invocation: true/);
+});
+
+test("initAgentSetup upgrades skill-only installs with host metadata", async () => {
+  const { initAgentSetup } = await import("../dist/agent-init.js");
+  const root = await makeTempRepo();
+  const packagedSkill = await readFile(
+    path.join(repositoryRoot, "skills", "qamap-pr-qa", "SKILL.md"),
+    "utf8",
+  );
+  await writeFile(path.join(root, "package.json"), JSON.stringify({ name: "smoke" }));
+  for (const hostRoot of [".agents", ".claude"]) {
+    const skillPath = path.join(root, hostRoot, "skills", "qamap-pr-qa", "SKILL.md");
+    await mkdir(path.dirname(skillPath), { recursive: true });
+    await writeFile(skillPath, packagedSkill);
+  }
+
+  const result = await initAgentSetup(root);
+
+  assert.deepEqual(result.files.map((file) => file.status), ["created", "updated", "updated", "created"]);
+  for (const hostRoot of [".agents", ".claude"]) {
+    const metadata = await readFile(
+      path.join(root, hostRoot, "skills", "qamap-pr-qa", "agents", "openai.yaml"),
+      "utf8",
+    );
+    assert.match(metadata, /display_name: QAMap PR QA/);
+  }
 });
 
 test("generateAgentContext reflects npm scripts and repository boundaries", async () => {


### PR DESCRIPTION
## Intent

Expose QAMap as a native, agent-callable PR QA skill without adding a second analysis engine. Both host manifests point to the existing vendor-neutral skill, and `qamap init --agent` now installs the complete skill bundle.

The skill follows one canonical `route.nextAction`, keeps static analysis separate from later command execution, and preserves directly changed repository test evidence in human and compact agent handoffs.

## Agent / Review Risk

Native host discovery metadata is new and remains a thin wrapper around the local CLI. Public marketplace distribution is not part of this PR. Future package version bumps must keep both manifest versions aligned.

Test-contract matching now prefers current-PR evidence over broad historical matches. Synthetic positive and negative fixtures protect unrelated-flow separation and embedded fixture-string false positives.

## Validation Evidence

- [x] `pnpm test` (257/257 tests passed)
- [x] `pnpm scan` (0 findings)
- [x] `pnpm bench:execution` (3/3 contracts passed; all seeded regressions caught)
- [x] Relevant `qamap qa --format agent` output reviewed
- [x] Full `pnpm release:check` passed
- [x] Both native plugin manifest validators passed
- [x] Coverage: 89.40% lines, 85.92% branches, 95.82% functions

## E2E / Manual Coverage

This is a repository-validation and agent-handoff change, so it does not invent a product-journey E2E. QAMap was run against this branch with working-tree changes and selected `pnpm test` as the single next action. The compact 3,573-byte handoff retained changed test evidence for both emitted flows.

## Maintainer Notes

No release, tag, marketplace publication, runner installation, or automatic manifest mutation is included.

## Collaboration Checklist

- [x] The branch uses an allowed prefix and contains no coding-agent product name.
- [x] The PR title follows `Type: imperative summary`.
- [x] `@ivory-code` is assigned.
- [x] Exactly one `type:` label and only relevant `area:` labels are applied.
- [x] The PR is intended to be squash-merged after required checks pass.