### PR TITLE
Chore: prepare 0.4.13 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qamap",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Turn PR changes into traceable local QA decisions and optional automation handoffs without an LLM call.",
   "author": {
     "name": "IvoryCanvas",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qamap",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Turn PR changes into traceable local QA decisions and optional automation handoffs without an LLM call.",
   "author": {
     "name": "IvoryCanvas",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.4.13 - 2026-08-11
+
 ### Added
 
 - Added separate English and Korean documentation entry points, including Korean quickstart, agent integration, and verification manifest guides.

--- a/README.ko.md
+++ b/README.ko.md
@@ -65,6 +65,10 @@ npx --yes @ivorycanvas/qamap@latest qa --format markdown
 diff가 증명하지 못하면, QAMap은 assertion을 지어내지 않고 근거 부족으로
 표시합니다.
 
+지원하는 실행 전제조건에서는 변경된 진입점부터 로컬 import와 필수
+provider까지 추적합니다. 그 전제조건을 mock으로 우회한 테스트는 충분한
+증명으로 보지 않고 불완전한 근거로 표시합니다.
+
 ## 실제 실행 예시
 
 아래 녹화는 공개 fixture를 사용합니다. QAMap은 중복 요청 위험과 변경

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ npx --yes @ivorycanvas/qamap@latest qa --format markdown
 QAMap keeps static reasoning and executed QA separate. A proposed scenario or E2E
 draft is never reported as a passing test.
 
+For supported runtime contracts, QAMap can trace a changed entry point through
+local imports to a required provider. A test that mocks away that prerequisite
+is disclosed as incomplete evidence instead of being promoted as proof.
+
 Cleanup-only commits remain visible as provenance but do not become standalone
 QA requirements. Unrelated issue tags and lifecycle stages stay separate. When
 the changed source does not prove an externally observable result, QAMap reports

--- a/docs/plugin-submission.md
+++ b/docs/plugin-submission.md
@@ -2,7 +2,7 @@
 
 QAMap packages one `skills-only` plugin for the shared OpenAI Plugins Directory. It reuses the same local CLI and `qamap.qa` contract as every other QAMap integration. It does not add an MCP server, hosted service, background hook, or second QA engine.
 
-QAMap `0.4.12` is approved and [published in the OpenAI Plugin Directory](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629). The directory listing, npm package, and GitHub release currently point to the same version. This repository remains the source of truth for the reviewed skill package and future listing updates.
+QAMap `0.4.12` is currently approved and [published in the OpenAI Plugin Directory](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629). npm and GitHub releases can move ahead independently; a newer directory version requires a fresh upload and review. This repository remains the source of truth for the reviewed skill package and future listing updates.
 
 Publishing a newer npm package or repository release does not update the
 directory listing automatically. Keep the approved version available, upload

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -4,9 +4,9 @@
 > public release. Older released sections are preserved as historical receipts
 > and are not required reading for contributors or users.
 
-## Next patch candidate - 2026-08-11 (unreleased)
+## 0.4.13 - 2026-08-11
 
-The next patch candidate improves the reasoning path from repository evidence to
+QAMap 0.4.13 improves the reasoning path from repository evidence to
 the validation that should actually be trusted. QAMap now keeps target-branch
 merge commits out of feature intent, clusters analyzer changes around their real
 verification contracts, preserves package working directories, routes repository
@@ -22,17 +22,17 @@ passes. Self-analysis also distinguishes benchmark revision snapshots from real
 repository tests and prefers the declared benchmark harness when the benchmark
 structure changes.
 
-| Gate | Candidate result |
+| Gate | Current result |
 | --- | --- |
 | `pnpm release:check` | Passed end to end |
 | `pnpm test` | 356/356 passing |
 | `pnpm scan` | 0 findings |
 | `pnpm bench:ci` | 30/30 static recommendation contracts passing |
 | `pnpm bench:execution` | 3/3 execution contracts passing; all three seeded regressions caught |
-| Coverage | Lines 89.72%, branches 86.81%, functions 95.73% |
+| Coverage | Lines 89.68%, branches 86.75%, functions 95.73% |
 | Runtime prerequisite controls | 5/5 passing across provider bypass, route-owned provider, wrapper-owned provider, a provider inside the marked wrapper branch, and an absent fail-fast contract |
 | Benchmark routing controls | Revision snapshots are excluded from runnable test evidence; the repository-owned benchmark harness remains selected |
-| Plugin package smoke | Packed 192 files, installed the current 0.4.12 artifact in isolation, and produced one intent with one exact evidence trace |
+| Plugin package smoke | Packed 192 files, installed the current 0.4.13 artifact in isolation, and produced one intent with one exact evidence trace |
 | Package preview | `pnpm pack --dry-run` passes and includes the new runtime-prerequisite and benchmark-path declarations and runtime files |
 
 The static `qa` command remains `not-run`. A public synthetic replay proves that
@@ -46,8 +46,9 @@ the validation route while base, head, and regression snapshots do not.
 These checks establish static selection quality and seeded-regression behavior,
 not correctness of an arbitrary user application. Dynamic context contracts,
 frameworks without supported evidence, and runtime behavior not represented in
-the repository remain explicit review work rather than guessed. This section is
-candidate evidence only; no `0.4.13` package has been published.
+the repository remain explicit review work rather than guessed. npm publication,
+the Git tag, and the GitHub Release follow only after this receipt passes from
+the merged release commit.
 
 ## 0.4.12 - 2026-08-07
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,7 +36,7 @@ Before treating the next public release as ready, the golden demo must satisfy t
 
 There is no fixed end date or patch count for `0.4.x`. QAMap will remain on compatible patch releases while real repositories still expose material gaps in change intent, affected-flow selection, scenario evidence, or automation-draft quality. `0.5.x` is not the next scheduled milestone; it is a release bar that must be earned by a stable, explicitly approved execution contract and evidence from repeated use outside the maintainer's repositories.
 
-### Current Focus After 0.4.12
+### Current Focus After 0.4.13
 
 The OpenAI Plugin Directory is now a real first-run surface, so the next patches
 prioritize recommendation quality over adding another distribution channel or

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Local zero-LLM PR QA designer that maps commit intent and diffs to traceable behavior lifecycles, QA scenarios, and optional automation drafts.",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugin/submission.json
+++ b/plugin/submission.json
@@ -73,5 +73,5 @@
       "reason": "The plugin must preserve the host's approval policy and QAMap's explicit action boundary."
     }
   ],
-  "releaseNotes": "QAMap 0.4.12 keeps cleanup-only work as provenance, separates unrelated commit lifecycles, reports missing observable proof explicitly, and makes the published plugin installation route easier to find."
+  "releaseNotes": "QAMap 0.4.13 improves evidence-to-validation routing, keeps target-branch merge history out of feature intent, detects migration graph conflicts, and traces supported runtime prerequisites without treating mocked consumers as sufficient proof."
 }

--- a/skills/qamap-pr-qa/SKILL.md
+++ b/skills/qamap-pr-qa/SKILL.md
@@ -21,7 +21,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
    If QAMap is not installed, disclose that the next command downloads the pinned package from the npm registry and follow the host's network approval policy before running it:
 
    ```sh
-   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.12 -- qamap qa . --base <base> --head HEAD --format agent
+   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.13 -- qamap qa . --base <base> --head HEAD --format agent
    ```
 
    This one-off form runs outside the target repository's package-manager contract, so it does not invoke Corepack or add a `packageManager` field. QAMap's analysis does not upload source code or make another LLM call. The calling agent still uses its own model tokens to invoke the skill and interpret the compact result.
@@ -37,7 +37,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
    - Use an explicit scoped pass only when a human wants to override that decision:
 
    ```sh
-   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.12 -- qamap qa <package-path> --workspace-root . --base <base> --head HEAD
+   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.13 -- qamap qa <package-path> --workspace-root . --base <base> --head HEAD
    ```
 
 4. Read and verify intent before generating code. In agent format:
@@ -60,7 +60,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
    - `run-repository-command` — when policy permits repository code execution, prefer QAMap's bounded executor so analysis and execution share one receipt:
 
      ```sh
-     npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.12 -- qamap qa run . --base <base> --head HEAD --format agent
+     npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.13 -- qamap qa run . --base <base> --head HEAD --format agent
      ```
 
      It re-analyzes the change and runs only the exact selected existing repository command. Do not substitute another command or run it again when `execution.performed` is true.
@@ -70,7 +70,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
 6. Only after a human or team accepts the scenario and automation adapter, create or preview executable coverage:
 
    ```sh
-   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.12 -- qamap e2e draft . --base <base> --head HEAD --dry-run
+   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.13 -- qamap e2e draft . --base <base> --head HEAD --dry-run
    ```
 
    If the selected adapter is absent, inspect and explicitly accept the `automation.setupCommand` proposal. Never install a runner merely because QAMap detected a web or mobile surface.
@@ -106,7 +106,7 @@ When the recommendation is wrong or too broad, do not repeatedly re-prompt for t
 If the team accepts QAMap for ongoing use, suggest this follow-up:
 
 ```sh
-npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.12 -- qamap manifest init .
+npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.13 -- qamap manifest init .
 ```
 
 Then humans should review `.qamap/manifest.yaml` and keep only durable team QA language.

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const TOOL_NAME = "QAMap";
-export const VERSION = "0.4.12";
+export const VERSION = "0.4.13";


### PR DESCRIPTION
## Summary

Align the package, CLI, native plugin manifests, portable skill, changelog, README, and release evidence on `0.4.13`. Keep the currently published OpenAI directory version explicit because directory updates require a separate reviewed upload.

## Behavioral Contract

No incompatible CLI, schema, or safety behavior change. The README continues to separate static QA design, explicit repository validation, and optional E2E drafting while documenting supported runtime-prerequisite evidence.

## Evidence

Closes #186.

Includes the compatible inference, repository-routing, migration-graph, runtime-prerequisite, localization, benchmark, and documentation improvements merged since `v0.4.12`.

## Checks

- [x] Focused regression test
- [x] `pnpm test`
- [x] `pnpm bench:ci` for inference, routing, trace, or output
- [x] `pnpm bench:execution` for E2E compiler or execution fixtures
- [x] `pnpm scan` for scanner, security, or repository policy
- [x] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
- [x] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

`pnpm release:check` passed end to end: 356/356 tests, 0 scanner findings, 30/30 static contracts, 3/3 execution contracts, 89.68% line / 86.75% branch / 95.73% function coverage, and a 192-file package preview. `npm publish --dry-run --access public` also passed.

The secondary static QAMap pass remained `not-run` and selected the narrower `pnpm test`; the maintainer runbook and primary review correctly required the stronger `pnpm release:check`. The release commit does not itself publish npm, create a tag, create a GitHub Release, or replace the approved OpenAI directory version.