### PR TITLE
Fix: keep merged baseline out of QA evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixed
 
+- Target-branch merge commits no longer place imported baseline hunks ahead of the feature branch's own QA evidence; ordinary non-merge review fixes keep their latest-change priority.
 - One analyzer-rule change now keeps its import/export adapters and matching result schema in a single repository-verification intent instead of expanding internal filenames into product-domain QA flows.
 - Diff-only analyzer changes now recover a concrete rule subject from the changed rule path when commit text does not describe behavior.
 - Automatic package commands now remain workspace-root executable, while explicitly selected package validation runs from the selected package instead of the workspace root.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -42,26 +42,36 @@ The OpenAI Plugin Directory is now a real first-run surface, so the next patches
 prioritize recommendation quality over adding another distribution channel or
 runner name. The current generalized work queue is:
 
-1. The next patch candidate now detects target-branch-aware Django migration
-   graph conflicts when a changed migration branches from a non-leaf node. It
-   preserves exact changed-dependency and base-leaf evidence, works for committed
-   and working-tree changes, and routes the result to a repository-declared graph
-   or deployment-plan command instead of fabricated product E2E. Dynamic and
-   squashed dependency declarations remain explicit manual-review boundaries.
-2. Extract framework-neutral presentation contracts from changed UI code. An
+1. Keep long-lived and recently synchronized branches inside the real PR
+   evidence boundary. The complete comparison stays merge-base aware, while
+   latest-change priority must come from the branch's own non-merge first-parent
+   history rather than target-only hunks introduced by a merge commit.
+2. Trace runtime prerequisites across reused code. A route or entry point that
+   bypasses a provider, wrapper, dependency injection boundary, or required
+   initialization path should surface a render or startup regression before
+   selector and fixture advice.
+3. Treat changed repository tests as behavior contracts. Preserve explicit
+   normalization boundaries, negative assertions, state transitions, retry
+   prohibitions, and cross-file value continuity instead of reducing them to a
+   generic request to run the suite.
+4. Extract framework-neutral presentation contracts from changed UI code. An
    overlay becoming inline content, scroll-lock removal, responsive overflow,
    replaced-element sizing, and inherited icon color should produce concrete
    interaction or visual checks only when the diff carries the required
    evidence.
-3. Keep repository workflow metadata in its own behavior class. Documentation,
+5. Keep repository workflow metadata in its own behavior class. Documentation,
    issue forms, pull-request templates, and their contract tests must route to
    link, schema, field, label, and template validation rather than fabricated
    endpoint or application-launch scenarios.
-4. Turn each real miss into a domain-neutral public fixture with a positive
+6. Prefer repository-owned validation commands from package scripts, CI
+   workflows, and adjacent test harnesses over blocked optional automation.
+   Vocabulary in a property or filename must not create a domain risk without
+   matching behavior evidence.
+7. Turn each real miss into a domain-neutral public fixture with a positive
    contract and an unrelated negative control. A new shared heuristic is not
    complete until both sides pass the static benchmark and the existing
    execution contract remains honest.
-5. Re-run the published skill against unrelated repositories and compare its
+8. Re-run the published skill against unrelated repositories and compare its
    deterministic result with independent human or agent review. Preserve
    `not-run`, `passed`, `failed`, and `blocked` exactly; plugin availability is
    not evidence that product QA ran.

--- a/src/test-plan.ts
+++ b/src/test-plan.ts
@@ -1094,18 +1094,37 @@ async function mergePriorityDiffEvidence(
   options: AddedDiffTextOptions,
 ): Promise<void> {
   try {
+    const priorityCommit = await resolvePriorityDiffCommit(gitRoot, options.base, options.head);
+    if (!priorityCommit) {
+      return;
+    }
     const { stdout } = await git(gitRoot, [
       "diff",
       "--no-color",
       "--find-renames",
       "--unified=0",
-      `${options.head}^`,
-      options.head,
+      `${priorityCommit}^`,
+      priorityCommit,
     ]);
     mergeAddedDiffEvidence(byFile, stdout, relativeRoot);
   } catch {
     // A root commit has no parent; the complete base/head diff below remains valid.
   }
+}
+
+async function resolvePriorityDiffCommit(
+  gitRoot: string,
+  base: string,
+  head: string,
+): Promise<string | undefined> {
+  const { stdout } = await git(gitRoot, [
+    "rev-list",
+    "--first-parent",
+    "--no-merges",
+    "--max-count=1",
+    `${base}..${head}`,
+  ]);
+  return stdout.trim() || undefined;
 }
 
 async function mergeUntrackedDiffEvidence(

--- a/test/change-intent.test.mjs
+++ b/test/change-intent.test.mjs
@@ -4889,6 +4889,50 @@ test("diff evidence reserves the latest commit before large branch history", asy
   );
 });
 
+test("diff evidence keeps merged target-branch changes outside the QA evidence boundary", async (t) => {
+  const root = await makeRepo(t);
+  const jobFile = "src/jobs/deliveryWorker.ts";
+  const jobTestFile = "test/deliveryWorker.test.ts";
+  const baselineFile = "src/catalog/CatalogScreen.tsx";
+
+  await write(root, jobFile, "export const deliveryState = 'idle';\n");
+  await write(root, jobTestFile, "it('starts idle', () => expect(true).toBe(true));\n");
+  commit(root, "chore: baseline");
+  branch(root, "feature/delivery-recovery");
+
+  await write(root, jobFile, "export const deliveryState = 'recovering';\n");
+  await write(
+    root,
+    jobTestFile,
+    [
+      "it('starts idle', () => expect(true).toBe(true));",
+      "it('does not dispatch recovery twice', () => expect(true).toBe(true));",
+      "",
+    ].join("\n"),
+  );
+  commit(root, "fix: prevent duplicate delivery recovery");
+
+  git(root, "switch", "main");
+  await write(root, baselineFile, "export function CatalogScreen() { return <main>Catalog</main>; }\n");
+  commit(root, "feat: add catalog browsing screen");
+
+  git(root, "switch", "feature/delivery-recovery");
+  git(root, "merge", "--no-ff", "main", "-m", "Merge main into feature/delivery-recovery");
+
+  const evidence = await collectAddedDiffEvidence(root, { base: "main", head: "HEAD" });
+  const qa = await generateQaDraft(root, { base: "main", head: "HEAD" });
+  assert.equal(evidence[baselineFile], undefined);
+  assert.equal(Object.keys(evidence)[0], jobFile);
+  assert.ok(
+    evidence[jobTestFile].some((hunk) =>
+      hunk.lines.some((line) => /does not dispatch recovery twice/i.test(line.text))
+    ),
+  );
+  assert.equal(JSON.stringify(qa).includes("CatalogScreen"), false);
+  assert.ok(JSON.stringify(qa).includes("deliveryWorker"));
+  assert.equal(qa.execution.status, "not-run");
+});
+
 async function analyze(root, files) {
   const addedDiffEvidence = await collectAddedDiffEvidence(root, { base: "main", head: "HEAD" });
   const addedDiffText = addedDiffTextFromEvidence(addedDiffEvidence);


### PR DESCRIPTION
## Summary

Keep target-branch updates introduced by a merge commit outside the feature branch's priority QA evidence. This prevents unrelated baseline code from becoming the apparent intent or strongest scenario source on long-lived branches.

## Behavioral Contract

- Keep the complete PR evidence boundary on the selected base/head comparison.
- Select latest-change priority from the newest non-merge commit on the branch's first-parent history that is not reachable from the base.
- Do not insert target-only merge hunks into intent, lifecycle, flow, or trace evidence.
- Preserve latest-commit priority for ordinary non-merge review follow-ups.
- Preserve static QA execution as not-run.

## Evidence

Closes #182.

- Added a synthetic Git regression with a feature change, an unrelated target-branch UI change, and a target synchronization merge at HEAD.
- The regression requires the feature implementation and changed test to remain first-party evidence and rejects the target-only UI file.
- The existing large-history test remains the non-merge latest-change control.

## Checks

- [x] Focused regression test (2/2)
- [x] pnpm test
- [x] pnpm bench:ci
- [ ] pnpm bench:execution for E2E compiler or execution fixtures
- [x] pnpm scan
- [ ] pnpm plugin:check and pnpm plugin:smoke for plugin changes
- [x] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

- pnpm bench:execution: N/A; no automation compiler or execution fixture changed.
- Plugin checks: N/A; no skill, plugin metadata, or packaged plugin asset changed.
- QAMap's static comparison selected the focused repository test and kept execution as not-run; the repository checks above were run independently.
- No package version or release metadata changed.
