### PR TITLE
Fix: rank substantive change intents ahead of cleanup tip commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Added a third seeded-regression execution contract that requires the byte-identical generated browser artifact to fail when corrected input leaves stale validation feedback and pass when first-touch revalidation is restored.
 - Added native Codex and Claude Code plugin manifests that expose the existing vendor-neutral `qamap-pr-qa` skill without duplicating the local analysis engine.
 - Added Codex skill presentation metadata and a plugin contract test that keeps both host manifests, the npm package, and the shared skill version aligned.
+- Added multi-commit benchmark fixtures: a target can declare ordered `commits` overlays instead of a single `head/` snapshot, and a `mustNamePrimaryIntent` expectation pins which intent must rank first. A new cleanup-tip fixture materializes a feature commit followed by `fix: minor refactor` and requires the feature to stay in the headline, flow title, and draft filename.
+- Added `restored` to the visible success-outcome vocabulary so standard "restored to defaults" confirmations qualify as diff-anchored success signals, matching the existing completed-state words such as `updated` and `archived`.
 
 ### Changed
 
@@ -25,6 +27,10 @@
 - Unrelated feature tests no longer attach to a flow merely because both paths contain generic structural words, and standalone nested packages with their own lockfile can route changed contracts to their package suite.
 - Changed-test contract extraction now ignores test-like source strings embedded inside fixture builders instead of reporting them as executable repository tests.
 - Compact agent handoffs now retain one repository test-evidence path for secondary affected flows instead of dropping that trace during the 4KB payload reduction.
+
+### Fixed
+
+- Fixed change-intent review ranking so a cleanup-shaped tip commit (for example `fix: minor refactor` or `fix: tidy up and add tests`) no longer displaces the branch's substantive intent from the headline, scenario names, and generated draft filenames. Cleanup-only intents are demoted below substantive intents but never dropped, and pure-cleanup branches keep their newest intent first. Observed on real public PR branches, where review-feedback commits routinely close a branch.
 
 ## 0.4.8 - 2026-07-27
 

--- a/bench.config.json
+++ b/bench.config.json
@@ -197,6 +197,28 @@
       }
     },
     {
+      "name": "web-preferences-cleanup-tip",
+      "fixture": "test/benchmarks/web-preferences-cleanup-tip",
+      "commits": [
+        { "dir": "head-1", "message": "feat: add a preferences reset action" },
+        { "dir": "head-2", "message": "fix: minor refactor" }
+      ],
+      "expect": {
+        "runner": "playwright",
+        "minFlows": 1,
+        "minChangeIntents": 1,
+        "mustReachFiles": ["src/pages/preferences.tsx"],
+        "mustNamePrimaryIntent": ["preferences reset action"],
+        "mustNameFlows": ["preferences reset"],
+        "mustFindSelectors": ["reset-preferences"],
+        "mustFindSuccessSignals": ["Preferences restored to defaults"],
+        "mustDraftFiles": ["preferences-reset"],
+        "maxBlankActions": 0,
+        "maxGenericTitles": 0,
+        "maxAgentBytes": 8192
+      }
+    },
+    {
       "name": "web-symbol-annotated-renewal",
       "fixture": "test/benchmarks/web-symbol-annotated-renewal",
       "commitMessage": "fix: prevent duplicate subscription renewal requests",

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -2,7 +2,7 @@
 
 QAMap's unit tests prove that the implementation behaves as coded. The benchmark contract checks a different question: does a representative PR receive a useful QA answer?
 
-`bench.config.json` is committed and runs in CI. Each target under `test/benchmarks/` contains a `base/` repository snapshot and a `head/` overlay. The runner materializes them as a temporary Git repository with a `main` baseline and one feature commit. Intent fixtures set a synthetic `commitMessage` so commit-to-lifecycle behavior is part of the contract. QAMap reads those repositories but never installs dependencies or executes their code.
+`bench.config.json` is committed and runs in CI. Each target under `test/benchmarks/` contains a `base/` repository snapshot and a `head/` overlay. The runner materializes them as a temporary Git repository with a `main` baseline and one feature commit. Intent fixtures set a synthetic `commitMessage` so commit-to-lifecycle behavior is part of the contract. A target may instead declare a `commits` array of `{dir, message}` overlays to materialize a multi-commit branch — the shape real pull-request branches have, including a cleanup commit at the tip. QAMap reads those repositories but never installs dependencies or executes their code.
 
 ## Run the public contract
 
@@ -21,6 +21,7 @@ The command fails when any target violates its declared expectations. The corpus
 - a React change spanning two user surfaces that must produce two independent primary scenario receipts, actions, assertions, and compiled drafts;
 - a presentation-only React condition that must not create behavioral state-transition QA;
 - a web preferences change that must execute the submit action once, map the immediate visible outcome, and keep unproven persistence, request-failure, and re-entry QA explicit instead of manufacturing passing coverage;
+- a multi-commit branch whose tip is a cleanup commit (`fix: minor refactor`) that must keep the substantive feature intent ranked first in the headline, flow title, and generated draft filename;
 - a repository-backed web persistence change that must connect one changed storage write to the matching read key, editable field, save action, route, and reload assertion before its primary draft can be fully mapped;
 - a form-validation timing change that must connect the changed trigger mode to one validated input, visible error, submit action, and success outcome before it can compile invalid-input, correction, and successful-submission coverage;
 - a mobile reminder change that must become scheduling, calendar, duplicate, resynchronization, and entry-routing QA;
@@ -66,6 +67,7 @@ Each target can declare:
 | Field | Meaning |
 | --- | --- |
 | `commitMessage` | Commit message used when materializing a fixture. Public PR reductions preserve the behavior-bearing source message; synthetic fixtures use neutral vocabulary. |
+| `commits` | Ordered `{dir, message}` overlays committed sequentially on the change branch instead of the single `head/` overlay. Use this to model multi-commit branches, such as a feature commit followed by a cleanup tip commit. |
 | `provenanceKind` | Expected fixture provenance. `public-pull-request` requires a pinned repository, PR URL, base/head commits, license, and matching `PROVENANCE.md`. |
 | `runner` | Expected `playwright`, `maestro`, or `manual` output adapter. Runner correctness alone is not a useful intent benchmark. |
 | `routeStatus`, `routeNextAction` | Expected canonical machine route and next action. Repository-verification fixtures use these instead of treating optional automation readiness as applicable. |
@@ -82,6 +84,7 @@ Each target can declare:
 | `minManifestBehaviorNodes` | Minimum Behavior Graph nodes carrying verification-manifest evidence. |
 | `mustHaveBehaviorKinds` | Behavior Graph node kinds that must be present, such as `flow`, `surface`, `source`, `assertion`, or `locator`. |
 | `mustNameIntents` | Concrete terms that must appear in the inferred intent title. |
+| `mustNamePrimaryIntent` | Terms that must appear in the first-ranked intent title — the headline humans and agents read first. Use this when ordering matters, not merely presence. |
 | `mustNotNameIntents` | Misleading terms that must not appear in inferred intent titles. |
 | `mustIncludeLifecycle` | Trigger, condition, action, state, effect, or outcome terms that must survive in the ordered lifecycle. |
 | `mustIncludeQaScenarios` | Failure, boundary, state-transition, or primary QA terms that must be proposed before runner compilation. |

--- a/scripts/bench.mjs
+++ b/scripts/bench.mjs
@@ -340,6 +340,14 @@ function evaluateContract(expect, result, plan, qa) {
   }
   appendMissingTerms(failures, "intent title", result.intentTitles, expect.mustNameIntents);
   appendUnexpectedTerms(failures, "intent title", result.intentTitles, expect.mustNotNameIntents);
+  // The first intent is the headline that humans and agents read first, so a
+  // fixture can pin what must rank as primary, not merely appear somewhere.
+  appendMissingTerms(
+    failures,
+    "primary intent title",
+    result.intentTitles.slice(0, 1),
+    expect.mustNamePrimaryIntent,
+  );
   appendMissingTerms(failures, "intent lifecycle", result.intentLifecycle, expect.mustIncludeLifecycle);
   appendUnexpectedTerms(failures, "intent lifecycle", result.intentLifecycle, expect.mustNotIncludeLifecycle);
   appendMissingTerms(failures, "intent QA scenario", result.intentScenarios, expect.mustIncludeQaScenarios);
@@ -702,11 +710,23 @@ async function materializeFixture(target, configDir) {
     });
   }
   await git(repositoryRoot, ["switch", "-c", "benchmark/change"]);
-  if (await exists(headRoot)) {
-    await fs.cp(headRoot, repositoryRoot, { recursive: true, force: true });
+  // A target may declare `commits: [{dir, message}]` to materialize a
+  // multi-commit branch (for example a feature commit followed by a cleanup
+  // tip commit, the shape real pull-request branches routinely have).
+  // Single-head targets keep the original one-commit behavior.
+  const commitPlan = Array.isArray(target.commits) && target.commits.length > 0
+    ? target.commits.map((step) => ({
+      root: path.join(fixtureRoot, step.dir),
+      message: step.message ?? "benchmark change",
+    }))
+    : [{ root: headRoot, message: target.commitMessage ?? "benchmark change" }];
+  for (const step of commitPlan) {
+    if (await exists(step.root)) {
+      await fs.cp(step.root, repositoryRoot, { recursive: true, force: true });
+    }
+    await git(repositoryRoot, ["add", "-A"]);
+    await git(repositoryRoot, ["commit", "--allow-empty", "-m", step.message]);
   }
-  await git(repositoryRoot, ["add", "-A"]);
-  await git(repositoryRoot, ["commit", "--allow-empty", "-m", target.commitMessage ?? "benchmark change"]);
   const prepared = targetPaths(target, repositoryRoot, "main", "HEAD");
   return {
     ...prepared,

--- a/src/change-intent.ts
+++ b/src/change-intent.ts
@@ -321,6 +321,7 @@ function rankChangeIntentsForReview(
     .map((intent, index) => ({
       intent,
       index,
+      cleanupOnly: isCleanupOnlyIntent(intent) ? 1 : 0,
       latestCommit: intent.commits.length === 0
         ? -1
         : Math.max(...intent.commits.map((commit) => commitOrder.get(commit.sha) ?? -1)),
@@ -329,11 +330,37 @@ function rankChangeIntentsForReview(
       ).length,
     }))
     .sort((left, right) =>
+      left.cleanupOnly - right.cleanupOnly ||
       right.latestCommit - left.latestCommit ||
       right.locatedEvidence - left.locatedEvidence ||
       left.index - right.index
     )
     .map(({ intent }) => intent);
+}
+
+// Public PR branches routinely end with review-feedback commits ("fix: minor
+// refactor", "fix: tidy up and add tests"). Their behavioral conventional type
+// lets them seed an intent, but the subject describes housekeeping, not the
+// branch's substantive behavior change, so recency alone would headline them.
+// Demote intents whose every commit is cleanup-shaped below substantive
+// intents; demotion only reorders and never drops an intent. Kept separate
+// from isLowSignalCommitStatement so seed/supporting classification and the
+// working-tree current-delta focus are unchanged.
+const cleanupCommitStatementPattern =
+  /^(?:minor\s+)?(?:refactor(?:ing|s)?|clean\s?-?ups?|tidy(?:ing)?(?:\s+up)?|polish(?:ing)?|nits?|typos?|reformat(?:ting)?|lint(?:ing)?|whitespace|merge)\b/i;
+const reviewFeedbackStatementPattern =
+  /^(?:address(?:es|ed|ing)?\s+(?:review|pr\s+)?(?:comments?|feedback)|apply(?:ing)?\s+review\b)/i;
+
+function isCleanupCommitStatement(statement: string): boolean {
+  const trimmed = statement.trim();
+  return cleanupCommitStatementPattern.test(trimmed) || reviewFeedbackStatementPattern.test(trimmed);
+}
+
+function isCleanupOnlyIntent(intent: ChangeIntent): boolean {
+  if (intent.commits.length === 0) {
+    return false;
+  }
+  return intent.commits.every((commit) => isCleanupCommitStatement(commit.statement));
 }
 
 async function collectCommitEvidence(

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -2836,7 +2836,7 @@ function repositorySuccessOutcome(
 }
 
 function isVisibleSuccessOutcome(value: string): boolean {
-  return /\b(?:active|confirmed|saved|scheduled|refreshed|succeeded|success|completed|created|updated|deleted|sent|approved|accepted|pinned|unpinned|enabled|disabled|activated|deactivated|connected|disconnected|published|archived|ready|queued)\b/i.test(value) ||
+  return /\b(?:active|confirmed|saved|scheduled|refreshed|succeeded|success|completed|created|updated|deleted|sent|approved|accepted|pinned|unpinned|enabled|disabled|activated|deactivated|connected|disconnected|published|archived|restored|ready|queued)\b/i.test(value) ||
     /(?:완료|성공|예약(?:됨|됐|되)|저장(?:됨|됐|되)|등록(?:됨|됐|되)|제출(?:됨|됐|되)|승인(?:됨|됐|되))/.test(value);
 }
 

--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -4,6 +4,7 @@ Each directory represents one reduced pull request:
 
 - `base/` is committed on a temporary `main` branch.
 - `head/` is copied over the baseline and committed on `benchmark/change`; intent fixtures provide a neutral synthetic `commitMessage`.
+- A target may instead declare `commits: [{dir, message}]` overlays that are committed sequentially, materializing a multi-commit branch such as a feature commit followed by a cleanup tip commit.
 - `bench.config.json` declares the human expectation for the resulting QA draft.
 
 Fixtures must stay small, synthetic, and safe to publish. The benchmark runner only reads the materialized repositories. It does not install dependencies, start services, run package scripts, or execute generated tests.

--- a/test/benchmarks/web-preferences-cleanup-tip/base/package.json
+++ b/test/benchmarks/web-preferences-cleanup-tip/base/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "benchmark-web-preferences-cleanup-tip",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "@playwright/test": "1.56.0",
+    "react": "19.0.0",
+    "vite": "7.3.5"
+  }
+}

--- a/test/benchmarks/web-preferences-cleanup-tip/base/playwright.config.ts
+++ b/test/benchmarks/web-preferences-cleanup-tip/base/playwright.config.ts
@@ -1,0 +1,1 @@
+export default { use: { baseURL: "http://127.0.0.1:4173" } };

--- a/test/benchmarks/web-preferences-cleanup-tip/base/src/pages/preferences.tsx
+++ b/test/benchmarks/web-preferences-cleanup-tip/base/src/pages/preferences.tsx
@@ -1,0 +1,22 @@
+import { useState } from "react";
+
+export function PreferencesPage() {
+  const [density, setDensity] = useState("comfortable");
+
+  return (
+    <main>
+      <h1>Workspace preferences</h1>
+      <label htmlFor="density-select">Layout density</label>
+      <select
+        data-testid="density-select"
+        id="density-select"
+        value={density}
+        onChange={(event) => setDensity(event.target.value)}
+      >
+        <option value="comfortable">Comfortable</option>
+        <option value="compact">Compact</option>
+      </select>
+      <p data-testid="density-summary">Current density: {density}</p>
+    </main>
+  );
+}

--- a/test/benchmarks/web-preferences-cleanup-tip/head-1/src/pages/preferences.tsx
+++ b/test/benchmarks/web-preferences-cleanup-tip/head-1/src/pages/preferences.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+
+const defaultDensity = "comfortable";
+
+export function PreferencesPage() {
+  const [density, setDensity] = useState(defaultDensity);
+  const [resetConfirmed, setResetConfirmed] = useState(false);
+
+  return (
+    <main>
+      <h1>Workspace preferences</h1>
+      <label htmlFor="density-select">Layout density</label>
+      <select
+        data-testid="density-select"
+        id="density-select"
+        value={density}
+        onChange={(event) => {
+          setDensity(event.target.value);
+          setResetConfirmed(false);
+        }}
+      >
+        <option value="comfortable">Comfortable</option>
+        <option value="compact">Compact</option>
+      </select>
+      <p data-testid="density-summary">Current density: {density}</p>
+      <button
+        data-testid="reset-preferences"
+        type="button"
+        onClick={() => {
+          setDensity(defaultDensity);
+          setResetConfirmed(true);
+        }}
+      >
+        Reset preferences
+      </button>
+      {resetConfirmed ? (
+        <p data-testid="reset-confirmation">Preferences restored to defaults</p>
+      ) : null}
+    </main>
+  );
+}

--- a/test/benchmarks/web-preferences-cleanup-tip/head-2/src/pages/preferences.tsx
+++ b/test/benchmarks/web-preferences-cleanup-tip/head-2/src/pages/preferences.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+
+const defaultDensity = "comfortable";
+
+export function PreferencesPage() {
+  const [density, setDensity] = useState(defaultDensity);
+  const [confirmationVisible, setConfirmationVisible] = useState(false);
+
+  return (
+    <main>
+      <h1>Workspace preferences</h1>
+      <label htmlFor="density-select">Layout density</label>
+      <select
+        data-testid="density-select"
+        id="density-select"
+        value={density}
+        onChange={(event) => {
+          setDensity(event.target.value);
+          setConfirmationVisible(false);
+        }}
+      >
+        <option value="comfortable">Comfortable</option>
+        <option value="compact">Compact</option>
+      </select>
+      <p data-testid="density-summary">Current density: {density}</p>
+      <button
+        data-testid="reset-preferences"
+        type="button"
+        onClick={() => {
+          setDensity(defaultDensity);
+          setConfirmationVisible(true);
+        }}
+      >
+        Reset preferences
+      </button>
+      {confirmationVisible ? (
+        <p data-testid="reset-confirmation">Preferences restored to defaults</p>
+      ) : null}
+    </main>
+  );
+}

--- a/test/change-intent.test.mjs
+++ b/test/change-intent.test.mjs
@@ -3703,6 +3703,73 @@ test("change intents prioritize the newest independent feature for review", asyn
   assert.ok(residualIntentIndex > 1);
 });
 
+test("a cleanup tip commit does not displace the substantive change intent", async (t) => {
+  const root = await makeRepo(t);
+  const dialogFile = "src/reports/resetReportPreferences.ts";
+
+  await write(root, dialogFile, "export const resetReportPreferences = () => 'idle';\n");
+  commit(root, "chore: baseline");
+  branch(root, "feature/report-preferences-reset");
+
+  await write(
+    root,
+    dialogFile,
+    [
+      "export function resetReportPreferences(confirmed) {",
+      "  if (!confirmed) return 'Reset requires confirmation';",
+      "  localStorage.removeItem('report-preferences');",
+      "  return 'Report preferences reset';",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  commit(root, "feat: add report preferences reset dialog");
+
+  await write(
+    root,
+    dialogFile,
+    [
+      "export function resetReportPreferences(isConfirmed) {",
+      "  if (!isConfirmed) return 'Reset requires confirmation';",
+      "  localStorage.removeItem('report-preferences');",
+      "  return 'Report preferences reset';",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  commit(root, "fix: minor refactor");
+
+  const analysis = await analyze(root, [dialogFile]);
+
+  assert.match(analysis.intents[0].title, /report preferences reset dialog/i);
+  const cleanupIntentIndex = analysis.intents.findIndex((intent) =>
+    /minor refactor/i.test(intent.title)
+  );
+  assert.ok(cleanupIntentIndex > 0, "cleanup intent must be demoted, not dropped");
+});
+
+test("a branch of only cleanup commits keeps its newest cleanup intent first", async (t) => {
+  const root = await makeRepo(t);
+  const labelFile = "src/listings/listingLabels.ts";
+  const entryFile = "src/journals/journalEntry.ts";
+
+  await write(root, labelFile, "export const listingLabel = () => 'Listing';\n");
+  await write(root, entryFile, "export const journalEntry = () => 'Entry';\n");
+  commit(root, "chore: baseline");
+  branch(root, "chore/cleanup-pass");
+
+  await write(root, labelFile, "export const listingLabel = () => 'Listing label';\n");
+  commit(root, "fix: reformat listing labels");
+
+  await write(root, entryFile, "export const journalEntry = () => 'Journal entry';\n");
+  commit(root, "fix: minor refactor");
+
+  const analysis = await analyze(root, [labelFile, entryFile]);
+
+  assert.ok(analysis.intents.length >= 2);
+  assert.match(analysis.intents[0].title, /minor refactor/i);
+});
+
 test("diff evidence reserves the latest commit before large branch history", async (t) => {
   const root = await makeRepo(t);
   const latestTestFile = "src/z-latest/RevenueScreen.test.tsx";


### PR DESCRIPTION
## Intent

Real pull-request branches routinely end with a cleanup commit — `fix: minor refactor`, `fix: tidy up and add tests` — left after review feedback. The unreleased review ranking introduced in #146 sorts intents by recency first, so that cleanup tip commit displaces the branch's substantive intent from the headline, the "Affected behavior" line, scenario names, and the generated draft filename (for example `minor-refactor.spec.ts`). The engine already detects both intents at high confidence; only the ordering is wrong.

This PR ranks substantive intents ahead of cleanup-only intents while keeping recency order within each tier, so #146's current-task focus is preserved for substantive work. Demotion only reorders: cleanup intents are never dropped, and a branch containing only cleanup commits still headlines its newest intent.

Reproduced on merged PRs of two unrelated public repositories (documenso, formbricks) before the fix; both headline the substantive intent after it.

## Agent / Review Risk

- Reordering changes which intents survive top-N truncation in compact agent payloads, so lean outputs can surface different scenarios than before. Intent ids are computed before ranking and stay stable.
- A terse but substantive subject such as `fix: address review feedback` on a tip commit would rank the older feature intent first. Damage is bounded to ordering because demotion never drops an intent.
- The cleanup predicate is deliberately separate from `isLowSignalCommitStatement`; folding them together would change seed/supporting classification and silently remove QA scenarios.

## Validation Evidence

- [x] `pnpm test` — 276/276, including two new ranking regression tests (cleanup tip demoted; pure-cleanup branch keeps newest first)
- [x] `pnpm scan` — 0 findings
- [x] `pnpm bench:ci` — all targets pass, including the new `web-preferences-cleanup-tip` fixture; with the ranking fix reverted the fixture fails on primary intent title, flow title, and draft path, proving it guards this regression
- [x] `pnpm bench:execution` — 3/3 contracts pass
- [x] Relevant `qamap qa` output reviewed on the materialized fixture and on real public PR branches

## E2E / Manual Coverage

The new benchmark fixture materializes a multi-commit branch (feature commit + `fix: minor refactor` tip) and pins the primary intent title, flow title, draft filename, changed-file reach, selectors, and the diff-anchored success signal. No live E2E execution is required; the fixture exercises static analysis and draft mapping.

## Maintainer Notes

- `scripts/bench.mjs` now accepts `commits: [{dir, message}]` per target to materialize multi-commit branches; single-`head/` fixtures are untouched. Documented in `docs/benchmarking.md` and `test/benchmarks/README.md`.
- New expect key `mustNamePrimaryIntent` asserts on the first-ranked intent title, because `mustNameIntents` only checks presence anywhere in the list.
- `restored` joins the visible success-outcome vocabulary (alongside `updated`, `archived`) so standard "restored to defaults" confirmations qualify as diff-anchored success signals. `reset` was deliberately not added: it would collide with action labels such as "Reset preferences".

## Collaboration Checklist

- [x] The branch uses an allowed prefix and contains no coding-agent product name.
- [x] The PR title follows `Type: imperative summary`.
- [x] `@ivory-code` is assigned, or assignment is left for a maintainer when permissions do not allow it.
- [x] Exactly one `type:` label and only relevant `area:` labels are applied.
- [x] The PR is intended to be squash-merged after required checks pass.
