### PR TITLE
fix: keep matcher vocabulary out of lifecycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - Documentation and contributor-workflow changes no longer produce clean-install, app-launch, endpoint, authentication, response-shape, selector, fixture, or product E2E guidance without runtime evidence.
 - Compact agent output now prioritizes changed guides and contributor templates over accompanying release notes and generated documentation assets.
+- Static-analysis source classifiers and regular-expression vocabulary no longer become fabricated user actions; executable product calls remain eligible when the diff supports them.
 
 ## 0.4.12 - 2026-08-07
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,6 +86,8 @@ Product sources can contribute user actions, state, effects, and outcomes. Comma
 
 The same boundary applies downstream. E2E setup and fixture discovery only inspect runtime-relevant product, command, and configuration evidence. Analyzer rules and benchmark vocabulary may explain why a QA scenario exists, but `/api`, `fixture`, payment, scheduling, or routing words inside those files cannot create product setup requirements by themselves.
 
+Lifecycle extraction applies the same rule inside source lines. Tokens inside regular-expression literals are matcher vocabulary, not function calls, and source-role classifiers require analyzer structure before they can contribute analysis-rule evidence. Real calls in product sources remain eligible, so this boundary removes fabricated actions without hiding executable behavior.
+
 Repository boundaries are evidence boundaries too. A nested directory containing its own `.git` file or directory is a separate working copy, even when it lives under the analyzed root. Project, import-graph, workspace-package, test, mock, and fixture discovery must not borrow evidence from that nested repository. This prevents an abandoned worktree or local clone from making the current change appear tested or fixture-ready.
 
 ## Scenario Routing and Compilation Receipts

--- a/src/change-intent.ts
+++ b/src/change-intent.ts
@@ -2796,6 +2796,9 @@ function collectCodeBehaviorSignalsFromText(
   }
   for (const match of text.matchAll(/\b([A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)*)\s*\(/g)) {
     const symbol = match[1];
+    if (isInsideRegexLiteral(text, match.index ?? 0)) {
+      continue;
+    }
     const prefix = text.slice(0, match.index ?? 0);
     if (/\b(?:function|class)\s+$/.test(prefix)) {
       continue;
@@ -2817,6 +2820,11 @@ function collectCodeBehaviorSignalsFromText(
       evidence: codeSignalEvidence(label, file, symbol, hunk, line),
     });
   }
+}
+
+function isInsideRegexLiteral(text: string, index: number): boolean {
+  const prefix = text.slice(0, index);
+  return /(?:^|\b(?:return|case)\s+|[=(:,!\[{};?&|]\s*)\/(?![/*])(?:\\.|[^/\\\n])*$/.test(prefix);
 }
 
 function codeSignalEvidence(

--- a/src/source-role.ts
+++ b/src/source-role.ts
@@ -106,6 +106,8 @@ function hasCommandSourceSignal(text: string): boolean {
 function isAnalysisRuleSource(file: string, text: string): boolean {
   const pathSignal = /(?:^|\/)(?:analyzers?|classifiers?|heuristics?|linters?|matchers?|policies|rules?|scanner)(?:\/|$)/i.test(file) ||
     /(?:^|\/)(?:change-intent|scenario-routing|qa|qa-trace|rule-engine|analyzer|classifier|heuristic|linter|matcher|scanner)(?:\.[^/]+)?$/i.test(file);
+  const sourceRoleClassifier = /(?:^|\/)source-role(?:\.[^/]+)?$/i.test(file) &&
+    /\b(?:classify\w*SourceRole|is\w*Path|repository-workflow)\b/i.test(text);
   const staticAnalysisSignal = /\b(?:static[- ]analysis|false positive|negative control|qa scenario|reasoning trace|scenario routing|change intent|diff evidence|source role|routed scenario|analyzer adapter|lint(?:er|ing)?)\b|\b(?:AddedDiffEvidence|ChangeIntentEvidence|QaReasoningTrace|build\w*(?:Trace|Evidence|Scenario)|collectAddedDiffEvidence|routeQaScenario|scenarioAutomation|scenarioEvidence|classifyChangeSourceRole|sourceRole|mustNot\w*|mustFind\w*)\b/i.test(text);
   const vocabularyRuleSignal = /\b(?:analyze\w*Evidence|collect\w*Evidence|\w+Vocabulary|evidencePattern|rulePattern)\b/i.test(text);
   const ruleStructure = /\bRegExp\b|\.match(?:All)?\s*\(|\.test\s*\(|(?:^|\s)\/(?:\\.|[^/\n]){3,}\/\w*|mustNot|mustFind|pattern/i.test(text);
@@ -121,7 +123,8 @@ function isAnalysisRuleSource(file: string, text: string): boolean {
   if (analyzerSchema) {
     return true;
   }
-  return (pathSignal && (staticAnalysisSignal || vocabularyRuleSignal || analyzerContractStructure)) ||
+  return sourceRoleClassifier ||
+    (pathSignal && (staticAnalysisSignal || vocabularyRuleSignal || analyzerContractStructure)) ||
     (staticAnalysisSignal && (ruleStructure || analyzerContractStructure)) ||
     agentActionContractStructure ||
     (repositoryAnalysisStructure && (qaPlanningStructure || repositoryContextPath));

--- a/test/change-intent.test.mjs
+++ b/test/change-intent.test.mjs
@@ -1104,6 +1104,80 @@ test("analysis-only changes stay analyzer verification even inside a CLI reposit
   assert.ok(compactSummary.flows[0].steps.length > 0);
 });
 
+test("analyzer path constants do not become executable lifecycle actions", async (t) => {
+  const root = await makeRepo(t);
+  const sourceRoleFile = "src/source-role.ts";
+  await write(
+    root,
+    sourceRoleFile,
+    [
+      "export type SourceRole =",
+      '  | "product";',
+      "export function classifySourceRole(_file) {",
+      "  return 'product';",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  commit(root, "benchmark baseline");
+  branch(root, "fix/repository-workflow-role");
+  await write(
+    root,
+    sourceRoleFile,
+    [
+      "export type SourceRole =",
+      '  | "product"',
+      '  | "repository-workflow";',
+      "export function classifySourceRole(file) {",
+      "  if (isRepositoryWorkflowPath(file)) return 'repository-workflow';",
+      "  return 'product';",
+      "}",
+      "export function isRepositoryWorkflowPath(file) {",
+      "  return /(?:^|\\/)\\.github\\/(?:ISSUE_TEMPLATE\\/.+|PULL_REQUEST_TEMPLATE(?:\\/.*)?\\.md|CODEOWNERS)$/i.test(file);",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  commit(root, "fix: classify repository workflow metadata");
+
+  const qa = await generateQaDraft(root, { base: "main", head: "HEAD" });
+  const lifecycle = qa.changeAnalysis.intents.flatMap((intent) => intent.lifecycle);
+  const evidence = qa.changeAnalysis.intents.flatMap((intent) => intent.evidence);
+  const agent = formatAgentQaDraft(qa);
+
+  assert.ok(evidence.some((item) => item.sourceRole === "analysis-rule"));
+  assert.ok(lifecycle.some((stage) => /positive and negative controls/i.test(stage.label)));
+  assert.equal(lifecycle.some((stage) => /PULL_REQUEST_TEMPLATE|CODEOWNERS/.test(stage.label)), false);
+  assert.doesNotMatch(agent, /Invoke `(?:PULL_REQUEST_TEMPLATE|CODEOWNERS)`/);
+});
+
+test("regex group vocabulary does not hide real product calls or become one", async (t) => {
+  const root = await makeRepo(t);
+  const resolverFile = "src/features/templates/resolveTemplate.ts";
+  await write(root, resolverFile, "export function resolveTemplate() { return false; }\n");
+  commit(root, "benchmark baseline");
+  branch(root, "feature/template-audit");
+  await write(
+    root,
+    resolverFile,
+    [
+      "const templatePattern = /PULL_REQUEST_TEMPLATE(?:\\/.*)?\\.md/;",
+      "export function resolveTemplate(value) {",
+      "  sendTemplateAudit(value);",
+      "  return templatePattern.test(value);",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  commit(root, "feat: audit selected repository templates");
+
+  const analysis = await analyze(root, [resolverFile]);
+  const labels = analysis.intents.flatMap((intent) => intent.lifecycle.map((stage) => stage.label));
+
+  assert.ok(labels.some((label) => /Invoke `sendTemplateAudit`/.test(label)));
+  assert.equal(labels.some((label) => /PULL_REQUEST_TEMPLATE/.test(label)), false);
+});
+
 test("compacted agent payloads keep identifier values whole and disclose a full report", async (t) => {
   const root = await makeRepo(t);
   const pageFile = "src/deeply/nested/preferences/panels/workspace/settingsPanel.tsx";


### PR DESCRIPTION
## Summary

Prevent static-analysis path constants and regular-expression vocabulary from appearing as executable user lifecycle actions.

## Behavioral Contract

- Tokens inside regular-expression literals are treated as matcher vocabulary, not function calls.
- Analyzer source-role classifiers require implementation evidence before they contribute analysis-rule scenarios.
- Real product calls remain eligible when the changed source actually invokes them.

## Evidence

Closes #173.

The regression fixture includes:
- a source-role analyzer containing repository path constants,
- an assertion that those constants never become lifecycle actions,
- a product-source positive control proving a real function call is still retained.

## Checks

- [x] Focused regression test
- [x] `pnpm test`
- [x] `pnpm bench:ci` for inference, routing, trace, or output
- [ ] `pnpm bench:execution` for E2E compiler or execution fixtures
- [ ] `pnpm scan` for scanner, security, or repository policy
- [ ] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
- [x] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

- Full suite: 342/342 passed.
- Static QA benchmark: 28/28 passed.
- Coverage: 89.75% lines, 86.57% branches, 95.65% functions.
- QAMap replay of the prior public analyzer PR no longer emits the path constant as an action and selects the focused repository command.
- `bench:execution`, `scan`, and plugin checks are N/A because this change does not modify the E2E compiler, scanner, repository policy, or plugin bundle.
