### PR TITLE
fix: keep supporting release notes out of qa flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Documentation and contributor-workflow changes no longer produce clean-install, app-launch, endpoint, authentication, response-shape, selector, fixture, or product E2E guidance without runtime evidence.
 - Compact agent output now prioritizes changed guides and contributor templates over accompanying release notes and generated documentation assets.
 - Static-analysis source classifiers and regular-expression vocabulary no longer become fabricated user actions; executable product calls remain eligible when the diff supports them.
+- Release notes remain supporting provenance instead of a competing configuration flow when substantive diff evidence already defines the QA intent; release-only and real configuration changes keep their own verification paths.
 
 ## 0.4.12 - 2026-08-07
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,6 +88,8 @@ The same boundary applies downstream. E2E setup and fixture discovery only inspe
 
 Lifecycle extraction applies the same rule inside source lines. Tokens inside regular-expression literals are matcher vocabulary, not function calls, and source-role classifiers require analyzer structure before they can contribute analysis-rule evidence. Real calls in product sources remain eligible, so this boundary removes fabricated actions without hiding executable behavior.
 
+Release notes follow the same evidence hierarchy. When code or another substantive diff already produces an evidence-backed intent, a changelog entry is supporting provenance rather than a second configuration flow. Release-only changes still receive maintainer verification, and actual package, dependency, build, environment, or runtime configuration changes remain separate QA work.
+
 Repository boundaries are evidence boundaries too. A nested directory containing its own `.git` file or directory is a separate working copy, even when it lives under the analyzed root. Project, import-graph, workspace-package, test, mock, and fixture discovery must not borrow evidence from that nested repository. This prevents an abandoned worktree or local clone from making the current change appear tested or fixture-ready.
 
 ## Scenario Routing and Compilation Receipts

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -5755,11 +5755,16 @@ function prioritizeChangeIntentCandidates(
         qaScenarios: scopedScenarios,
       } satisfies FlowCandidate;
     }));
+  const hasSubstantiveCandidate = intentCandidates.length > 0 ||
+    heuristicCandidates.some((candidate) => !isSupportingReleaseMetadataCandidate(candidate));
+  const effectiveHeuristicCandidates = hasSubstantiveCandidate
+    ? heuristicCandidates.filter((candidate) => !isSupportingReleaseMetadataCandidate(candidate))
+    : heuristicCandidates;
   if (intentCandidates.length === 0) {
     if (provenanceOnlyFiles.size === 0) {
-      return heuristicCandidates;
+      return effectiveHeuristicCandidates;
     }
-    return heuristicCandidates.flatMap((candidate): FlowCandidate[] => {
+    return effectiveHeuristicCandidates.flatMap((candidate): FlowCandidate[] => {
       const remainingFiles = candidate.files.filter((file) => !provenanceOnlyFiles.has(file));
       return remainingFiles.length > 0
         ? [scopeResidualHeuristicCandidate(candidate, remainingFiles, domainLanguage)]
@@ -5768,7 +5773,7 @@ function prioritizeChangeIntentCandidates(
   }
 
   const changedAssetFiles = uniqueStrings(
-    heuristicCandidates.flatMap((candidate) => candidate.files).filter(isStaticAssetFile),
+    effectiveHeuristicCandidates.flatMap((candidate) => candidate.files).filter(isStaticAssetFile),
   );
   const intentCandidatesWithAssets = intentCandidates.map((candidate) => ({
     ...candidate,
@@ -5781,7 +5786,7 @@ function prioritizeChangeIntentCandidates(
     ...provenanceOnlyFiles,
     ...intentCandidatesWithAssets.flatMap((candidate) => candidate.files),
   ]);
-  const nonOverlapping = heuristicCandidates.flatMap((candidate): FlowCandidate[] => {
+  const nonOverlapping = effectiveHeuristicCandidates.flatMap((candidate): FlowCandidate[] => {
     if (isVerificationOnlyKind(candidate.kind)) {
       const sameKindIntentClaims = intentCandidatesWithAssets.some((intentCandidate) =>
         intentCandidate.kind === candidate.kind
@@ -5801,6 +5806,12 @@ function prioritizeChangeIntentCandidates(
       : [];
   });
   return [...intentCandidatesWithAssets, ...nonOverlapping].slice(0, 4);
+}
+
+function isSupportingReleaseMetadataCandidate(candidate: FlowCandidate): boolean {
+  return candidate.kind === "config" &&
+    candidate.files.length > 0 &&
+    candidate.files.every(isReleaseMetadataFile);
 }
 
 function scopeResidualHeuristicCandidate(

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -2671,6 +2671,154 @@ test("generateE2ePlan avoids turning release metadata into domain journeys", asy
   assert.ok(plan.flows.some((flow) => /configuration verification/.test(flow.title)));
 });
 
+test("generateE2ePlan treats release notes as supporting evidence beside substantive intent", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src"), { recursive: true });
+  await mkdir(path.join(root, "test"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      name: "analysis-fixture",
+      scripts: {
+        test: "node --test test/*.test.mjs",
+      },
+    }),
+  );
+  await writeFile(
+    path.join(root, "src/change-intent.ts"),
+    "export function collectEvidence(value) { return value.includes('expected'); }\n",
+  );
+  await writeFile(path.join(root, "test/change-intent.test.mjs"), "assert.equal(collectEvidence('expected'), true);\n");
+  await writeFile(path.join(root, "CHANGELOG.md"), "# Changelog\n\n## Unreleased\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "fix/analyzer-boundary"]);
+  await writeFile(
+    path.join(root, "src/change-intent.ts"),
+    [
+      "const matcherVocabulary = /expected(?:-control)?/;",
+      "export function collectEvidence(value) {",
+      "  return matcherVocabulary.test(value);",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  await writeFile(
+    path.join(root, "test/change-intent.test.mjs"),
+    [
+      "assert.equal(collectEvidence('expected'), true);",
+      "assert.equal(collectEvidence('unrelated'), false);",
+      "",
+    ].join("\n"),
+  );
+  await writeFile(
+    path.join(root, "CHANGELOG.md"),
+    "# Changelog\n\n## Unreleased\n\n- Keep matcher vocabulary out of user lifecycles.\n",
+  );
+
+  const workingTreePlan = await generateE2ePlan(root, {
+    base: "main",
+    head: "HEAD",
+    includeWorkingTree: true,
+  });
+
+  assert.equal(
+    workingTreePlan.flows.some((flow) => /release metadata configuration verification/i.test(flow.title)),
+    false,
+  );
+
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "fix: keep matcher vocabulary out of lifecycles"]);
+
+  const plan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const qa = await generateQaDraft(root, { base: "main", head: "HEAD" });
+  const agent = JSON.parse(formatAgentQaDraft(qa));
+
+  assert.ok(plan.flows.some((flow) => flow.intentId && /matcher vocabulary/i.test(flow.title)));
+  assert.equal(plan.flows.some((flow) => /release metadata configuration verification/i.test(flow.title)), false);
+  assert.equal(agent.flows.some((flow) => /release metadata configuration verification/i.test(flow.title)), false);
+  assert.deepEqual(agent.commands, ["node --test test/change-intent.test.mjs"]);
+
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      name: "analysis-fixture",
+      scripts: {
+        test: "node --test test/*.test.mjs",
+      },
+      dependencies: {
+        undici: "^7.0.0",
+      },
+    }),
+  );
+  await git(root, ["add", "package.json"]);
+  await git(root, ["commit", "-m", "chore: add the runtime transport dependency"]);
+
+  const configurationPlan = await generateE2ePlan(root, { base: "main", head: "HEAD" });
+  const configurationFlow = configurationPlan.flows.find((flow) =>
+    /configuration verification/i.test(flow.title),
+  );
+
+  assert.ok(configurationFlow);
+  assert.ok(configurationFlow.files.includes("package.json"));
+});
+
+test("generateE2ePlan does not require commit intent to treat release notes as supporting evidence", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, "src"), { recursive: true });
+  await mkdir(path.join(root, "test"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      name: "command-fixture",
+      bin: {
+        fixture: "dist/cli.js",
+      },
+      scripts: {
+        test: "node --test test/*.test.mjs",
+      },
+    }),
+  );
+  await writeFile(path.join(root, "src/e2e.ts"), "export function prioritize(candidates) { return candidates; }\n");
+  await writeFile(path.join(root, "test/e2e.test.mjs"), "assert.equal(prioritize([]).length, 0);\n");
+  await writeFile(path.join(root, "CHANGELOG.md"), "# Changelog\n\n## Unreleased\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await git(root, ["switch", "-c", "fix/local-candidate-priority"]);
+  await writeFile(
+    path.join(root, "src/e2e.ts"),
+    [
+      "export function prioritize(candidates) {",
+      "  return candidates.filter((candidate) => candidate.kind !== 'release-note');",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  await writeFile(
+    path.join(root, "test/e2e.test.mjs"),
+    "assert.deepEqual(prioritize([{ kind: 'release-note' }]), []);\n",
+  );
+  await writeFile(
+    path.join(root, "CHANGELOG.md"),
+    "# Changelog\n\n## Unreleased\n\n- Keep supporting release notes out of the primary QA flow.\n",
+  );
+
+  const plan = await generateE2ePlan(root, {
+    base: "main",
+    head: "HEAD",
+    includeWorkingTree: true,
+  });
+
+  assert.ok(plan.flows.some((flow) => /CLI command verification/i.test(flow.title)));
+  assert.equal(plan.flows.some((flow) => /release metadata configuration verification/i.test(flow.title)), false);
+});
+
 test("generateE2ePlan keeps package release metadata out of product workflows", async () => {
   const root = await makeTempRepo();
   await initGitRepo(root);


### PR DESCRIPTION
## Summary

Keep release notes as supporting provenance when substantive code or repository evidence already defines the QA flow.

## Behavioral Contract

- A changelog or release-note update does not create a competing configuration flow beside substantive QA evidence.
- The rule works for committed PR ranges and uncommitted working-tree analysis.
- Release-only changes retain maintainer verification.
- Real package, dependency, build, environment, and runtime configuration changes retain a separate configuration flow.

## Evidence

Closes #175.

The regression coverage includes:
- a committed analyzer change with a focused repository test and release note,
- the same change before commit through working-tree analysis,
- a CLI working-tree change without a commit-derived intent,
- a release-only positive control,
- a real dependency-change control.

## Checks

- [x] Focused regression test
- [x] `pnpm test`
- [x] `pnpm bench:ci` for inference, routing, trace, or output
- [ ] `pnpm bench:execution` for E2E compiler or execution fixtures
- [ ] `pnpm scan` for scanner, security, or repository policy
- [ ] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
- [x] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

- Full suite: 344/344 passed.
- Static QA benchmark: 28/28 passed.
- Coverage: 89.79% lines, 86.75% branches, 95.66% functions.
- Replaying public PR #174 now returns one analyzer verification flow and its focused repository command, with no release-metadata flow.
- Running the same comparison over this uncommitted working tree returns one CLI command verification flow and its focused repository command.
- `bench:execution`, `scan`, and plugin checks are N/A because this change does not modify execution fixtures, scanner policy, or the plugin bundle.
