### PR TITLE
Docs: point install links at official steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Documented the shared Node.js 20+ runtime contract, the actively supported LTS recommendation, and verified npm, pnpm, Yarn, and Bun installation and repeat-use commands in both READMEs.
+- Linked the English and Korean plugin guidance directly to OpenAI's official installation steps instead of the general Plugins overview.
 
 ## 0.4.13 - 2026-08-11
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 **ChatGPT 또는 Codex에 설치:** **Plugins**에서 **QAMap**을 검색하고
 **+**를 누른 뒤 새 대화를 시작하세요.
 [QAMap 열기](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629)
-· [설치 안내](https://learn.chatgpt.com/docs/plugins)
+· [공식 설치 단계](https://learn.chatgpt.com/docs/plugins#install-and-use-a-plugin)
 
 ![QAMap: 변경이 무엇을 증명해야 하는지 찾습니다](docs/assets/qamap-cover-ko.png)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **Install in ChatGPT or Codex:** open **Plugins**, search for **QAMap**, select
 **+**, then start a new chat. [Open QAMap](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629)
-· [Installation guide](https://learn.chatgpt.com/docs/plugins)
+· [Official installation steps](https://learn.chatgpt.com/docs/plugins#install-and-use-a-plugin)
 
 ![QAMap: find what a change needs to prove](docs/assets/qamap-cover.png)
 

--- a/docs/ko/agent-integration.md
+++ b/docs/ko/agent-integration.md
@@ -12,7 +12,7 @@ ChatGPT 또는 Codex의 **Plugins**에서 **QAMap**을 검색하고 **+**를 누
 새 대화를 시작합니다.
 
 - [QAMap 플러그인 열기](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629)
-- [OpenAI 플러그인 설치 안내](https://learn.chatgpt.com/docs/plugins)
+- [OpenAI 공식 플러그인 설치 단계](https://learn.chatgpt.com/docs/plugins#install-and-use-a-plugin)
 
 플러그인이 저장소를 분석하려면 호스트가 체크아웃된 저장소와 로컬 shell에
 접근할 수 있어야 합니다. 웹 전용 대화에서 로컬 저장소 접근 권한이 없으면

--- a/test/contributor-workflow.test.mjs
+++ b/test/contributor-workflow.test.mjs
@@ -100,3 +100,24 @@ test("entry-point documentation links resolve inside the repository", async () =
     }
   }
 });
+
+test("public plugin guidance links directly to the official installation steps", async () => {
+  const installationUrl =
+    "https://learn.chatgpt.com/docs/plugins#install-and-use-a-plugin";
+
+  for (const relativeDocument of [
+    "README.md",
+    "README.ko.md",
+    "docs/ko/agent-integration.md",
+  ]) {
+    const source = await readFile(path.join(repositoryRoot, relativeDocument), "utf8");
+    assert.ok(
+      source.includes(installationUrl),
+      `${relativeDocument} must link directly to the official plugin installation steps`,
+    );
+    assert.ok(
+      !source.includes("https://learn.chatgpt.com/docs/plugins)"),
+      `${relativeDocument} must not send readers to the general Plugins overview`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Link the English and Korean plugin guidance directly to OpenAI's official installation section so readers do not land at the top of the general Plugins overview. Keep the QAMap directory listing as the direct product link and add a regression contract for all public installation entry points.

Closes #190

## Behavioral Contract

No runtime behavior change. Public plugin guidance must distinguish the direct QAMap listing from the official installation steps and link to the exact installation section.

## Evidence

- `README.md`
- `README.ko.md`
- `docs/ko/agent-integration.md`
- `test/contributor-workflow.test.mjs`

## Checks

- [x] Focused regression test
- [ ] `pnpm test`
- [ ] `pnpm bench:ci` for inference, routing, trace, or output
- [ ] `pnpm bench:execution` for E2E compiler or execution fixtures
- [ ] `pnpm scan` for scanner, security, or repository policy
- [ ] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
- [x] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

Focused verification passed with `pnpm build && node --test test/contributor-workflow.test.mjs` (5 tests). The official installation page returned HTTP 200. QAMap static comparison selected the same documentation contract and command with execution state `not-run`; the command was then run separately and passed. Benchmark, scanner, execution-fixture, and plugin-package checks are N/A because this is a documentation-link correction.