### PR TITLE
Docs: clarify runtime and package manager support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Documented the shared Node.js 20+ runtime contract, the actively supported LTS recommendation, and verified npm, pnpm, Yarn, and Bun installation and repeat-use commands in both READMEs.
+
 ## 0.4.13 - 2026-08-11
 
 ### Added

--- a/README.ko.md
+++ b/README.ko.md
@@ -32,11 +32,37 @@ manifest와 테스트 runner도 첫 실행에는 필요하지 않습니다.
 
 ## 60초 만에 실행하기
 
-Node.js 20 이상이 필요합니다. 검토하려는 브랜치에서 실행하세요.
+QAMap은 Node.js 20 이상이 필요합니다. 가능하면
+[현재 지원 중인 Node.js LTS](https://nodejs.org/en/about/previous-releases)를
+사용하세요. Node.js 20에서도 패키지는 동작하지만 Node.js 공식 지원은
+종료되었습니다. 호환되는 Node.js 버전에서는 모두 같은 QAMap 명령을
+사용합니다.
+
+검토하려는 브랜치에서 실행하세요. 저장소가 npm, pnpm, Yarn, Bun 중 무엇을
+사용하더라도 실행할 수 있으며 프로젝트 의존성에는 QAMap을 추가하지 않습니다.
 
 ```sh
 npx --yes @ivorycanvas/qamap@latest qa
 ```
+
+<details>
+<summary>검증한 Node.js 버전</summary>
+
+공개된 `0.4.13` 패키지는 2026-08-11에 다음 버전에서 설치와 실제 `qa`
+smoke를 완료했습니다. 모든 버전에서 설치 명령은 같습니다.
+
+| Node.js | smoke | 안내 |
+| --- | --- | --- |
+| 20 | 통과 | 패키지는 호환되지만 공식 지원 종료 상태이므로 보안 업데이트를 위해 업그레이드 권장 |
+| 22 | 통과 | 검증 시점에 지원 중인 LTS |
+| 24 | 통과 | 검증 시점에 지원 중인 LTS |
+| 26 | 통과 | 검증 시점의 Current 버전이며 운영 환경은 LTS 권장 |
+
+정확한 버전과 패키지 매니저 범위는
+[release validation 기록](docs/release-validation.md#unreleased---2026-08-11)에서
+확인할 수 있습니다.
+
+</details>
 
 일반적인 저장소에서는 base branch를 자동으로 찾습니다. 필요한 경우에만
 직접 지정하세요.
@@ -119,25 +145,51 @@ selector, fixture, Playwright, Maestro, 테스트 runner가 없다는 이유로 
 QA 시나리오를 숨기지 않습니다. 이 항목들은 자동화 수단이며, 무엇을
 검증해야 하는가보다 먼저 오지 않습니다.
 
-## 반복 사용을 위한 짧은 명령
+## 반복 사용을 위한 설치
 
-JavaScript 저장소에는 개발 의존성으로 설치할 수 있습니다.
+위의 일회성 `npx` 명령은 저장소의 의존성 파일을 바꾸지 않으므로 첫 실행에
+가장 안전합니다. JavaScript 프로젝트에 QAMap 버전을 고정하려면 저장소가
+이미 사용하는 패키지 매니저로 설치하세요.
+
+| 패키지 매니저 | 설치 | 짧은 스크립트 추가 |
+| --- | --- | --- |
+| npm | `npm install --save-dev @ivorycanvas/qamap` | `npm exec -- qamap init --scripts` |
+| pnpm | `pnpm add --save-dev @ivorycanvas/qamap` | `pnpm exec qamap init --scripts` |
+| Yarn 1 이상 | `yarn add --dev @ivorycanvas/qamap` | `yarn qamap init --scripts` |
+| Bun | `bun add --dev @ivorycanvas/qamap` | `bun run qamap init --scripts` |
+
+`init --scripts`는 `qa`, `qa:local`, `qa:run`, `qa:e2e`를 추가합니다. 저장소가
+사용하는 방식에 맞춰 같은 스크립트를 실행하세요.
 
 ```sh
-pnpm add -D @ivorycanvas/qamap
-pnpm exec qamap init --scripts
+npm run qa       # npm
+pnpm qa          # pnpm
+yarn qa          # Yarn
+bun run qa       # Bun
 ```
 
-이후 다음 명령을 사용합니다.
+아직 커밋하지 않은 변경을 포함하려면 `qa:local`, 선택된 기존 검증을
+실행하려면 `qa:run`, 선택적 E2E 초안을 미리 보려면 `qa:e2e`로 `qa`를
+바꾸면 됩니다. 다른 언어의 저장소는 범용 `npx` 명령을 그대로 사용할 수
+있습니다.
+
+<details>
+<summary>패키지 매니저별 일회성 실행 명령</summary>
+
+프로젝트 의존성에 QAMap을 추가하지 않고 다음 명령도 사용할 수 있습니다.
 
 ```sh
-pnpm qa          # 커밋된 브랜치 변경
-pnpm qa:local    # 아직 커밋하지 않은 변경 포함
-pnpm qa:run      # 선택된 기존 검증 실행
-pnpm qa:e2e      # 선택적 E2E 초안 미리보기
+pnpm dlx @ivorycanvas/qamap@latest qa
+yarn dlx @ivorycanvas/qamap@latest qa  # Yarn 2+
+bunx @ivorycanvas/qamap@latest qa
 ```
 
-다른 언어의 저장소는 범용 `npx` 명령을 그대로 사용할 수 있습니다.
+Yarn Classic은 범용 `npx` 명령을 사용하거나 프로젝트에 QAMap을 설치하세요.
+Corepack으로 관리되는 패키지 매니저는 저장소의 `packageManager` 정보를
+추가하거나 갱신할 수 있습니다. 파일을 전혀 바꾸지 않는 첫 확인이 필요하면
+`npx` 명령을 사용하세요.
+
+</details>
 
 ## 동작 방식
 

--- a/README.md
+++ b/README.md
@@ -31,11 +31,36 @@ manifest and test runner are optional.
 
 ## Run The CLI In 60 Seconds
 
-Requires Node.js 20 or newer. Run this from the branch you want to review:
+QAMap requires Node.js 20 or newer. Use an
+[actively supported Node.js LTS release](https://nodejs.org/en/about/previous-releases)
+when possible; Node.js 20 remains package-compatible but is upstream EOL. The
+same QAMap command works on every compatible Node.js version.
+
+Run this from the branch you want to review. It works regardless of whether the
+repository uses npm, pnpm, Yarn, or Bun, and it does not add QAMap to the
+project's dependencies:
 
 ```sh
 npx --yes @ivorycanvas/qamap@latest qa
 ```
+
+<details>
+<summary>Validated Node.js lines</summary>
+
+The published `0.4.13` package completed an install and real `qa` smoke on these
+lines on 2026-08-11. The install command is the same for every line.
+
+| Node.js | Smoke | Guidance |
+| --- | --- | --- |
+| 20 | Passed | Package-compatible, but upstream EOL; upgrade for security fixes |
+| 22 | Passed | Supported LTS at the time of validation |
+| 24 | Passed | Supported LTS at the time of validation |
+| 26 | Passed | Current release at the time of validation; prefer LTS for production |
+
+See the [release validation receipt](docs/release-validation.md#unreleased---2026-08-11)
+for exact versions and package-manager coverage.
+
+</details>
 
 QAMap infers the base branch in standard repositories. Override it only when
 needed:
@@ -134,25 +159,49 @@ QAMap does not hide an important QA scenario because a repository lacks a
 selector, fixture, Playwright, Maestro, or test runner. Those are automation
 details. Missing evidence remains visible instead of becoming a fabricated pass.
 
-## Daily Commands
+## Install For Repeat Use
 
-Install QAMap once in a JavaScript repository:
+The one-off `npx` command above is the safest first run because it leaves the
+repository's dependency files unchanged. To pin QAMap in a JavaScript project,
+use the repository's package manager:
+
+| Package manager | Install | Add the short scripts |
+| --- | --- | --- |
+| npm | `npm install --save-dev @ivorycanvas/qamap` | `npm exec -- qamap init --scripts` |
+| pnpm | `pnpm add --save-dev @ivorycanvas/qamap` | `pnpm exec qamap init --scripts` |
+| Yarn 1 or newer | `yarn add --dev @ivorycanvas/qamap` | `yarn qamap init --scripts` |
+| Bun | `bun add --dev @ivorycanvas/qamap` | `bun run qamap init --scripts` |
+
+`init --scripts` adds `qa`, `qa:local`, `qa:run`, and `qa:e2e`. Run the same
+script with the syntax your project already uses:
 
 ```sh
-pnpm add -D @ivorycanvas/qamap
-pnpm exec qamap init --scripts
+npm run qa       # npm
+pnpm qa          # pnpm
+yarn qa          # Yarn
+bun run qa       # Bun
 ```
 
-Then use:
+Replace `qa` with `qa:local` to include uncommitted changes, `qa:run` to run the
+selected existing validation, or `qa:e2e` to preview the optional E2E draft.
+Non-JavaScript repositories can keep using the universal `npx` command.
+
+<details>
+<summary>Package-manager-specific one-off commands</summary>
+
+These commands also work without adding QAMap as a project dependency:
 
 ```sh
-pnpm qa          # committed branch changes
-pnpm qa:local    # include uncommitted changes
-pnpm qa:run      # run the selected existing validation
-pnpm qa:e2e      # preview the optional E2E draft
+pnpm dlx @ivorycanvas/qamap@latest qa
+yarn dlx @ivorycanvas/qamap@latest qa  # Yarn 2+
+bunx @ivorycanvas/qamap@latest qa
 ```
 
-Other repository types can keep using the universal `npx` command.
+Yarn Classic users can use the universal `npx` command or install QAMap in the
+project. Corepack-managed package managers may add or update the repository's
+`packageManager` metadata; use the `npx` first run when a no-write check matters.
+
+</details>
 
 ## How It Works
 

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -4,6 +4,28 @@
 > public release. Older released sections are preserved as historical receipts
 > and are not required reading for contributors or users.
 
+## Unreleased - 2026-08-11
+
+The public `@ivorycanvas/qamap@0.4.13` package was installed and exercised in
+isolated temporary projects before expanding the README installation guidance.
+Every package-manager path ran the same synthetic duplicate-request branch
+analysis and kept product execution explicitly `not-run`.
+
+| Gate | Current result |
+| --- | --- |
+| Node.js runtime smoke | Node 20.20.2, 22.23.2, 24.19.0, and 26.7.0 loaded QAMap 0.4.13 and produced one `qamap.qa` v1 intent from the same committed diff |
+| npm | npm 10.9.2 installed the development dependency, generated all four repeat-use scripts, and completed the QA smoke |
+| pnpm | pnpm 11.21.0 completed one-off and project-installed QA smokes and generated all four repeat-use scripts |
+| Yarn Classic | Yarn 1.22.22 installed and ran the package, generated all four repeat-use scripts, and completed the QA smoke |
+| Yarn Modern | Yarn 4.6.0 completed one-off and project-installed QA smokes and generated all four repeat-use scripts |
+| Bun | Bun 1.3.1 completed one-off and project-installed QA smokes and generated all four repeat-use scripts |
+| Repository mutation check | The synthetic target repository remained clean after every QA run; Corepack metadata changes occurred only in isolated package-manager host projects |
+
+These results establish package installation and CLI smoke compatibility, not
+a new runtime guarantee beyond the declared Node.js `>=20` engine contract.
+Node.js 20 is upstream EOL, so the README recommends an actively supported LTS
+release even though the compatibility smoke still passes.
+
 ## 0.4.13 - 2026-08-11
 
 QAMap 0.4.13 improves the reasoning path from repository evidence to


### PR DESCRIPTION
## Summary

- Clarify the shared Node.js 20+ runtime contract and recommend an actively supported LTS release.
- Add verified npm, pnpm, Yarn, and Bun installation and repeat-use commands to the English and Korean READMEs.
- Record the isolated public-package compatibility smoke without expanding QAMap's runtime guarantee.

## Behavioral Contract

No runtime behavior change. Users can choose a copyable installation path for their existing package manager while the no-write `npx` first run remains the default.

## Evidence

Closes #188.

The public `@ivorycanvas/qamap@0.4.13` package completed the same committed synthetic branch analysis on Node 20, 22, 24, and 26. Project-installed QA smokes passed with npm 10, pnpm 11, Yarn 1, Yarn 4, and Bun 1.3, and every manager generated the same four repeat-use scripts.

## Checks

- [x] Focused regression test
- [x] `pnpm test`
- [ ] `pnpm bench:ci` for inference, routing, trace, or output
- [ ] `pnpm bench:execution` for E2E compiler or execution fixtures
- [ ] `pnpm scan` for scanner, security, or repository policy
- [ ] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
- [x] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

`pnpm test` passed 356/356. The focused entry-point documentation test passed. Package-manager and Node compatibility were tested in isolated temporary projects and did not modify the synthetic target repository.

`pnpm bench:ci`, `pnpm bench:execution`, `pnpm scan`, and plugin checks are N/A because this change modifies documentation only. Node.js 20 remains engine-compatible but is upstream EOL; the README therefore recommends an actively supported LTS line.
