### PR TITLE
Docs: highlight the OpenAI Plugin Directory listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,15 @@
 [![npm version](https://img.shields.io/npm/v/@ivorycanvas/qamap.svg)](https://www.npmjs.com/package/@ivorycanvas/qamap)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
+<a href="https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629">
+  <img src="docs/assets/openai-plugin-directory-badge.svg" alt="QAMap is available in the OpenAI Plugin Directory" height="64">
+</a>
+
 ![QAMap: find what a change needs to prove](docs/assets/qamap-cover.png)
 
 **Find what a change needs to prove before merge.**
+
+[QAMap is available in the OpenAI Plugin Directory](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629) as a skills-only plugin. On supported OpenAI surfaces with a checked-out repository and local shell, it invokes the same local QAMap CLI.
 
 QAMap is a local-first, zero-LLM QA tool. It reads the current branch, repository structure, existing tests, and diff evidence to answer four questions:
 
@@ -149,7 +155,7 @@ npx --yes @ivorycanvas/qamap@latest init --agent
 
 The skill calls the same local CLI. It does not introduce another analysis engine or LLM request. See the [agent format contract](docs/agent-format.md) and [agent skill guide](docs/agent-skill.md).
 
-The repository also packages the same workflow as a skills-only OpenAI plugin candidate. It adds no MCP server or hosted service. QAMap itself makes no extra LLM call, while the calling agent still uses its own model tokens to invoke and interpret the skill. See the [plugin submission contract](docs/plugin-submission.md). Public directory availability is not implied until OpenAI approves the listing.
+The same workflow is also [published in the OpenAI Plugin Directory](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629) as a skills-only plugin. It adds no MCP server or hosted service. QAMap itself makes no extra LLM call, while the calling agent still uses its own model tokens to invoke and interpret the skill. See the [plugin submission contract](docs/plugin-submission.md).
 
 ## Optional Team Memory
 

--- a/docs/agent-skill.md
+++ b/docs/agent-skill.md
@@ -104,7 +104,7 @@ pnpm plugin:check
 pnpm plugin:smoke
 ```
 
-Public directory availability is not implied by the presence of either manifest. Until a listing is approved, `qamap init --agent` and the portable skill install remain the stable onboarding paths. The full skills-only boundary and submission sequence are documented in [plugin-submission.md](plugin-submission.md).
+Public directory availability is not implied by the presence of either manifest alone. QAMap `0.4.11` is currently [published in the OpenAI Plugin Directory](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629). `qamap init --agent` and the portable skill install remain vendor-neutral onboarding paths. The full skills-only boundary and submission sequence are documented in [plugin-submission.md](plugin-submission.md).
 
 ## What The Agent Should Do With The Output
 

--- a/docs/assets/openai-plugin-directory-badge.svg
+++ b/docs/assets/openai-plugin-directory-badge.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="360" height="64" viewBox="0 0 360 64" role="img" aria-labelledby="title description">
+  <title id="title">QAMap in the OpenAI Plugin Directory</title>
+  <desc id="description">Open the published QAMap listing in the OpenAI Plugin Directory.</desc>
+  <rect x="0.5" y="0.5" width="359" height="63" rx="8" fill="#07111f" stroke="#27466e"/>
+  <g transform="translate(10 10)">
+    <rect x="0.5" y="0.5" width="43" height="43" rx="10" fill="#07111f" stroke="#27466e"/>
+    <path d="M12 13V22C12 28 16 32 22 34" fill="none" stroke="#19bef2" stroke-width="2" stroke-linecap="round"/>
+    <path d="M32 13V22C32 28 28 32 22 34" fill="none" stroke="#19bef2" stroke-width="2" stroke-linecap="round"/>
+    <path d="M22 13V34" fill="none" stroke="#19bef2" stroke-width="2" stroke-linecap="round"/>
+    <circle cx="12" cy="10" r="3.5" fill="#07111f" stroke="#19bef2" stroke-width="2"/>
+    <circle cx="22" cy="10" r="3.5" fill="#07111f" stroke="#19bef2" stroke-width="2"/>
+    <circle cx="32" cy="10" r="3.5" fill="#07111f" stroke="#19bef2" stroke-width="2"/>
+    <circle cx="22" cy="34" r="3.5" fill="#07111f" stroke="#19bef2" stroke-width="2"/>
+    <circle cx="22" cy="41" r="6" fill="#07111f" stroke="#ffb414" stroke-width="2"/>
+    <path d="M18.5 41L21 43.5L25.5 38.5" fill="none" stroke="#ffb414" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <text x="68" y="25" fill="#8ea4bc" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600">AVAILABLE IN</text>
+  <text x="68" y="47" fill="#f5f8fc" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="18" font-weight="600">OpenAI Plugin Directory</text>
+</svg>

--- a/docs/plugin-submission.md
+++ b/docs/plugin-submission.md
@@ -2,7 +2,7 @@
 
 QAMap packages one `skills-only` plugin for the shared OpenAI Plugins Directory. It reuses the same local CLI and `qamap.qa` contract as every other QAMap integration. It does not add an MCP server, hosted service, background hook, or second QA engine.
 
-The source package is a submission candidate. It is not an approved or publicly listed OpenAI plugin until OpenAI accepts it.
+QAMap `0.4.11` is approved and [published in the OpenAI Plugin Directory](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629). This repository remains the source of truth for the reviewed skill package and future listing updates.
 
 ## Product Boundary
 
@@ -42,7 +42,7 @@ pnpm plugin:smoke
 
 The repository CI and `release:check` run both gates.
 
-## Maintainer Submission Sequence
+## Maintainer Submission And Update Sequence
 
 1. Complete the normal QAMap release gate and publish the exact package version referenced by the skill.
 2. Run a fresh public-registry install and agent-format smoke against that published version.
@@ -51,6 +51,6 @@ The repository CI and `release:check` run both gates.
 5. Use `plugin/submission.json` as the source of truth for listing copy, starter prompts, and the five positive and three negative evaluations.
 6. Upload the canonical logo from `skills/qamap-pr-qa/assets/qamap-logo.png`.
 7. Review every requested permission and test receipt before submitting.
-8. Do not announce directory availability until the listing is approved and visible.
+8. For a new plugin version, keep the currently published listing available until the replacement has been reviewed and is visible.
 
 See the official [Plugins overview](https://developers.openai.com/plugins/) and [submission guide](https://developers.openai.com/plugins/deploy/submission) for current platform requirements.


### PR DESCRIPTION
## Why

QAMap `0.4.11` is now approved and published in the OpenAI Plugin Directory, but the repository documentation still described the package as an unpublished submission candidate. A plain text badge also did not carry the QAMap identity shown in the directory.

## Behavioral Contract

- Show a compact, clickable directory badge with the QAMap icon near the top of the README.
- Link directly to the published QAMap listing.
- Describe the listing accurately as a skills-only plugin without implying OpenAI endorsement.
- Preserve the local-first boundary: supported surfaces still invoke the same local QAMap CLI.
- Update maintainer guidance for future published plugin versions.

## Evidence

- [ ] Focused regression test added or updated. Not applicable: documentation and static artwork only.
- [x] `pnpm test` - 315/315 passing.
- [ ] `pnpm bench:ci` for QA inference, routing, trace, or output changes. Not applicable.
- [ ] `pnpm bench:execution` for E2E compiler or execution-fixture changes. Not applicable.
- [ ] `pnpm scan` for scanner, security, or repository-policy changes. Not applicable.
- [x] `pnpm plugin:check`
- [x] SVG parsed with `xmllint`; `git diff --check` passed.

## Public OSS Check

- [x] No private repository name, path, source, customer data, credential, or internal smoke output is included.
- [x] This is a documentation-only status update; shared-inference controls are not applicable.
- [x] User-facing commands and claims match actual behavior and the visible directory listing.

## Review Notes

The badge uses QAMap's own icon rather than an OpenAI logo. It communicates directory availability without presenting the listing as a product endorsement. The PR is intended to be squash-merged after required checks pass.