### PR TITLE
Refactor: clarify the core QA workflow

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -106,22 +106,36 @@ provider까지 추적합니다. 그 전제조건을 mock으로 우회한 테스�
 
 ```txt
 QAMap QA
-Local static analysis. Product QA was not run.
+Local static analysis. No cloud or LLM token. Product QA was not run.
 
 Change
-  Prevent duplicate subscription renewal requests
+  Prevent duplicate subscription renewal requests (medium confidence; review required)
+  Flow:
+    action: Prevent duplicate subscription renewal requests.
+    -> observable-outcome: Subscription status becomes active.
+  Affected behavior: Prevent duplicate subscription renewal requests
 
 Verify before merge
-  REQUIRED     Subscription becomes visibly active
-  RECOMMENDED  Duplicate renewal request is prevented
+  REQUIRED  Prevent duplicate subscription renewal requests
+    Proof: Verify visible text "Subscription active" appears.
+    Evidence: src/pages/renewal.tsx:11 (RenewalPage)
+  RECOMMENDED  Failure, timeout, and retry handling
+    Proof: Verify each response produces the intended visible or persisted state.
+    Evidence: src/pages/renewal.tsx:11 (RenewalPage)
+  RECOMMENDED  Duplicate renewal request
+    Proof: Verify duplicate renewal request is prevented or handled explicitly.
+    Evidence: src/pages/renewal.tsx:11 (RenewalPage)
 
 Evidence
-  3/3 scenarios connect to 6 unique diff sources.
-  Existing validation: npm run test:e2e (selected, not run)
+  3/3 scenarios connect to 5 unique diff source(s).
+  Routing: 1 required, 2 recommended, 0 review-only.
+  Optional E2E mapping: 1 mapped, 1 partial, 1 unmapped; not executed.
+  Supplemental validation: npm run test:e2e (available, not selected for this QA route)
 
 Next
-  Run selected validation: qamap qa run
-  Preview E2E draft: qamap e2e draft . --dry-run
+  Review the selected scenarios before choosing an execution step.
+  Preview an optional automation or checklist draft: qamap e2e draft . --dry-run
+  Open the full reasoning trace: qamap qa --format markdown
 ```
 
 ## 반복해서 CLI 사용하기

--- a/README.md
+++ b/README.md
@@ -113,22 +113,36 @@ marked `not run`.
 
 ```txt
 QAMap QA
-Local static analysis. Product QA was not run.
+Local static analysis. No cloud or LLM token. Product QA was not run.
 
 Change
-  Prevent duplicate subscription renewal requests
+  Prevent duplicate subscription renewal requests (medium confidence; review required)
+  Flow:
+    action: Prevent duplicate subscription renewal requests.
+    -> observable-outcome: Subscription status becomes active.
+  Affected behavior: Prevent duplicate subscription renewal requests
 
 Verify before merge
-  REQUIRED     Subscription becomes visibly active
-  RECOMMENDED  Duplicate renewal request is prevented
+  REQUIRED  Prevent duplicate subscription renewal requests
+    Proof: Verify visible text "Subscription active" appears.
+    Evidence: src/pages/renewal.tsx:11 (RenewalPage)
+  RECOMMENDED  Failure, timeout, and retry handling
+    Proof: Verify each response produces the intended visible or persisted state.
+    Evidence: src/pages/renewal.tsx:11 (RenewalPage)
+  RECOMMENDED  Duplicate renewal request
+    Proof: Verify duplicate renewal request is prevented or handled explicitly.
+    Evidence: src/pages/renewal.tsx:11 (RenewalPage)
 
 Evidence
-  3/3 scenarios connect to 6 unique diff sources.
-  Existing validation: npm run test:e2e (selected, not run)
+  3/3 scenarios connect to 5 unique diff source(s).
+  Routing: 1 required, 2 recommended, 0 review-only.
+  Optional E2E mapping: 1 mapped, 1 partial, 1 unmapped; not executed.
+  Supplemental validation: npm run test:e2e (available, not selected for this QA route)
 
 Next
-  Run selected validation: qamap qa run
-  Preview E2E draft: qamap e2e draft . --dry-run
+  Review the selected scenarios before choosing an execution step.
+  Preview an optional automation or checklist draft: qamap e2e draft . --dry-run
+  Open the full reasoning trace: qamap qa --format markdown
 ```
 
 </details>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,6 +23,19 @@ commit range + base/head diff
   -> normalized evidence and verdict
 ```
 
+## Public Workflow Boundary
+
+The internal pipeline can grow, but normal users should need only a small set of
+decisions: run `qa`, inspect its evidence, explicitly run a selected existing
+validation, or opt into an automation draft. Scanner, readiness, legacy
+manifest, and adapter commands remain available for advanced and compatibility
+workflows without becoming separate concepts every first-time user must learn.
+
+This boundary is deliberate. QAMap should work without configuration, while
+team context and lower-level controls become visible only when a repository has
+a concrete reason to customize them. Analysis never silently crosses into
+execution, installation, or repository writes.
+
 The repository, not a model session, is the source of truth. Commit subjects and bodies provide author intent, source code supplies observable structure, optional symbol QA annotations bind important exports to local semantics, and `.qamap/manifest.yaml` supplies reviewed team-wide product intent that commits and code alone cannot prove.
 
 ## Knowledge Authority And Test Classes

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6,6 +6,10 @@ Every QAMap command, with what it produces and when to reach for it. For the sho
 > and `qamap e2e draft --dry-run`. Search for a command name instead of reading
 > this document from top to bottom.
 
+`qamap --help` intentionally shows only that core workflow. Use
+`qamap qa --help` for its analysis and execution options, or `qamap help --all`
+when maintaining an older scanner, CI, manifest, or compatibility workflow.
+
 ## Quick Commands
 
 ```sh

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -107,7 +107,11 @@ async function main(argv: string[]): Promise<number> {
   }
 
   if (command === "help" || command === "--help" || command === "-h") {
-    printHelp();
+    if (rest.includes("--all") || rest.includes("all")) {
+      printFullHelp();
+    } else {
+      printHelp();
+    }
     return 0;
   }
 
@@ -285,6 +289,10 @@ async function main(argv: string[]): Promise<number> {
   }
 
   if (command === "qa") {
+    if (rest[0] === "help" || rest[0] === "--help" || rest[0] === "-h") {
+      printQaHelp();
+      return 0;
+    }
     const runValidation = rest[0] === "run";
     const options = parseOptions(runValidation ? rest.slice(1) : rest);
     const loadedConfig = await loadOptionsConfig(options);
@@ -1020,10 +1028,76 @@ Want shorter commands for repeat use? Run once: qamap init --scripts
       Adds qa, qa:local, qa:run, and qa:e2e package scripts without replacing
       existing scripts unless --force is passed.
 
-Full command reference: qamap help`);
+Full command reference: qamap help --all`);
 }
 
 function printHelp(): void {
+  console.log(`QAMap ${VERSION}
+
+Find what a change needs to prove before merge.
+
+Core workflow:
+  qamap qa [path]
+      Analyze the current branch and show changed behavior, QA scenarios,
+      diff evidence, and the safest next action. Does not run product QA.
+
+  qamap qa run [path]
+      Re-analyze the branch and run only the exact existing repository
+      validation selected by QAMap. Returns an explicit execution receipt.
+
+  qamap e2e draft [path] --dry-run
+      Preview an optional automation or checklist draft after reviewing the
+      selected QA scenarios. Does not install a runner or execute the draft.
+
+  qamap manifest init [path]
+      Optional: create repo-local QA context when repeated runs need durable
+      team language or flow corrections.
+
+Agent and repeat-use setup:
+  qamap init --agent [path]
+  qamap init --scripts [path]
+
+Output:
+  --format text       concise human summary (default)
+  --format markdown   complete reasoning trace
+  --format agent      compact versioned agent contract
+  --format json       complete structured result
+
+Use \`qamap qa --help\` for QA options or \`qamap help --all\` for every
+advanced and compatibility command.`);
+}
+
+function printQaHelp(): void {
+  console.log(`QAMap ${VERSION}
+
+Analyze first. Execute only through an explicit follow-up command.
+
+Usage:
+  qamap qa [path] [--workspace-root <path>] [--manifest <file>]
+    [--base <ref>] [--head <ref>] [--include-working-tree]
+    [--runner maestro|playwright|manual] [--format <format>] [--output <file>]
+
+  qamap qa run [path] [--workspace-root <path>] [--manifest <file>]
+    [--base <ref>] [--head <ref>] [--include-working-tree]
+    [--timeout-ms <n>] [--format <format>] [--output <file>]
+
+Behavior:
+  qa       maps diff -> affected behavior -> risk -> scenario -> evidence.
+           Product QA and generated drafts remain marked not run.
+  qa run   repeats the analysis, then executes only the selected existing
+           repository command when the action contract permits it.
+
+Common examples:
+  qamap qa
+  qamap qa --include-working-tree
+  qamap qa --format markdown
+  qamap qa --format agent
+  qamap qa run
+
+Use \`qamap help --all\` for every advanced and compatibility command.`);
+}
+
+function printFullHelp(): void {
   console.log(`QAMap ${VERSION}
 
 Local zero-LLM PR QA design, deterministic automation drafts, and repository guardrails.

--- a/test/cli-help.test.mjs
+++ b/test/cli-help.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const cli = path.join(repositoryRoot, "dist/cli.js");
+
+function runCli(...args) {
+  return execFileSync(process.execPath, [cli, ...args], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    env: { ...process.env, NO_COLOR: "1" },
+  });
+}
+
+test("default help teaches the small QA workflow before advanced commands", () => {
+  const output = runCli("--help");
+
+  for (const command of [
+    "qamap qa [path]",
+    "qamap qa run [path]",
+    "qamap e2e draft [path] --dry-run",
+    "qamap manifest init [path]",
+    "qamap init --agent [path]",
+    "qamap help --all",
+  ]) {
+    assert.match(output, new RegExp(command.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+  assert.doesNotMatch(output, /qamap scan \[path\]/);
+  assert.doesNotMatch(output, /qamap flows suggest/);
+});
+
+test("full help preserves advanced and compatibility commands", () => {
+  const output = runCli("help", "--all");
+
+  assert.match(output, /qamap scan \[path\]/);
+  assert.match(output, /qamap verify \[path\]/);
+  assert.match(output, /qamap flows suggest \[path\]/);
+  assert.match(output, /qamap domains suggest \[path\]/);
+});
+
+test("QA help explains the analysis and execution boundary", () => {
+  const output = runCli("qa", "--help");
+
+  assert.match(output, /maps diff -> affected behavior -> risk -> scenario -> evidence/);
+  assert.match(output, /Product QA and generated drafts remain marked not run/);
+  assert.match(output, /executes only the selected existing\s+repository command/);
+});

--- a/test/readme-demo.test.mjs
+++ b/test/readme-demo.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { formatTextQaDraft, generateQaDraft } from "../dist/qa.js";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("public README demos are generated from the current QA engine", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "qamap-readme-demo-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  git(root, "init", "-b", "main");
+  git(root, "config", "user.email", "qamap@example.test");
+  git(root, "config", "user.name", "QAMap Test");
+
+  await write(root, "package.json", JSON.stringify({
+    scripts: { dev: "vite", "test:e2e": "playwright test" },
+    dependencies: {
+      react: "19.0.0",
+      vite: "7.0.0",
+      "@playwright/test": "1.56.0",
+    },
+  }));
+  await write(
+    root,
+    "playwright.config.ts",
+    "export default { use: { baseURL: 'http://127.0.0.1:4173' } };\n",
+  );
+  await write(root, "src/pages/renewal.tsx", renewalSource(false));
+  commit(root, "benchmark baseline");
+  git(root, "switch", "-c", "fix/renewal-duplicate");
+  await write(root, "src/pages/renewal.tsx", renewalSource(true));
+  commit(root, "fix: prevent duplicate subscription renewal requests");
+
+  const result = await generateQaDraft(root, { base: "main", head: "HEAD" });
+  const actual = formatTextQaDraft(result).trimEnd();
+
+  for (const [file, heading] of [
+    ["README.md", "## See A Real Run"],
+    ["README.ko.md", "## 실제 실행 예시"],
+  ]) {
+    const source = await readFile(path.join(repositoryRoot, file), "utf8");
+    assert.equal(extractTextBlock(source, heading), actual, `${file} demo drifted from the QA engine`);
+  }
+});
+
+function renewalSource(withDuplicateGuard) {
+  return [
+    "/**",
+    " * @qamapFlow subscription-renewal",
+    " * @qamapStage action Renew the subscription",
+    " * @qamapOutcome Subscription status becomes active",
+    " * @qamapRisk Duplicate renewal request",
+    " */",
+    "export default function RenewalPage() {",
+    "  const [status, setStatus] = useState('idle');",
+    "  const [renewing, setRenewing] = useState(false);",
+    "  async function renew() {",
+    withDuplicateGuard ? "    if (renewing) return;" : "",
+    "    setRenewing(true);",
+    "    await renewSubscription();",
+    "    setStatus('active');",
+    "  }",
+    "  return <main>",
+    "    <button data-testid=\"renew-subscription\" onClick={renew}>Renew subscription</button>",
+    "    {status === 'active' ? <p>Subscription active</p> : null}",
+    "  </main>;",
+    "}",
+    "async function renewSubscription() {",
+    "  const response = await fetch('/api/subscriptions/renew', { method: 'POST' });",
+    "  if (!response.ok) throw new Error('Could not renew subscription');",
+    "  return response.json();",
+    "}",
+    "",
+  ].filter(Boolean).join("\n");
+}
+
+function extractTextBlock(source, heading) {
+  const section = source.slice(source.indexOf(heading) + heading.length);
+  const match = section.match(/```txt\n([\s\S]*?)\n```/);
+  assert.ok(match, `${heading} must contain a txt code block`);
+  return match[1];
+}
+
+async function write(root, file, content) {
+  await mkdir(path.dirname(path.join(root, file)), { recursive: true });
+  await writeFile(path.join(root, file), content);
+}
+
+function commit(root, message) {
+  git(root, "add", "-A");
+  git(root, "commit", "-m", message);
+}
+
+function git(root, ...args) {
+  execFileSync("git", args, { cwd: root, stdio: "ignore" });
+}


### PR DESCRIPTION
## Summary

Make QAMap teach one small public workflow: analyze the change, inspect traceable evidence, explicitly run an existing validation, or optionally preview an automation draft. Advanced and compatibility commands remain available without crowding the first-run experience.

## Behavioral Contract

- `qamap --help` presents only the core QA workflow and setup paths.
- `qamap qa --help` explains the diff-to-evidence pipeline and the analysis/execution boundary.
- `qamap help --all` preserves every advanced and compatibility command.
- README examples must equal output generated by the current QA engine.
- No inference, routing, execution, or existing command behavior is removed.

## Evidence

- `test/cli-help.test.mjs` covers the concise default, full compatibility help, and explicit execution boundary.
- `test/readme-demo.test.mjs` generates a generic subscription-renewal branch fixture and compares both README examples byte-for-byte with the engine output.
- Negative controls ensure advanced scanner and legacy flow commands do not return to default help.

## Checks

- [x] Focused regression test
- [x] `pnpm test`
- [x] `pnpm bench:ci` for inference, routing, trace, or output
- [ ] `pnpm bench:execution` for E2E compiler or execution fixtures
- [ ] `pnpm scan` for scanner, security, or repository policy
- [x] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
- [x] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

This is a progressive-disclosure change, not a command removal. `help --all` keeps the full surface available. `pnpm coverage` also passed at 89.98% lines, 86.85% branches, and 95.76% functions. `bench:execution` and `scan` are N/A because this PR does not change the compiler, execution fixtures, scanner, security policy, or repository policy.