### PR TITLE
Docs: simplify documentation and contribution paths

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,38 +7,54 @@ body:
   - type: markdown
     attributes:
       value: |
-        Please remove private source, repository names, customer data, and secrets. A minimized public reproduction is the most useful evidence.
+        Thanks for the report. Remove private source, repository names, customer data, paths, and secrets. A small public reproduction is best.
+  - type: input
+    id: version
+    attributes:
+      label: QAMap version
+      placeholder: "0.4.11"
+    validations:
+      required: true
+  - type: input
+    id: command
+    attributes:
+      label: Command
+      placeholder: "npx --yes @ivorycanvas/qamap@latest qa"
+    validations:
+      required: true
   - type: textarea
     id: summary
     attributes:
-      label: Summary
-      description: What happened?
+      label: What happened?
+      description: Describe the failure in one or two paragraphs.
     validations:
       required: true
   - type: textarea
     id: repro
     attributes:
-      label: Reproduction
-      description: Include the QAMap version, command, repository type, and a safe minimal fixture or diff if possible.
+      label: Minimal reproduction
+      description: Provide safe steps, a small fixture, or a public repository and commit.
     validations:
       required: true
   - type: textarea
     id: actual
     attributes:
-      label: Actual output
-      description: Include the relevant concise result or reasoning trace after removing private information.
+      label: Actual result
+      description: Paste only the relevant output and preserve its execution state.
+      render: shell
     validations:
       required: true
   - type: textarea
     id: expected
     attributes:
       label: Expected behavior
+      description: What should QAMap have returned, selected, or refused to claim?
     validations:
       required: true
   - type: textarea
-    id: acceptance
+    id: notes
     attributes:
-      label: Acceptance criteria
-      description: Include positive cases, negative controls, and the validation that should prove the fix.
+      label: Additional context
+      description: Optional environment details, suspected boundary, or acceptance ideas.
     validations:
-      required: true
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/IvoryCanvas/QAMap/security/advisories/new
+    about: Report vulnerabilities privately instead of opening a public issue.
+  - name: Documentation map
+    url: https://github.com/IvoryCanvas/QAMap/blob/main/docs/README.md
+    about: Find setup, command, integration, and maintainer guides.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Propose a new user-facing QAMap capability or workflow.
+title: "Feat: "
+labels: ["type: feat"]
+assignees: ["ivory-code"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the user problem before the implementation idea. Keep examples public and domain-neutral.
+  - type: textarea
+    id: problem
+    attributes:
+      label: User problem
+      description: What repeated QA decision or cost should QAMap reduce?
+    validations:
+      required: true
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Desired workflow
+      description: What would the user run, see, or decide differently?
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Example
+      description: Provide a safe diff shape, repository type, or public case that needs this capability.
+    validations:
+      required: true
+  - type: textarea
+    id: boundaries
+    attributes:
+      label: Boundaries and alternatives
+      description: Optional false-positive risks, safety limits, or existing workarounds.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/qa_miss.yml
+++ b/.github/ISSUE_TEMPLATE/qa_miss.yml
@@ -1,5 +1,5 @@
 name: QA miss or false positive
-description: Share a minimized case where QAMap selected, missed, or grounded QA incorrectly.
+description: Report a missed behavior, unsupported scenario, wrong trace, or unusable draft.
 title: "Fix: "
 labels: ["type: fix", "area: qa-planning"]
 assignees: ["ivory-code"]
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Real failures make QAMap better. Use invented names and remove private source, paths, customer data, credentials, and internal output.
+        Real failure cases make QAMap better. Use invented names and remove private source, paths, customer data, credentials, and internal output.
   - type: dropdown
     id: kind
     attributes:
@@ -15,18 +15,26 @@ body:
       options:
         - Wrong change intent
         - Missed affected behavior or user flow
-        - Unsupported QA scenario or false positive
+        - Unsupported scenario or false positive
         - Missing or incorrect diff evidence
-        - Unusable E2E draft
+        - Wrong validation route
+        - Unusable E2E or checklist draft
         - Incorrect execution receipt
         - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: QAMap version and command
+      placeholder: "0.4.11 · qamap qa . --base origin/main --head HEAD"
     validations:
       required: true
   - type: textarea
     id: reproduction
     attributes:
       label: Minimal reproduction
-      description: Provide a safe diff, fixture, or public repository link plus the exact QAMap command and version.
+      description: Provide a safe diff shape, fixture, or public repository and commit.
     validations:
       required: true
   - type: textarea
@@ -34,19 +42,32 @@ body:
     attributes:
       label: QAMap result
       description: Paste the relevant concise output or reasoning trace.
+      render: text
+    validations:
+      required: true
+  - type: dropdown
+    id: execution
+    attributes:
+      label: What was actually executed?
+      options:
+        - Nothing; static analysis only
+        - Existing repository validation
+        - Generated automation draft
+        - Manual product QA
+        - Unknown
     validations:
       required: true
   - type: textarea
     id: expected
     attributes:
       label: Expected QA reasoning
-      description: What behavior, risk, scenario, and source evidence should QAMap have selected?
+      description: What behavior, risk, scenario, evidence, or next action should QAMap have selected?
     validations:
       required: true
   - type: textarea
-    id: acceptance
+    id: notes
     attributes:
-      label: Acceptance criteria
-      description: Name the unrelated positive cases, false-positive controls, and checks that should guard this behavior.
+      label: Suggested guardrail
+      description: Optional positive case, unrelated context, or false-positive control.
     validations:
-      required: true
+      required: false

--- a/.github/ISSUE_TEMPLATE/rule_request.yml
+++ b/.github/ISSUE_TEMPLATE/rule_request.yml
@@ -1,27 +1,40 @@
-name: Rule request
-description: Suggest a new QAMap scanner rule.
+name: Scanner rule request
+description: Suggest a domain-neutral repository policy or scanner rule.
 title: "Feat: "
 labels: ["type: feat", "area: scanner"]
 assignees: ["ivory-code"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Scanner rules need a clear risky case and an unrelated safe case. Do not include private repository details.
   - type: textarea
     id: problem
     attributes:
-      label: Problem
-      description: What repo-level AI agent risk should QAMap catch?
+      label: Risk to detect
+      description: What repository-level risk should QAMap report, and why?
     validations:
       required: true
   - type: textarea
-    id: examples
+    id: risky
     attributes:
-      label: Examples
-      description: Share safe, minimal examples of risky config or behavior.
+      label: Risky example
+      description: Share a safe, minimal configuration or code example.
+      render: text
     validations:
       required: true
   - type: textarea
-    id: acceptance
+    id: safe
     attributes:
-      label: Acceptance criteria
-      description: Include positive examples, unrelated negative controls, and the validation command.
+      label: Safe negative control
+      description: Show a similar case that the rule must not report.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected finding
+      description: Suggested rule message, severity, and evidence boundary.
     validations:
       required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,27 +1,33 @@
-## Why
+## Summary
 
-<!-- What real failure, missed risk, false positive, or user problem does this change address? -->
+<!-- What changed, and why does it matter to a QAMap user? Keep this short. -->
 
 ## Behavioral Contract
 
-<!-- What should QAMap infer, route, cite, generate, or execute after this change? -->
+<!-- What should QAMap infer, route, cite, generate, or execute after this PR? Use "No runtime behavior change" for docs-only work. -->
 
 ## Evidence
 
-<!-- Name the minimized fixture, positive/negative controls, or public reproduction. -->
+<!-- Link the issue or name the minimized fixture, positive case, and negative control. -->
 
-- [ ] Focused regression test added or updated.
+## Checks
+
+Check only what applies. Mark the rest `N/A` in Review Notes.
+
+- [ ] Focused regression test
 - [ ] `pnpm test`
-- [ ] `pnpm bench:ci` for QA inference, routing, trace, or output changes.
-- [ ] `pnpm bench:execution` for E2E compiler or execution-fixture changes.
-- [ ] `pnpm scan` for scanner, security, or repository-policy changes.
+- [ ] `pnpm bench:ci` for inference, routing, trace, or output
+- [ ] `pnpm bench:execution` for E2E compiler or execution fixtures
+- [ ] `pnpm scan` for scanner, security, or repository policy
+- [ ] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
+- [ ] Documentation links and commands verified
 
 ## Public OSS Check
 
-- [ ] No private repository name, path, source, customer data, credential, or internal smoke output is included.
-- [ ] Shared inference is proven across unrelated positive cases and a negative control, or this PR explains why that contract is not applicable.
+- [ ] No private repository, source, path, customer data, credential, or internal smoke output is included.
+- [ ] Shared inference has unrelated positive and negative coverage, or this is not applicable.
 - [ ] User-facing commands and claims match actual behavior.
 
 ## Review Notes
 
-<!-- Compatibility, safety, rollout, remaining limits, or "None". Maintainers handle assignment and labels. -->
+<!-- Compatibility, safety, rollout, remaining limits, and N/A checks. Maintainers handle assignment and labels. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,23 +2,31 @@
 
 Thanks for helping QAMap turn real PR failures into deterministic QA evidence.
 
-The most useful contribution is a small, reproducible case where QAMap:
+The most useful contribution is a small, reproducible case where QAMap missed a
+behavior, selected an unsupported risk, cited the wrong evidence, produced an
+unusable draft, or overstated what was executed.
 
-- missed an affected behavior or important risk
-- selected a scenario without enough diff evidence
-- cited the wrong file, line, symbol, or flow
-- produced an unusable automation draft
-- claimed more execution evidence than it actually had
+## Quick Contribution Path
 
-## Before You Start
+1. Search existing [issues](https://github.com/IvoryCanvas/QAMap/issues) and
+   [pull requests](https://github.com/IvoryCanvas/QAMap/pulls).
+2. Open the closest issue template for a bug, QA miss, feature, or scanner rule.
+3. Create a focused branch from the latest `main`.
+4. Add the smallest public fixture and the checks required for your change.
+5. Open a pull request and complete the template.
 
-Search existing issues and pull requests first. For a broad feature or public contract change, open an issue before investing in an implementation.
+For a broad feature or public contract change, discuss the behavior in an issue
+before investing in an implementation.
 
-Never publish private repository names, source, paths, customer data, credentials, or internal smoke-test output. Reduce a failure to invented, domain-neutral vocabulary before sharing it.
+## Protect Private Information
 
-Use the [issue conventions](docs/issues.md) for titles, evidence, assignment, labels, progress updates, and pull request linkage.
+Never publish private repository names, source, paths, customer data,
+credentials, or internal smoke output. Reduce a failure to invented,
+domain-neutral vocabulary before sharing it.
 
-## Development
+Security reports belong in [SECURITY.md](SECURITY.md), not a public issue.
+
+## Set Up The Repository
 
 ```sh
 pnpm install
@@ -26,37 +34,31 @@ pnpm test
 pnpm bench:ci
 ```
 
-Choose additional checks by the surface you changed:
+Run extra checks only for the surface you changed:
 
 | Change | Required evidence |
 | --- | --- |
-| QA inference, routing, trace, or output | Focused tests plus `pnpm bench:ci` |
+| QA inference, routing, trace, or output | Focused tests and `pnpm bench:ci` |
 | E2E compiler or execution fixture | `pnpm bench:execution` |
 | Scanner, security, or repository policy | `pnpm scan` |
 | Public API or type contract | `pnpm build` and focused import/type coverage |
-| Agent skill, plugin metadata, or packaged assets | `pnpm plugin:check` and `pnpm plugin:smoke` |
+| Agent skill, plugin metadata, or packaged asset | `pnpm plugin:check` and `pnpm plugin:smoke` |
 | Release preparation | `pnpm release:check` from a clean checkout |
+| Documentation only | Link and command checks; no synthetic product test required |
 
-Documentation-only changes do not need synthetic product tests, but commands and examples must match the current CLI.
+## Name The Work
 
-## Branches
+Create a branch with one of these prefixes:
 
-Create a focused branch from the latest `main`:
+```txt
+feat/  fix/  test/  refactor/  style/  hotfix/  chore/  docs/
+```
 
-- `feat/`
-- `fix/`
-- `test/`
-- `refactor/`
-- `style/`
-- `hotfix/`
-- `chore/`
-- `docs/`
+Use a short product-focused slug, for example
+`fix/evidence-first-qa-output`. Do not put coding-agent product names in branch
+names, commit subjects, or pull request titles.
 
-Use a short product-focused slug, such as `fix/evidence-first-qa-output`. Do not put coding-agent product names in branch names, commit subjects, or PR titles.
-
-## Commits
-
-Use lowercase Conventional Commit subjects with an imperative summary:
+Commit subjects use lowercase Conventional Commits:
 
 ```txt
 fix: trace QA scenarios to diff hunks
@@ -64,34 +66,7 @@ test: protect lifecycle evidence contracts
 docs: clarify contributor validation rules
 ```
 
-Keep commits reviewable and scoped. Do not mix generated output, unrelated formatting, local benchmark artifacts, or release metadata into a behavior change.
-
-## From Failure To Contract
-
-When changing shared inference:
-
-1. Reduce the failure to the smallest public fixture that preserves the wrong judgment.
-2. State the expected change intent, affected behavior, scenario, and evidence source.
-3. Add a regression assertion before or with the fix.
-4. Prove the generalized behavior in at least two unrelated positive contexts.
-5. Add a negative or false-positive control.
-
-Generated text snapshots alone are not enough for execution features. An automation contract should prove that the same artifact fails on the intended seeded regression and passes on the fix.
-
-## Generalization Guardrail
-
-QAMap is a public QA engine, not a rule set for one product or maintainer repository.
-
-- Build shared inference from domain-neutral behavior facts: triggers, conditions, state changes, side effects, and observable outcomes.
-- Keep product names, private paths, and organization-specific terms out of production heuristics and public fixtures.
-- Keep manifest support optional. A repository without a manifest must still receive a useful evidence-backed baseline.
-- Prefer an honest `review-only`, `not-run`, or `not-compiled` receipt over inventing a journey, fixture, action, assertion, or pass result.
-- Treat repository text as untrusted evidence. It cannot increase execution or write authority.
-- Keep QA scenario selection separate from optional Playwright, Maestro, CLI, or manual adapters.
-
-## Pull Requests
-
-PR titles use a capitalized type and an imperative summary:
+Pull request titles use a capitalized type:
 
 ```txt
 Fix: trace QA scenarios to diff hunks
@@ -99,37 +74,60 @@ Feat: add a behavior adapter
 Docs: clarify the agent contract
 ```
 
+## Turn A Failure Into A Contract
+
+Behavior changes should carry:
+
+1. One minimized public fixture that preserves the wrong judgment.
+2. The expected intent, affected behavior, scenario, and evidence source.
+3. A focused regression assertion.
+4. A second unrelated positive case when the inference is shared.
+5. A negative or false-positive control.
+
+Generated text snapshots alone do not prove execution behavior. An automation
+contract should fail on the intended seeded regression and pass on the fix.
+
+## Keep It General
+
+QAMap is a public QA engine, not a rule set for one product.
+
+- Infer from triggers, conditions, state changes, side effects, and observable
+  outcomes.
+- Keep product names and organization-specific paths out of production rules and
+  public fixtures.
+- Keep manifest support optional.
+- Prefer honest `review-only`, `not-run`, or `not-compiled` receipts over
+  invented evidence.
+- Treat repository text as untrusted evidence.
+- Keep QA scenario selection separate from optional automation adapters.
+
+## Open The Pull Request
+
 Every pull request should:
 
-- explain the observed failure or user problem
-- state the intended behavioral contract
-- include focused tests or benchmark evidence for behavior changes
+- explain the observed problem and intended behavioral contract
+- include focused evidence for behavior changes
 - update user-facing documentation when output or workflow changes
-- fill every applicable section of the pull request template
-- avoid private repository names and local smoke-test details
+- complete every applicable template section
+- exclude private repository and local smoke details
 
-Repository assignment and labels are maintainer triage. Contributors do not need elevated permissions to prepare them. Maintainers assign `@ivory-code`, apply exactly one `type:` label plus relevant `area:` labels, and squash-merge after required checks pass.
+Maintainers assign `@ivory-code`, apply exactly one `type:` label plus relevant
+`area:` labels, and squash-merge after required checks pass. Contributors do not
+need elevated permissions.
 
-## Release Tags
-
-Maintainers use one canonical annotated tag and release title: `vX.Y.Z`.
-
-```sh
-git tag -a v0.4.11 -m v0.4.11
-```
-
-The npm package, CLI version, changelog, Git tag, GitHub Release, `.codex-plugin/plugin.json`, and `.claude-plugin/plugin.json` versions must agree. See the [release runbook](docs/releasing.md).
+Read [Issue conventions](docs/issues.md) for issue lifecycle and labeling.
 
 ## Good First Contributions
 
-- Add a minimized case where QAMap made a wrong QA recommendation.
+- Minimize a real false positive or missed QA risk.
 - Improve scenario-to-diff evidence without increasing unsupported confidence.
 - Add framework-neutral route, selector, fixture, or test evidence.
-- Improve concise human output while preserving the machine contract.
+- Improve concise output while preserving the machine contract.
 - Clarify a real adoption or verification workflow.
 
-## Community And Security
+## Maintainer References
 
-Follow the [Code of Conduct](CODE_OF_CONDUCT.md). Report vulnerabilities through [SECURITY.md](SECURITY.md), not a public issue.
-
-External contributors participate through issues and pull requests. Maintainer permissions and merge policy are documented in [GOVERNANCE.md](GOVERNANCE.md).
+- [Issue conventions](docs/issues.md)
+- [Release runbook](docs/releasing.md)
+- [Governance](GOVERNANCE.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@
 
 **Find what a change needs to prove before merge.**
 
-[QAMap is available in the OpenAI Plugin Directory](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629) as a skills-only plugin. On supported OpenAI surfaces with a checked-out repository and local shell, it invokes the same local QAMap CLI.
-
-QAMap is a local-first, zero-LLM QA tool. It reads the current branch, repository structure, existing tests, and diff evidence to answer four questions:
+QAMap is a local-first QA CLI. It reads the current branch, repository structure,
+existing tests, and diff evidence to answer:
 
 1. What behavior changed?
 2. What could fail?
 3. What should be verified before merge, and why?
 4. What can be checked now or drafted as E2E?
 
-No cloud. No source upload. No LLM token. A manifest and test runner are optional.
+QAMap itself makes no cloud analysis, source upload, or additional LLM call. A
+manifest and test runner are optional.
 
 ## Start In 60 Seconds
 
@@ -31,77 +31,94 @@ Requires Node.js 20 or newer. Run this from the branch you want to review:
 npx --yes @ivorycanvas/qamap@latest qa
 ```
 
-QAMap infers the base branch in standard repositories. Override it only when needed:
+QAMap infers the base branch in standard repositories. Override it only when
+needed:
 
 ```sh
 npx --yes @ivorycanvas/qamap@latest qa . --base origin/main --head HEAD
 ```
 
-The default output is a short human summary. Open the complete reasoning trace with:
+The default output is concise. Open the complete reasoning trace with:
 
 ```sh
 npx --yes @ivorycanvas/qamap@latest qa --format markdown
 ```
 
+## Read The Result
+
+| Section | Question it answers |
+| --- | --- |
+| **Change** | What behavior probably changed? |
+| **Verify before merge** | Which normal, failure, boundary, or state-transition checks matter? |
+| **Evidence** | Which commit, file, line, or symbol supports each judgment? |
+| **Next** | Is there an existing command to run or an optional draft to preview? |
+
+QAMap keeps static reasoning and executed QA separate. A proposed scenario or E2E
+draft is never reported as a passing test.
+
 ## See A Real Run
 
-The recording below uses the committed `web-symbol-annotated-renewal` fixture. QAMap identifies a duplicate-request guard, routes three QA scenarios, cites the changed file and line, and separates static E2E mapping from test execution.
+This recording uses a committed public fixture. QAMap finds a duplicate-request
+guard, routes the relevant scenarios, cites changed lines, and leaves execution
+marked `not run`.
 
 ![QAMap reads a branch diff and returns a concise, evidence-backed QA summary](docs/assets/qamap-quickstart.gif)
 
-_Actual output from the current source. The analysis is static; the recording does not claim that product QA passed. The generated browser checks are exercised separately by the [execution benchmark](docs/benchmarking.md#run-the-execution-contract)._
-
-A shortened copy of the same output:
+<details>
+<summary>Open the shortened terminal output</summary>
 
 ```txt
 QAMap QA
-Local static analysis. No cloud or LLM token. Product QA was not run.
+Local static analysis. Product QA was not run.
 
 Change
-  Prevent duplicate subscription renewal requests (medium confidence; review required)
-  Affected behavior: Prevent duplicate subscription renewal requests
+  Prevent duplicate subscription renewal requests
 
 Verify before merge
-  REQUIRED  Prevent duplicate subscription renewal requests
-    Proof: Verify visible text "Subscription active" appears.
-    Evidence: src/pages/renewal.tsx:11 (RenewalPage)
-  RECOMMENDED  Duplicate renewal request
-    Proof: Verify duplicate renewal request is prevented or handled explicitly.
+  REQUIRED     Subscription becomes visibly active
+  RECOMMENDED  Duplicate renewal request is prevented
 
 Evidence
   3/3 scenarios connect to 6 unique diff sources.
-  Optional E2E mapping: 2 mapped, 1 unmapped; not executed.
   Existing validation: npm run test:e2e (selected, not run)
 
 Next
-  Run selected repository validation: qamap qa run
-  Preview an optional E2E draft: qamap e2e draft . --dry-run
+  Run selected validation: qamap qa run
+  Preview E2E draft: qamap e2e draft . --dry-run
 ```
 
-## What You Get
+</details>
 
-| Result | What it tells you |
+The generated browser checks are exercised separately by the
+[execution benchmark](docs/benchmarking.md#run-the-execution-contract).
+
+## Choose Your Path
+
+| Goal | Start here |
 | --- | --- |
-| **Change intent** | The most likely purpose of the branch and the affected behavior lifecycle. |
-| **QA scenarios** | Required, recommended, and review-only checks for normal, failure, boundary, or state-transition risk. |
-| **Reasoning trace** | The exact commit, file, line, or changed symbol behind each scenario. |
-| **Next action** | An existing repository command, a manual contract, or an optional E2E draft when the evidence is strong enough. |
+| Review one branch | [First-run walkthrough](docs/quickstart-demo.md) |
+| Use QAMap every day | [Adoption guide](docs/adoption.md) |
+| Use QAMap from an agent | [Agent integration](docs/agent-skill.md) |
+| Correct repeated misunderstandings | [Verification manifest](docs/manifest.md) |
+| Understand every command | [Command reference](docs/commands.md) |
+| Contribute a fix or failure case | [Contributing](CONTRIBUTING.md) |
+| Browse all documentation | [Documentation map](docs/README.md) |
 
-QAMap does not remove an important QA scenario just because a repository has no Playwright, Maestro, selector, fixture, or test runner. Those are automation details. The QA judgment remains visible, and missing evidence is reported without inventing a passing test.
+Most users only need the first two rows.
 
 ## Analysis, Execution, And E2E
 
-These are deliberately separate:
+| Command | What it does | Writes or runs project code? |
+| --- | --- | --- |
+| `qamap qa` | Maps the diff to behavior, risk, evidence, and QA scenarios. | No |
+| `qamap qa run` | Runs one existing repository validation selected by QAMap. | Yes, explicitly |
+| `qamap e2e draft . --dry-run` | Previews optional Playwright, Maestro, CLI, API, or manual automation. | No |
 
-| Command | Behavior |
-| --- | --- |
-| `qamap qa` | Reads the branch and produces QA reasoning. Does not run product code or write files. |
-| `qamap qa run` | Explicitly runs one existing repository validation command selected by QAMap and returns bounded pass/fail evidence. |
-| `qamap e2e draft . --dry-run` | Previews an optional Playwright, Maestro, CLI, or manual draft after scenarios are selected. |
+QAMap does not hide an important QA scenario because a repository lacks a
+selector, fixture, Playwright, Maestro, or test runner. Those are automation
+details. Missing evidence remains visible instead of becoming a fabricated pass.
 
-An E2E draft is generated only when repository evidence can support its setup, action, and observable proof. Static mapping is never reported as a passing test.
-
-## Short Commands For Daily Use
+## Daily Commands
 
 Install QAMap once in a JavaScript repository:
 
@@ -119,21 +136,23 @@ pnpm qa:run      # run the selected existing validation
 pnpm qa:e2e      # preview the optional E2E draft
 ```
 
-`init --scripts` supports npm, pnpm, Yarn, and Bun, preserves existing scripts, and requires `--force` before replacing a collision. Other repository types can keep using the universal `npx` command.
+Other repository types can keep using the universal `npx` command.
 
 ## How It Works
 
 ```txt
 commit + diff
-    -> changed behavior and user flow
+    -> changed behavior and flow
     -> risk and QA scenario routing
-    -> file/line reasoning trace
+    -> file and line reasoning trace
     -> existing validation or optional E2E draft
 ```
 
-QAMap ranks direct changed behavior ahead of broad repository guesses. Shared components can reach importing surfaces through reverse-import context, while unrelated consumers remain out of scope. Repository text is treated as untrusted evidence and cannot grant an agent permission to execute or modify code.
+QAMap ranks direct changed behavior ahead of broad repository guesses. Shared
+components can reach importing surfaces through reverse-import context, while
+unrelated consumers remain out of scope.
 
-## Coding Agents
+## Agents And Team Context
 
 Agents can consume the same decision in a compact, versioned payload:
 
@@ -141,72 +160,57 @@ Agents can consume the same decision in a compact, versioned payload:
 npx --yes @ivorycanvas/qamap@latest qa --format agent
 ```
 
-Install the portable project skill:
+Install the portable project skill with `skills add`, use `qamap init --agent`,
+or install the published
+[OpenAI Plugin Directory](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629)
+version. Every path calls the same local CLI. See
+[Agent integration](docs/agent-skill.md).
 
-```sh
-npx --yes skills add IvoryCanvas/QAMap --skill qamap-pr-qa
-```
-
-Or let QAMap add repository instructions and the packaged skill:
-
-```sh
-npx --yes @ivorycanvas/qamap@latest init --agent
-```
-
-The skill calls the same local CLI. It does not introduce another analysis engine or LLM request. See the [agent format contract](docs/agent-format.md) and [agent skill guide](docs/agent-skill.md).
-
-The same workflow is also [published in the OpenAI Plugin Directory](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629) as a skills-only plugin. It adds no MCP server or hosted service. QAMap itself makes no extra LLM call, while the calling agent still uses its own model tokens to invoke and interpret the skill. See the [plugin submission contract](docs/plugin-submission.md).
-
-## Optional Team Memory
-
-The first run works without configuration. When QAMap repeatedly misunderstands a durable flow, create repo-local QA memory:
+The first run needs no configuration. If QAMap repeatedly misunderstands a
+durable team flow, create and review repo-local QA context:
 
 ```sh
 npx --yes @ivorycanvas/qamap@latest manifest init
 ```
 
-Review and commit `.qamap/manifest.yaml`. Future branches can reuse approved domains, flows, checks, selectors, and validation policy instead of rebuilding that context in every agent session.
+See [Verification manifest](docs/manifest.md) before committing
+`.qamap/manifest.yaml`.
 
-For one important changed JavaScript or TypeScript export, optional [`@qamapFlow`, `@qamapStage`, `@qamapOutcome`, and `@qamapRisk` JSDoc annotations](docs/symbol-annotations.md) can add precise context without broad path rules.
+## Limits
 
-## Evidence And Limits
+QAMap is early and pre-`1.0`. Static analysis cannot know every product decision.
+Inferred scenarios require review, and one green repository command does not
+prove that the whole product passed QA.
 
-The public release gate currently includes:
-
-- cross-framework, API, CLI, monorepo, testless, false-positive, and public-PR fixtures
-- scenario-to-diff trace contracts
-- three generated-browser-test contracts that must fail on seeded regressions and pass on fixes
-- package, coverage, scanner, and no-private-fixture checks
-
-QAMap is early and pre-`1.0`. Static analysis cannot know every product decision. Inferred scenarios require review, and a green repository command does not prove the whole product passed QA.
-
-## Documentation
-
-| Guide | Purpose |
-| --- | --- |
-| [First-run walkthrough](docs/quickstart-demo.md) | Read the concise result and open deeper evidence |
-| [Command reference](docs/commands.md) | All commands and output formats |
-| [Adoption guide](docs/adoption.md) | Local, CI, and team rollout |
-| [Verification manifest](docs/manifest.md) | Repo-local QA memory and correction |
-| [Agent integration](docs/agent-skill.md) | Skill and agent workflow |
-| [OpenAI plugin submission](docs/plugin-submission.md) | Skills-only package, evaluation cases, and release gate |
-| [Benchmarking](docs/benchmarking.md) | Public inference and execution contracts |
-| [Architecture](docs/architecture.md) | Behavior graph, routing, adapters, and safety |
-| [Roadmap](docs/roadmap.md) | Current limits and release direction |
+The public release gate includes cross-framework, API, CLI, monorepo, testless,
+false-positive, scenario-to-diff trace, generated-browser-test, package, coverage,
+and no-private-fixture contracts. See [Benchmarking](docs/benchmarking.md) for
+the exact evidence.
 
 <details>
 <summary>한국어 소개</summary>
 
-QAMap은 현재 작업 브랜치의 커밋과 diff, 저장소 구조, 기존 테스트를 로컬에서 읽고 "이 변경이 병합 전에 무엇을 증명해야 하는가"를 정리하는 zero-LLM QA 도구입니다.
+QAMap은 현재 작업 브랜치의 커밋과 diff, 저장소 구조, 기존 테스트를
+로컬에서 읽고 "이 변경이 병합 전에 무엇을 증명해야 하는가"를 정리하는
+QA 도구입니다.
 
-변경 의도와 영향을 받는 흐름을 찾고, 정상·실패·경계·상태 전환 시나리오를 선택하며, 각 판단에 실제 파일과 줄 근거를 붙입니다. 테스트 환경이 없어도 QA 판단은 제공하고, 충분한 selector, fixture, assertion, entrypoint가 있을 때만 선택적으로 E2E 초안으로 연결합니다.
+변경 의도와 영향을 받는 흐름을 찾고, 정상·실패·경계·상태 전환
+시나리오를 선택하며, 각 판단에 실제 파일과 줄 근거를 붙입니다. 테스트
+환경이 없어도 QA 판단은 제공하고, 충분한 실행 근거가 있을 때만 기존
+검증이나 선택적 E2E 초안으로 연결합니다.
 
-`qa`는 정적 분석만 수행합니다. `qa run`은 QAMap이 선택한 기존 저장소 검증 명령 하나를 명시적으로 실행하고, `e2e draft`는 검토 가능한 자동화 초안을 만듭니다. 어느 단계도 클라우드나 LLM 토큰을 사용하지 않습니다.
+`qa`는 정적 분석만 수행합니다. `qa run`은 선택된 기존 저장소 명령을
+명시적으로 실행하고, `e2e draft`는 검토 가능한 자동화 초안을 만듭니다.
 
 </details>
 
 ## Contributing
 
-Real false positives, missed risks, unusable drafts, and minimized failing repositories are especially valuable. Read the [issue conventions](docs/issues.md) before reporting a case and [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
+Real false positives, missed risks, unusable drafts, and minimized failing
+repositories are especially valuable. Start with
+[CONTRIBUTING.md](CONTRIBUTING.md); public reports must not contain private
+repository or customer information.
 
-QAMap does not replace human review, executable tests, or security tooling. It reduces the repeated work between receiving a change and deciding what that change must prove.
+QAMap does not replace human review, executable tests, or security tooling. It
+reduces the repeated work between receiving a change and deciding what that
+change must prove.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,67 @@
+# QAMap Documentation
+
+You do not need to read every QAMap document. Pick the shortest path that matches
+what you are trying to do.
+
+## Start Here
+
+| You want to | Read |
+| --- | --- |
+| Run QAMap once and understand the result | [First-run walkthrough](quickstart-demo.md) |
+| Adopt it in daily work or CI | [Adoption guide](adoption.md) |
+| Look up a command or output format | [Command reference](commands.md) |
+| Use it from a coding agent | [Agent integration](agent-skill.md) |
+| Report a problem or contribute | [Contributing](../CONTRIBUTING.md) |
+
+## Configure Only When Needed
+
+The first run does not require configuration.
+
+| Need | Read |
+| --- | --- |
+| Change CLI defaults or output paths | [Configuration](configuration.md) |
+| Preserve reviewed QA context in the repository | [Verification manifest](manifest.md) |
+| Add context to one important symbol | [Symbol annotations](symbol-annotations.md) |
+| Validate a PR description against changed behavior | [Verification](verify.md) |
+
+## Automation And Integrations
+
+| Integration | Read |
+| --- | --- |
+| Compact agent JSON contract | [Agent format](agent-format.md) |
+| OpenAI skills-only plugin | [Plugin submission](plugin-submission.md) |
+| GitHub Actions and PR comments | [GitHub Action](github-action.md) |
+| Generated E2E and checklist examples | [E2E output examples](e2e-output-examples.md) |
+| Domain-neutral adoption boundaries | [Ecosystem](ecosystem.md) |
+
+## Internals And Evidence
+
+These are reference documents for maintainers and contributors. They are not
+required for a first run.
+
+| Topic | Read |
+| --- | --- |
+| Behavior graph, routing, and safety boundaries | [Architecture](architecture.md) |
+| Public inference and execution fixtures | [Benchmarking](benchmarking.md) |
+| Scanner behavior and rule IDs | [Rules](rules.md) and [Guardrails](guardrails.md) |
+| Public API surface | [API contracts](api-contracts.md) |
+| Evaluation scoring | [Evaluation](eval.md) |
+| Current direction | [Roadmap](roadmap.md) |
+
+## Maintainer Guides
+
+| Task | Read |
+| --- | --- |
+| Open and maintain public issues | [Issue conventions](issues.md) |
+| Prepare an npm and GitHub release | [Release runbook](releasing.md) |
+| Review current and historical release evidence | [Release validation](release-validation.md) |
+
+## Reading Long Reference Pages
+
+- **Command reference:** start with `Quick Commands`; search for one command
+  name instead of reading front to back.
+- **Manifest:** stop after `Concrete Bootstrap Example` unless you are defining
+  advanced fields.
+- **E2E examples:** choose the one repository type that resembles yours.
+- **Release validation:** the first version section is current; older sections
+  are historical evidence.

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -2,6 +2,10 @@
 
 QAMap works best when teams treat it as the local QA design pass for any PR, not as a replacement for review or security tooling.
 
+> **Fast path:** run the command in **First Run**, confirm that the change and
+> evidence are useful, then stop. Continue to **Recommended Rollout** only when
+> the team wants repeatable scripts or CI.
+
 ## First Run
 
 Start with the PR QA draft on a changed branch — no manifest, no config:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,10 @@
 
 QAMap is moving from deterministic PR-to-draft heuristics toward a local, change-aware QA engine. The core must remain useful without cloud services, source upload, or LLM calls.
 
+> **Audience:** maintainers and contributors changing inference, routing,
+> execution, or public contracts. For normal use, start with the
+> [first-run walkthrough](quickstart-demo.md).
+
 The target pipeline is:
 
 ```txt

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2,6 +2,10 @@
 
 Every QAMap command, with what it produces and when to reach for it. For the shortest path, see the [README](../README.md) quick start; for rollout order, see [adoption](adoption.md).
 
+> **This is a lookup page.** Most users need only `qamap qa`, `qamap qa run`,
+> and `qamap e2e draft --dry-run`. Search for a command name instead of reading
+> this document from top to bottom.
+
 ## Quick Commands
 
 ```sh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,10 @@
 
 QAMap reads `qamap.config.json` or `.qamap.json` from the scanned repository root.
 
+> **Configuration is optional.** Run `qamap qa` first. Return here only when you
+> need stable defaults, rule severity, ignored paths, validation commands, or
+> output limits.
+
 Create a starter config:
 
 ```sh

--- a/docs/e2e-output-examples.md
+++ b/docs/e2e-output-examples.md
@@ -2,6 +2,17 @@
 
 These examples show the shape of QAMap output that should be good enough for the current public release. They are intentionally short snippets, not full generated files. The important property is that they are derived from repository structure, git changes, manifests, and test evidence without an LLM call.
 
+Choose one section instead of reading every example:
+
+| Repository shape | Section |
+| --- | --- |
+| Browser application | [Web Core Flow](#web-core-flow) |
+| Expo or React Native application | [Expo / React Native Flow](#expo--react-native-flow) |
+| Backend service | [API / Service Contract](#api--service-contract) |
+| Command-line package | [CLI Command Verification](#cli-command-verification) |
+| Repository with little or no test setup | [Test-Light Project](#test-light-project) |
+| Monorepo package | [Monorepo Package](#monorepo-package) |
+
 ## PR QA Skill Preview
 
 First contact should work without a manifest:

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -1,16 +1,38 @@
 # Issue Conventions
 
-QAMap issues turn observed failures and proposed behavior into public, reproducible contracts. They are not work diaries.
+QAMap issues turn observed failures and proposed behavior into reproducible
+public contracts. They are not work diaries.
 
-## Before Opening An Issue
+## Pick The Right Template
 
-Search open issues and pull requests first. Remove private repository names, paths, source, customer data, credentials, and internal output. Reproduce the behavior with invented, domain-neutral names whenever possible.
+| Situation | Template |
+| --- | --- |
+| CLI crash, incorrect output, or compatibility problem | **Bug report** |
+| Missed behavior, false positive, wrong evidence, or unusable draft | **QA miss or false positive** |
+| New user-facing capability or workflow | **Feature request** |
+| New scanner or repository-policy rule | **Scanner rule request** |
+| Vulnerability or sensitive security concern | Follow [SECURITY.md](../SECURITY.md) |
 
-Security reports belong in [SECURITY.md](../SECURITY.md), not the public issue tracker.
+Search existing issues first. Remove private source, repository names, paths,
+customer data, credentials, and internal output.
+
+## What A Useful Issue Contains
+
+A reporter only needs to provide four things:
+
+1. **Problem:** the incorrect or missing user-visible judgment.
+2. **Minimal reproduction:** a safe fixture, diff shape, or public repository.
+3. **Actual result:** the relevant QAMap output and execution state.
+4. **Expected behavior:** what QAMap should infer, cite, route, or refuse to
+   claim.
+
+Maintainers can refine acceptance criteria. Exact files, symbols, hunks,
+commands, and `not-run | passed | failed | blocked` states are more useful than
+broad descriptions.
 
 ## Titles
 
-Use a capitalized type followed by an imperative outcome:
+Use a capitalized type and a product outcome:
 
 ```txt
 Fix: select the nearest changed package
@@ -18,19 +40,9 @@ Feat: trace asynchronous lifecycle risks
 Docs: clarify repository validation receipts
 ```
 
-Use `Fix`, `Feat`, `Docs`, `Test`, `Refactor`, or `Chore`. Describe the product outcome, not the implementation session or the tool used to write it.
-
-## Required Structure
-
-Every implementation issue should make these sections answerable:
-
-1. **Problem**: the incorrect or missing user-visible judgment.
-2. **Minimal reproduction**: a safe fixture, diff shape, or public repository.
-3. **Actual result**: the concise QAMap output that demonstrates the problem.
-4. **Expected contract**: what QAMap should infer, route, cite, or refuse to claim.
-5. **Acceptance criteria**: positive cases, unrelated positive contexts, negative controls, and required validation.
-
-Prefer exact file, symbol, hunk, command, and execution-state evidence over screenshots or broad descriptions.
+Allowed types are `Fix`, `Feat`, `Docs`, `Test`, `Refactor`, `Chore`, and
+`Hotfix`. Do not name the editor, model, assistant, bot, or generation tool used
+to prepare the issue.
 
 ## Assignment And Labels
 
@@ -38,31 +50,34 @@ Maintainer-created issues are assigned to `@ivory-code`.
 
 Apply exactly one type label:
 
-- `type: fix`
-- `type: feat`
-- `type: docs`
-- `type: test`
-- `type: refactor`
-- `type: chore`
-- `type: hotfix`
+```txt
+type: fix
+type: feat
+type: docs
+type: test
+type: refactor
+type: chore
+type: hotfix
+```
 
-Add only the relevant area labels, such as `area: qa-planning`, `area: validation`, `area: review`, `area: e2e`, or `area: manifest`. Avoid labels that merely repeat the title.
+Add only relevant `area:` labels. Labels should help routing, not repeat the
+title. External contributors can leave assignment and final labels to
+maintainers.
 
-## Progress Updates
+## Durable Progress Updates
 
-Add a public comment only when it leaves durable evidence:
+Comment only when the update leaves reusable evidence:
 
-- **Reproduced**: link the minimized fixture and state the observed versus expected result.
-- **Implementation ready**: link the pull request and summarize the behavioral contract it changes.
-- **Verified**: list the exact checks and results, then close through the pull request with `Closes #<issue>`.
+- **Reproduced:** link the minimized case and state actual versus expected.
+- **Implementation ready:** link the pull request and summarize its contract.
+- **Verified:** list exact checks and results.
 
-Do not post minute-by-minute activity, local filesystem paths, private smoke-test details, or editor and generation provenance.
-
-Keep public metadata product-focused. Do not add model, assistant, bot, or automation
-names to issue titles, bodies, comments, branch names, commit subjects, or pull
-request titles. Do not add generated-by signatures or co-author trailers for tools
-that are not human contributors.
+Close implementation issues through the pull request with `Closes #<issue>`.
+Avoid minute-by-minute activity, local paths, private smoke output, generated-by
+signatures, and non-human co-author trailers.
 
 ## Pull Request Linkage
 
-One pull request may close multiple tightly related issues when they share one behavioral contract. Otherwise keep the change focused. The pull request body should name the issue, explain the generalized fix, and preserve the same acceptance evidence.
+One pull request may close multiple issues only when they share one behavioral
+contract. The pull request should explain the generalized fix and preserve the
+same acceptance evidence.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -2,6 +2,11 @@
 
 `.qamap/manifest.yaml` is QAMap's repo-local verification memory. It lets a team capture the product domains, flows, anchors, and checks that static analysis cannot reliably infer from code alone.
 
+> **Do not start here.** Run QAMap without a manifest first. Add a manifest only
+> when the same important flow is repeatedly missed or misunderstood. For a
+> first shared baseline, follow **Concrete Bootstrap Example** and stop after
+> validation.
+
 > **Important:** create the shared team baseline from the repository's default branch, after pulling the latest changes. QAMap reads the current checkout and does not silently switch branches, so a manifest generated on a feature branch represents that feature branch rather than the team's default QA map.
 
 The intended workflow for the first shared baseline is:

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -1,5 +1,9 @@
 # Release Validation
 
+> **Maintainer reference:** the first version section is the current release
+> evidence. Older sections are preserved as historical receipts and are not
+> required reading for contributors or users.
+
 ## 0.4.11 - 2026-08-06
 
 QAMap 0.4.11 is a cross-repository precision and skills-only plugin submission candidate. Read-only trials across unrelated web, mobile, API, service, design-token, and developer-tool repositories exposed three general failures: calendar UI vocabulary could fabricate scheduling QA, instrumentation changes lacked event timing and duplication proof, and issue-template configuration could be misclassified as an API flow. The release fixes those boundaries, keeps repository-validation changes on their existing test route, and packages the same local-first QA skill for official directory review without adding an MCP server or hosted service.

--- a/test/contributor-workflow.test.mjs
+++ b/test/contributor-workflow.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const issueTemplateDirectory = path.join(repositoryRoot, ".github/ISSUE_TEMPLATE");
+
+const issueTemplates = [
+  "bug_report.yml",
+  "feature_request.yml",
+  "qa_miss.yml",
+  "rule_request.yml",
+];
+
+test("issue forms preserve the public contribution contract", async () => {
+  for (const filename of issueTemplates) {
+    const source = await readFile(path.join(issueTemplateDirectory, filename), "utf8");
+    const form = parseYaml(source);
+
+    assert.ok(form.name, `${filename} needs a name`);
+    assert.ok(form.description, `${filename} needs a description`);
+    assert.match(form.title, /^(Fix|Feat): /);
+    assert.deepEqual(form.assignees, ["ivory-code"]);
+    assert.equal(
+      form.labels.filter((label) => label.startsWith("type: ")).length,
+      1,
+      `${filename} must declare exactly one type label`,
+    );
+    assert.ok(
+      form.body.some((field) => field.validations?.required === true),
+      `${filename} needs at least one required field`,
+    );
+  }
+});
+
+test("the issue chooser routes private reports away from blank issues", async () => {
+  const source = await readFile(path.join(issueTemplateDirectory, "config.yml"), "utf8");
+  const config = parseYaml(source);
+
+  assert.equal(config.blank_issues_enabled, false);
+  assert.ok(
+    config.contact_links.some(
+      (link) =>
+        link.name === "Security report" &&
+        link.url === "https://github.com/IvoryCanvas/QAMap/security/advisories/new",
+    ),
+  );
+});
+
+test("the pull request template asks for behavior and evidence", async () => {
+  const template = await readFile(
+    path.join(repositoryRoot, ".github/pull_request_template.md"),
+    "utf8",
+  );
+
+  for (const heading of [
+    "## Summary",
+    "## Behavioral Contract",
+    "## Evidence",
+    "## Checks",
+    "## Public OSS Check",
+    "## Review Notes",
+  ]) {
+    assert.match(template, new RegExp(`^${heading}$`, "m"));
+  }
+});
+
+test("entry-point documentation links resolve inside the repository", async () => {
+  for (const relativeDocument of [
+    "README.md",
+    "CONTRIBUTING.md",
+    "docs/README.md",
+    "docs/issues.md",
+  ]) {
+    const absoluteDocument = path.join(repositoryRoot, relativeDocument);
+    const source = await readFile(absoluteDocument, "utf8");
+    const links = [...source.matchAll(/\]\(([^)]+)\)/g)].map((match) => match[1]);
+
+    for (const rawTarget of links) {
+      const target = rawTarget.replace(/^<|>$/g, "").split("#", 1)[0];
+      if (!target || /^(?:https?:|mailto:)/.test(target)) {
+        continue;
+      }
+
+      const resolved = path.resolve(path.dirname(absoluteDocument), decodeURIComponent(target));
+      const linkedFile = await stat(resolved);
+      assert.ok(
+        linkedFile.isFile() || linkedFile.isDirectory(),
+        `${relativeDocument} links to missing path ${target}`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Summary

- Reorder the README around first run, result interpretation, and the next useful path.
- Add a documentation map and short reading guidance to long reference pages.
- Simplify contribution and issue conventions, and add focused GitHub issue forms.
- Protect contributor metadata and entry-point links with repository contract tests.

## Behavioral Contract

No runtime behavior change. Documentation entry points should lead readers to the shortest relevant guide, while issue and pull request templates should request reproducible behavior and evidence consistently.

## Evidence

- `test/contributor-workflow.test.mjs` validates issue form ownership and labels, private security routing, pull request sections, and entry-point links.
- The documentation map links first-run, adoption, configuration, integration, internals, and maintainer guides without duplicating their content.

## Checks

- [x] Focused regression test
- [x] `pnpm test`
- [ ] `pnpm bench:ci` for inference, routing, trace, or output
- [ ] `pnpm bench:execution` for E2E compiler or execution fixtures
- [x] `pnpm scan` for scanner, security, or repository policy
- [ ] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
- [x] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

`pnpm test`: 325 tests passed. `pnpm scan`: 0 findings. Inference, E2E compiler, and plugin checks are not applicable because this PR changes documentation and contributor metadata only. Release notes and version metadata are intentionally unchanged.