### PR TITLE
Docs: make plugin installation easier to find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- The README first screen now makes the OpenAI plugin installation path explicit, links the published listing and official installation guide, and distinguishes app installation from a one-off local CLI run.
 - Change-intent clustering now uses commit scope and subject rather than body prose, treats distinct issue tags as intent boundaries, and splits transitive keyword chains around a behavior-bearing anchor.
 - Cleanup-only commits remain visible as provenance with zero standalone QA scenarios, while behavior-describing refactors stay eligible for review.
 - Human and agent documentation now explains provenance-only intents and explicit observable-proof gaps.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,12 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 <a href="https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629">
-  <img src="docs/assets/openai-plugin-directory-badge.svg" alt="QAMap is available in the OpenAI Plugin Directory" height="64">
+  <img src="docs/assets/openai-plugin-directory-badge.svg" alt="Install QAMap from the OpenAI Plugin Directory" height="64">
 </a>
+
+**Install in ChatGPT or Codex:** open **Plugins**, search for **QAMap**, select
+**+**, then start a new chat. [Open QAMap](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629)
+· [Installation guide](https://learn.chatgpt.com/docs/plugins)
 
 ![QAMap: find what a change needs to prove](docs/assets/qamap-cover.png)
 
@@ -23,7 +27,7 @@ existing tests, and diff evidence to answer:
 QAMap itself makes no cloud analysis, source upload, or additional LLM call. A
 manifest and test runner are optional.
 
-## Start In 60 Seconds
+## Run The CLI In 60 Seconds
 
 Requires Node.js 20 or newer. Run this from the branch you want to review:
 

--- a/docs/assets/openai-plugin-directory-badge.svg
+++ b/docs/assets/openai-plugin-directory-badge.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="360" height="64" viewBox="0 0 360 64" role="img" aria-labelledby="title description">
-  <title id="title">QAMap in the OpenAI Plugin Directory</title>
-  <desc id="description">Open the published QAMap listing in the OpenAI Plugin Directory.</desc>
+  <title id="title">Install QAMap from the OpenAI Plugin Directory</title>
+  <desc id="description">Open the published QAMap listing and install the plugin.</desc>
   <rect x="0.5" y="0.5" width="359" height="63" rx="8" fill="#07111f" stroke="#27466e"/>
   <g transform="translate(10 10)">
     <rect x="0.5" y="0.5" width="43" height="43" rx="10" fill="#07111f" stroke="#27466e"/>
@@ -14,6 +14,6 @@
     <circle cx="22" cy="41" r="6" fill="#07111f" stroke="#ffb414" stroke-width="2"/>
     <path d="M18.5 41L21 43.5L25.5 38.5" fill="none" stroke="#ffb414" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
-  <text x="68" y="25" fill="#8ea4bc" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600">AVAILABLE IN</text>
+  <text x="68" y="25" fill="#8ea4bc" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600">INSTALL QAMAP FROM</text>
   <text x="68" y="47" fill="#f5f8fc" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="18" font-weight="600">OpenAI Plugin Directory</text>
 </svg>


### PR DESCRIPTION
## Summary

- Make the published OpenAI plugin installation path explicit on the README first screen.
- Explain the short Plugins → QAMap → + → new chat flow beside the directory badge.
- Distinguish app installation from the one-off local CLI path.

Closes #163

## Behavioral Contract

No runtime behavior change. A first-time visitor can identify and follow either the OpenAI plugin path or the local CLI path without inferring that the directory badge is only informational.

## Evidence

- Public OpenAI listing link retained.
- Official plugin installation guide returns HTTP 200.
- Updated SVG badge rendered at its committed dimensions without clipped text.

## Checks

- [x] Focused regression test
- [x] `pnpm test`
- [ ] `pnpm bench:ci` for inference, routing, trace, or output
- [ ] `pnpm bench:execution` for E2E compiler or execution fixtures
- [ ] `pnpm scan` for scanner, security, or repository policy
- [x] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
- [x] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

`pnpm bench:ci`, `pnpm bench:execution`, and `pnpm scan` are N/A because this PR changes only public onboarding copy and one documentation asset. Focused documentation tests passed 4/4; the full suite passed 330/330; the isolated plugin smoke packed 172 files and produced one evidence-backed intent.