### PR TITLE
Chore: prepare 0.4.12 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qamap",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Turn PR changes into traceable local QA decisions and optional automation handoffs without an LLM call.",
   "author": {
     "name": "IvoryCanvas",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qamap",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Turn PR changes into traceable local QA decisions and optional automation handoffs without an LLM call.",
   "author": {
     "name": "IvoryCanvas",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.4.12 - 2026-08-07
+
 ### Changed
 
 - The README first screen now makes the OpenAI plugin installation path explicit, links the published listing and official installation guide, and distinguishes app installation from a one-off local CLI run.

--- a/docs/plugin-submission.md
+++ b/docs/plugin-submission.md
@@ -4,6 +4,11 @@ QAMap packages one `skills-only` plugin for the shared OpenAI Plugins Directory.
 
 QAMap `0.4.11` is approved and [published in the OpenAI Plugin Directory](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629). This repository remains the source of truth for the reviewed skill package and future listing updates.
 
+Publishing a newer npm package or repository release does not update the
+directory listing automatically. Keep the approved version available, upload
+the replacement package as a new plugin version, and publish it only after the
+replacement passes review.
+
 ## Product Boundary
 
 - The first action is the read-only `qamap qa --format agent` analysis.

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -4,13 +4,15 @@
 > evidence. Older sections are preserved as historical receipts and are not
 > required reading for contributors or users.
 
-## Unreleased
+## 0.4.12 - 2026-08-07
 
-The current development branch tightens the first-run contract between commit
-history and required QA. Cleanup-only commits remain visible without creating
-standalone scenarios, unrelated work cannot join through transitive keyword
-bridges or repeated commit-body prose, and a primary scenario cannot use a raw
-implementation symbol or its own title as observable proof.
+QAMap 0.4.12 tightens the first-run contract between commit history and
+required QA. Cleanup-only commits remain visible without creating standalone
+scenarios, unrelated work cannot join through transitive keyword bridges or
+repeated commit-body prose, and a primary scenario cannot use a raw
+implementation symbol or its own title as observable proof. The README also
+makes the published OpenAI plugin installation route explicit while preserving
+the one-off local CLI path.
 
 | Gate | Current result |
 | --- | --- |
@@ -19,9 +21,9 @@ implementation symbol or its own title as observable proof.
 | `pnpm scan` | 0 findings |
 | `pnpm bench:ci` | All static recommendation contracts passing |
 | `pnpm bench:execution` | 3/3 execution contracts passing; duplicate-request, missing-persistence, and stale-validation regressions caught |
-| Coverage | Lines 89.73%, branches 86.48%, functions 95.70% |
+| Coverage | Lines 89.73%, branches 86.46%, functions 95.70% |
 | Plugin package check | Submission metadata valid; isolated packed install produced one intent with one exact evidence trace |
-| Package preview | `pnpm pack --dry-run` passes for `@ivorycanvas/qamap@0.4.11`; 172 files packed |
+| Package preview | `pnpm pack --dry-run` passes for `@ivorycanvas/qamap@0.4.12`; 172 files packed |
 | Focused regressions | Cleanup-only, behavior-changing refactor, distinct issue tags, repeated commit-body vocabulary, transitive bridges, visible proof, and proof-gap controls pass |
 | Public repository replay | Documenso PRs #3032 and #2889 plus Formbricks PRs #8683 and #8691 analyzed read-only |
 | Cleanup handling | `Minor refactor` and `Tidy up and add tests` remain provenance-only and do not produce QA contracts or fallback smoke flows |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Local zero-LLM PR QA designer that maps commit intent and diffs to traceable behavior lifecycles, QA scenarios, and optional automation drafts.",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugin/submission.json
+++ b/plugin/submission.json
@@ -73,5 +73,5 @@
       "reason": "The plugin must preserve the host's approval policy and QAMap's explicit action boundary."
     }
   ],
-  "releaseNotes": "Initial skills-only submission. QAMap analyzes local branch changes without an additional LLM call, returns compact evidence-backed QA routing, and keeps repository execution and optional automation behind explicit action contracts."
+  "releaseNotes": "QAMap 0.4.12 keeps cleanup-only work as provenance, separates unrelated commit lifecycles, reports missing observable proof explicitly, and makes the published plugin installation route easier to find."
 }

--- a/skills/qamap-pr-qa/SKILL.md
+++ b/skills/qamap-pr-qa/SKILL.md
@@ -21,7 +21,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
    If QAMap is not installed, disclose that the next command downloads the pinned package from the npm registry and follow the host's network approval policy before running it:
 
    ```sh
-   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.11 -- qamap qa . --base <base> --head HEAD --format agent
+   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.12 -- qamap qa . --base <base> --head HEAD --format agent
    ```
 
    This one-off form runs outside the target repository's package-manager contract, so it does not invoke Corepack or add a `packageManager` field. QAMap's analysis does not upload source code or make another LLM call. The calling agent still uses its own model tokens to invoke the skill and interpret the compact result.
@@ -35,7 +35,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
    - Use an explicit scoped pass only when a human wants to override that decision:
 
    ```sh
-   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.11 -- qamap qa <package-path> --workspace-root . --base <base> --head HEAD
+   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.12 -- qamap qa <package-path> --workspace-root . --base <base> --head HEAD
    ```
 
 4. Read and verify intent before generating code. In agent format:
@@ -58,7 +58,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
    - `run-repository-command` — when policy permits repository code execution, prefer QAMap's bounded executor so analysis and execution share one receipt:
 
      ```sh
-     npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.11 -- qamap qa run . --base <base> --head HEAD --format agent
+     npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.12 -- qamap qa run . --base <base> --head HEAD --format agent
      ```
 
      It re-analyzes the change and runs only the exact selected existing repository command. Do not substitute another command or run it again when `execution.performed` is true.
@@ -68,7 +68,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
 6. Only after a human or team accepts the scenario and automation adapter, create or preview executable coverage:
 
    ```sh
-   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.11 -- qamap e2e draft . --base <base> --head HEAD --dry-run
+   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.12 -- qamap e2e draft . --base <base> --head HEAD --dry-run
    ```
 
    If the selected adapter is absent, inspect and explicitly accept the `automation.setupCommand` proposal. Never install a runner merely because QAMap detected a web or mobile surface.
@@ -104,7 +104,7 @@ When the recommendation is wrong or too broad, do not repeatedly re-prompt for t
 If the team accepts QAMap for ongoing use, suggest this follow-up:
 
 ```sh
-npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.11 -- qamap manifest init .
+npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.12 -- qamap manifest init .
 ```
 
 Then humans should review `.qamap/manifest.yaml` and keep only durable team QA language.

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const TOOL_NAME = "QAMap";
-export const VERSION = "0.4.11";
+export const VERSION = "0.4.12";


### PR DESCRIPTION
## Summary

Align the package, CLI, plugin manifests, and portable skill on `0.4.12`. Publish the release notes and validation receipt, and document that npm and OpenAI Plugin Directory versions are updated independently.

## Behavioral Contract

No new runtime behavior change. Every repository release surface reports `0.4.12`, while the currently approved OpenAI directory listing remains `0.4.11` until a replacement package is reviewed and published.

## Evidence

Closes #165.

Includes the release-ready changes delivered through #162 and the installation-path clarification from #164.

## Checks

- [x] Focused regression test
- [x] `pnpm test`
- [x] `pnpm bench:ci` for inference, routing, trace, or output
- [x] `pnpm bench:execution` for E2E compiler or execution fixtures
- [x] `pnpm scan` for scanner, security, or repository policy
- [x] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
- [x] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

`pnpm release:check` passed end to end: 330/330 tests, 0 scanner findings, all static contracts, 3/3 execution contracts, 89.73% line / 86.46% branch / 95.70% function coverage, and a 172-file package preview.

The release commit does not publish npm, create a tag, create a GitHub Release, or replace the approved OpenAI directory version. Those actions follow successful npm publication.