### PR TITLE
Fix: surface delivery integrity risks before optional E2E

### DIFF
--- a/bench.config.json
+++ b/bench.config.json
@@ -2,6 +2,27 @@
   "$comment": "Committed quality contract. Each fixture is materialized as a temporary Git repository with a main baseline and one PR change.",
   "targets": [
     {
+      "name": "web-delivery-integrity-missing-asset",
+      "fixture": "test/benchmarks/web-delivery-integrity-missing-asset",
+      "commitMessage": "feat: show the updated workspace preview",
+      "expect": {
+        "readinessBasis": "repository-validation",
+        "automationApplicable": false,
+        "minFlows": 1,
+        "minChangeIntents": 1,
+        "minReasoningTraces": 1,
+        "maxUntraceableRequiredScenarios": 0,
+        "mustReachFiles": ["src/pages/workspace-preview.tsx"],
+        "mustIncludeQaScenarios": ["Committed artifacts and validation history remain intact"],
+        "mustFindIntentEvidence": ["absent from both the committed head and workspace"],
+        "mustTraceScenarioFiles": ["src/pages/workspace-preview.tsx"],
+        "mustRecommendCommands": ["run build"],
+        "maxBlankActions": 0,
+        "maxGenericTitles": 0,
+        "maxAgentBytes": 4096
+      }
+    },
+    {
       "name": "public-calcom-signup-validation",
       "fixture": "test/benchmarks/public-calcom-signup-validation",
       "commitMessage": "fix: defer email validation to after first blur on signup form",

--- a/src/change-intent.ts
+++ b/src/change-intent.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import {
@@ -269,7 +269,14 @@ export async function analyzeChangeIntents(
       changedSourceRoles,
     ),
   ]);
+  const deliveryIntegrityEvidence = await collectDeliveryIntegrityEvidence(
+    root,
+    gitRoot,
+    options,
+    changedSourceRoles,
+  );
   const riskEvidence = uniqueEvidence([
+    ...deliveryIntegrityEvidence,
     ...collectDiffRiskEvidence(options.addedDiffEvidence ?? {}, changedSourceRoles),
     ...collectRemovalContractEvidence(
       options.changedFiles,
@@ -807,12 +814,14 @@ function buildDiffOnlyIntent(
   const roleEvidence = riskEvidence.filter((item) =>
     item.sourceRole === "analysis-rule" || item.sourceRole === "command"
   );
+  const deliveryIntegrityEvidence = riskEvidence.filter(isDeliveryIntegrityEvidence);
   const lifecycle = limitLifecycleStages([
     ...lifecycleFromCodeSignals(codeSignals),
     ...lifecycleFromSourceRoles(roleEvidence),
+    ...lifecycleFromDeliveryIntegrityEvidence(deliveryIntegrityEvidence),
   ]);
   const stageKinds = new Set(lifecycle.map((stage) => stage.kind));
-  const hasRecognizedSourceRole = roleEvidence.length > 0;
+  const hasRecognizedSourceRole = roleEvidence.length > 0 || deliveryIntegrityEvidence.length > 0;
   const hasSymbolAnnotation = annotationEvidence.length > 0;
   if (
     (!hasRecognizedSourceRole && !hasSymbolAnnotation && (lifecycle.length < 3 || stageKinds.size < 3)) ||
@@ -823,9 +832,12 @@ function buildDiffOnlyIntent(
   const files = uniqueStrings([
     ...codeSignals.map((signal) => signal.file),
     ...roleEvidence.map((item) => item.file ?? "").filter(Boolean),
+    ...deliveryIntegrityEvidence.map((item) => item.file ?? "").filter(Boolean),
   ]).slice(0, maxIntentFiles);
   const annotatedFlow = firstQaAnnotationFlow(annotationEvidence);
-  const titleSubject = annotatedFlow
+  const titleSubject = deliveryIntegrityEvidence.length > 0
+    ? "Delivery integrity"
+    : annotatedFlow
     ? humanizeIdentifier(annotatedFlow)
     : diffIntentSubject(files[0], roleEvidence[0]?.sourceRole, roleEvidence);
   const analysisRuleChange = roleEvidence.some((item) => item.sourceRole === "analysis-rule");
@@ -976,6 +988,7 @@ function buildLifecycle(
 
   stages.push(...lifecycleFromDetectedRiskEvidence(roleEvidence));
   stages.push(...lifecycleFromSourceRoles(roleEvidence));
+  stages.push(...lifecycleFromDeliveryIntegrityEvidence(roleEvidence.filter(isDeliveryIntegrityEvidence)));
 
   return limitLifecycleStages(removeRedundantOutcomeTimingTriggers(stages));
 }
@@ -1246,6 +1259,58 @@ function buildIntentQaScenarios(
   );
   const searchable = `${hasProductDiffEvidence ? title : ""} ${productLifecycle.map((stage) => stage.label).join(" ")}`
     .toLowerCase();
+
+  const deliveryIntegrityEvidence = evidence.filter(isDeliveryIntegrityEvidence);
+  if (deliveryIntegrityEvidence.length > 0) {
+    const missingAssetEvidence = deliveryIntegrityEvidence.filter((item) =>
+      item.symbol === "delivery-integrity:missing-asset" ||
+      item.symbol === "delivery-integrity:uncommitted-asset"
+    );
+    const historyRewriteEvidence = deliveryIntegrityEvidence.filter((item) =>
+      item.symbol === "delivery-integrity:history-rewrite"
+    );
+    const deliveryIntegrity = makeScenario(
+      intentId,
+      "delivery-integrity",
+      "failure",
+      "critical",
+      "Committed artifacts and validation history remain intact",
+      uniqueStrings([
+        missingAssetEvidence.length > 0
+          ? "Prepare a clean checkout of the changed commit without untracked workspace files."
+          : "Inspect the changed validation or release workflow from a clean branch checkout.",
+        historyRewriteEvidence.length > 0
+          ? "Preserve the branch tip and commit graph before evaluating the changed workflow."
+          : "Use the repository's normal build, bundle, or export contract.",
+      ]),
+      uniqueStrings([
+        missingAssetEvidence.length > 0
+          ? "Resolve every changed literal local asset reference against the committed head, then run the repository build, bundle, or export command."
+          : "Run the repository-owned validation path without allowing it to replace branch commits.",
+        historyRewriteEvidence.length > 0
+          ? "Inspect the exact workflow commands that reset, commit, restore, or force-push the checked-out branch."
+          : "Inspect the produced artifact from a clean checkout rather than the current workspace alone.",
+      ]),
+      uniqueStrings([
+        missingAssetEvidence.length > 0
+          ? "Verify every referenced local asset exists in the committed head and is included in the produced artifact."
+          : "Verify the produced artifact contains every changed runtime dependency.",
+        historyRewriteEvidence.length > 0
+          ? "Verify validation and release jobs leave the pull request branch tip and commit history unchanged."
+          : "Verify the clean-checkout artifact matches the branch being reviewed.",
+      ]),
+      uniqueStrings([
+        missingAssetEvidence.some((item) => item.symbol === "delivery-integrity:uncommitted-asset")
+          ? "Asset present only in the local workspace"
+          : "Asset absent from a clean checkout",
+        historyRewriteEvidence.length > 0 ? "Validation job rewrites branch history" : "Bundle omits a referenced asset",
+      ]),
+      deliveryIntegrityEvidence,
+    );
+    deliveryIntegrity.rationale =
+      "The changed source or workflow can produce a branch that works locally but cannot be reproduced safely from the committed review evidence; resolve this delivery blocker before optional product automation.";
+    scenarios.push(deliveryIntegrity);
+  }
 
   const retiredSurfaceEvidence = productEvidence.filter((item) =>
     item.kind === "diff" &&
@@ -2617,6 +2682,244 @@ function collectDiffRiskEvidence(
     }
   }
   return uniqueEvidence(evidence);
+}
+
+async function collectDeliveryIntegrityEvidence(
+  root: string,
+  gitRoot: string,
+  options: ChangeIntentAnalysisOptions,
+  changedSourceRoles: ReturnType<typeof classifyChangedSourceRoles>,
+): Promise<ChangeIntentEvidence[]> {
+  const relativeRoot = toPosixPath(path.relative(gitRoot, root)).replace(/^\.\/+|\/+$/g, "");
+  const evidence: ChangeIntentEvidence[] = [];
+  const assetChecks: Array<Promise<ChangeIntentEvidence | undefined>> = [];
+
+  for (const [file, hunks] of Object.entries(options.addedDiffEvidence ?? {})) {
+    const sourceRole = changedSourceRoles[file]?.role ??
+      classifyChangeSourceRole(file, diffTextForRoleClassification(hunks)).role;
+    if (sourceRole === "product" || sourceRole === "configuration") {
+      for (const hunk of hunks) {
+        for (const line of hunk.lines) {
+          for (const reference of literalLocalAssetReferences(line.text)) {
+            const resolved = resolveLocalAssetReference(file, reference);
+            if (!resolved) continue;
+            const repositoryPath = relativeRoot ? `${relativeRoot}/${resolved}` : resolved;
+            assetChecks.push((async () => {
+              if (await gitPathExistsAtRef(gitRoot, options.head, repositoryPath)) {
+                return undefined;
+              }
+              if (await hasDeclaredGeneratedAssetContract(root, gitRoot, repositoryPath)) {
+                return undefined;
+              }
+              const presentInWorkspace = await filePathExists(path.join(root, resolved));
+              return diffRiskEvidence(
+                file,
+                hunk,
+                line.line,
+                presentInWorkspace
+                  ? "delivery-integrity:uncommitted-asset"
+                  : "delivery-integrity:missing-asset",
+                presentInWorkspace
+                  ? `Changed local asset reference ${reference} resolves in the workspace but is absent from the committed head at ${resolved}.`
+                  : `Changed local asset reference ${reference} is absent from both the committed head and workspace at ${resolved}.`,
+                "head",
+                sourceRole,
+              );
+            })());
+          }
+        }
+      }
+    }
+    if (isCiValidationWorkflowPath(file)) {
+      evidence.push(...collectDestructiveWorkflowEvidence(file, hunks));
+    }
+  }
+
+  evidence.push(...(await Promise.all(assetChecks)).filter(
+    (item): item is ChangeIntentEvidence => Boolean(item),
+  ));
+  return uniqueEvidence(evidence);
+}
+
+function literalLocalAssetReferences(text: string): string[] {
+  const trimmed = text.trim();
+  if (/^(?:\/\/|#|\*|<!--)/.test(trimmed)) {
+    return [];
+  }
+  const references: string[] = [];
+  const quotedPatterns = [
+    /\b(?:from|import)\s*["'`]([^"'`]+)["'`]/gi,
+    /\b(?:require|url|URL)\s*\(\s*["'`]([^"'`]+)["'`]/gi,
+    /\b(?:src|href|poster)\s*=\s*(?:\{\s*)?["'`]([^"'`]+)["'`]/gi,
+  ];
+  for (const pattern of quotedPatterns) {
+    for (const match of text.matchAll(pattern)) {
+      references.push(match[1]);
+    }
+  }
+  for (const match of text.matchAll(/\burl\(\s*([^"'`\s)][^)]*?)\s*\)/gi)) {
+    references.push(match[1]);
+  }
+  return uniqueStrings(references.filter(isLiteralLocalAssetReference));
+}
+
+function isLiteralLocalAssetReference(value: string): boolean {
+  const reference = value.trim();
+  if (
+    !reference ||
+    reference.includes("${") ||
+    /^(?:[a-z][a-z0-9+.-]*:|\/\/|#)/i.test(reference) ||
+    !(reference.startsWith("./") || reference.startsWith("../") || reference.startsWith("/"))
+  ) {
+    return false;
+  }
+  return /\.(?:avif|bmp|gif|ico|jpe?g|png|webp|svg|mp3|m4a|ogg|wav|mp4|webm|woff2?|ttf|otf|eot)(?:[?#].*)?$/i.test(
+    reference,
+  );
+}
+
+function resolveLocalAssetReference(sourceFile: string, referenceInput: string): string | undefined {
+  const reference = referenceInput.trim().replace(/[?#].*$/, "");
+  const resolved = reference.startsWith("/")
+    ? path.posix.join("public", reference.slice(1))
+    : path.posix.normalize(path.posix.join(path.posix.dirname(toPosixPath(sourceFile)), reference));
+  if (!resolved || resolved === ".." || resolved.startsWith("../") || path.posix.isAbsolute(resolved)) {
+    return undefined;
+  }
+  return resolved;
+}
+
+async function gitPathExistsAtRef(root: string, ref: string, file: string): Promise<boolean> {
+  try {
+    await execFileAsync("git", ["cat-file", "-e", `${ref}:${file}`], { cwd: root });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function hasDeclaredGeneratedAssetContract(
+  root: string,
+  gitRoot: string,
+  repositoryPath: string,
+): Promise<boolean> {
+  try {
+    await execFileAsync("git", ["check-ignore", "-q", "--", repositoryPath], { cwd: gitRoot });
+  } catch {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(await readFile(path.join(root, "package.json"), "utf8")) as {
+      scripts?: Record<string, unknown>;
+    };
+    return Object.entries(parsed.scripts ?? {}).some(([name, command]) =>
+      typeof command === "string" &&
+      /^(?:generate|codegen|prepare|prebuild|postinstall)(?::|$)/i.test(name) &&
+      /\b(?:asset|codegen|copy|generate|public|static)\b/i.test(command)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isCiValidationWorkflowPath(fileInput: string): boolean {
+  const file = toPosixPath(fileInput);
+  return /(?:^|\/)\.github\/workflows\/[^/]+\.ya?ml$/i.test(file) ||
+    /(?:^|\/)\.circleci\/config\.ya?ml$/i.test(file) ||
+    /(?:^|\/)(?:\.gitlab-ci|bitbucket-pipelines|azure-pipelines)\.ya?ml$/i.test(file);
+}
+
+function collectDestructiveWorkflowEvidence(
+  file: string,
+  hunks: AddedDiffHunk[],
+): ChangeIntentEvidence[] {
+  const candidates = hunks.flatMap((hunk) => hunk.lines.flatMap((line) => {
+    const description = destructiveWorkflowCommandDescription(line.text);
+    return description ? [{ hunk, line, description }] : [];
+  }));
+  if (!candidates.some((candidate) => candidate.description.startsWith("force-pushes"))) {
+    return [];
+  }
+  return candidates.map(({ hunk, line, description }) => diffRiskEvidence(
+    file,
+    hunk,
+    line.line,
+    "delivery-integrity:history-rewrite",
+    `Changed validation workflow ${description}.`,
+    "head",
+    "configuration",
+  ));
+}
+
+function destructiveWorkflowCommandDescription(text: string): string | undefined {
+  const trimmed = text.trim();
+  if (/^(?:#|\/\/)/.test(trimmed) || /\b(?:echo|printf)\b[^\n]*\bgit\s+/i.test(trimmed)) {
+    return undefined;
+  }
+  if (/\bgit\s+push\b[^\n]*(?:--force(?:-with-lease)?|(?:^|\s)-f(?:\s|$))/i.test(trimmed)) {
+    return "force-pushes Git history";
+  }
+  if (/\bgit\s+reset\s+--hard\b/i.test(trimmed)) {
+    return "hard-resets the checked-out branch before a force-push";
+  }
+  if (/\bgit\s+checkout\b[^\n]*(?:--force|\s--\s+\.?\/?\*?|\s--\s+\.)/i.test(trimmed)) {
+    return "replaces checked-out files before a force-push";
+  }
+  if (/\bgit\s+restore\b[^\n]*--source(?:=|\s)/i.test(trimmed)) {
+    return "restores files from another revision before a force-push";
+  }
+  if (/\bgit\s+commit\b/i.test(trimmed)) {
+    return "creates a commit before a force-push";
+  }
+  return undefined;
+}
+
+function isDeliveryIntegrityEvidence(evidence: ChangeIntentEvidence): boolean {
+  return evidence.symbol?.startsWith("delivery-integrity:") ?? false;
+}
+
+function lifecycleFromDeliveryIntegrityEvidence(
+  evidence: ChangeIntentEvidence[],
+): BehaviorLifecycleStage[] {
+  if (evidence.length === 0) {
+    return [];
+  }
+  const files = uniqueStrings(evidence.map((item) => item.file ?? "").filter(Boolean));
+  return [
+    createLifecycleStage(
+      "condition",
+      "A changed delivery path depends on committed artifacts and preserved branch history.",
+      "high",
+      evidence,
+      files,
+      "delivery-integrity:precondition",
+    ),
+    createLifecycleStage(
+      "action",
+      "Validate the clean-checkout artifact and workflow history.",
+      "high",
+      evidence,
+      files,
+      "delivery-integrity:validation",
+    ),
+    createLifecycleStage(
+      "observable-outcome",
+      "Observe a reproducible artifact without rewriting the review branch.",
+      "high",
+      evidence,
+      files,
+      "delivery-integrity:result",
+    ),
+  ];
+}
+
+async function filePathExists(file: string): Promise<boolean> {
+  try {
+    await access(file);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function collectRemovalContractEvidence(

--- a/src/qa.ts
+++ b/src/qa.ts
@@ -228,6 +228,7 @@ export interface QaCurrentDelta {
 type QaVerificationMode =
   | "command-contract"
   | "analysis-rule"
+  | "delivery-integrity"
   | "schema-graph"
   | "transformation-contract"
   | "existing-test-evidence"
@@ -386,7 +387,9 @@ export async function generateQaDraft(rootInput: string, options: QaDraftOptions
   );
   const routedCandidateCommands = flows.some((flow) => flow.verificationMode === "schema-graph")
     ? candidateCommandsWithoutInsufficientTests.filter(isMigrationGraphValidationCommand)
-    : candidateCommandsWithoutInsufficientTests;
+    : flows.some((flow) => flow.verificationMode === "delivery-integrity")
+      ? candidateCommandsWithoutInsufficientTests.filter(isDeliveryIntegrityValidationCommand)
+      : candidateCommandsWithoutInsufficientTests;
   const suggestedCommands = await preferLocallyRunnableValidationCommands(root, routedCandidateCommands);
   const missingEvidence = uniqueMissingEvidence([
     ...runtimePrerequisiteTestGaps.map(runtimePrerequisiteMissingEvidence),
@@ -3638,7 +3641,9 @@ function qaFlowFromDraftFile(file: E2eDraftFile): QaDraftFlow {
   const verificationMode = verificationModeForDraftFile(file);
   const knowledge = qaFlowKnowledge(file, verificationMode);
   return {
-    title: file.flowTitle,
+    title: verificationMode === "delivery-integrity"
+      ? "Delivery integrity verification"
+      : file.flowTitle,
     source: formatDraftSource(file.source),
     draftPath: file.path,
     runnableStatus: file.runnableStatus,
@@ -3894,6 +3899,9 @@ function buildFlowReasons(file: E2eDraftFile): string[] {
   if (verificationMode === "analysis-rule") {
     return ["Analyzer rules changed; verify positive, negative, and neighboring-rule controls instead of inventing a product journey."];
   }
+  if (verificationMode === "delivery-integrity") {
+    return ["The branch may not reproduce safely from committed evidence; resolve missing artifacts or history-rewriting validation before optional product automation."];
+  }
   if (verificationMode === "schema-graph") {
     return ["The changed migration dependency diverges from the target branch graph; restore one leaf and validate the deployment order instead of inventing a product journey."];
   }
@@ -4099,6 +4107,11 @@ function verificationModeForDraftFile(file: E2eDraftFile): QaVerificationMode | 
   if (file.flowKind === "transformation") {
     return "transformation-contract";
   }
+  if (file.qaScenarios?.some((scenario) =>
+    scenario.evidence.some((source) => source.symbol?.startsWith("delivery-integrity:"))
+  )) {
+    return "delivery-integrity";
+  }
   const scenarioSourceRoles = (file.qaScenarios ?? [])
     .flatMap((scenario) => scenario.evidence)
     .map((source) => source.sourceRole)
@@ -4125,6 +4138,9 @@ function formatVerificationMode(mode: QaVerificationMode): string {
   if (mode === "analysis-rule") {
     return "analyzer rule boundary verification";
   }
+  if (mode === "delivery-integrity") {
+    return "clean-checkout artifact and workflow history verification";
+  }
   if (mode === "schema-graph") {
     return "migration graph and deployment-order verification";
   }
@@ -4141,6 +4157,10 @@ function formatVerificationMode(mode: QaVerificationMode): string {
     return "documentation contract verification";
   }
   return "generated artifact verification";
+}
+
+function isDeliveryIntegrityValidationCommand(command: string): boolean {
+  return /\b(?:actionlint|archive|build|bundle|export|pack|package|workflow)\b/i.test(command);
 }
 
 function isMigrationGraphValidationCommand(command: string): boolean {

--- a/test/benchmarks/web-delivery-integrity-missing-asset/base/package.json
+++ b/test/benchmarks/web-delivery-integrity-missing-asset/base/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "benchmark-delivery-integrity",
+  "private": true,
+  "scripts": {
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@vitejs/plugin-react": "latest",
+    "vite": "latest"
+  }
+}

--- a/test/benchmarks/web-delivery-integrity-missing-asset/base/src/pages/workspace-preview.tsx
+++ b/test/benchmarks/web-delivery-integrity-missing-asset/base/src/pages/workspace-preview.tsx
@@ -1,0 +1,3 @@
+export function WorkspacePreview() {
+  return <main>Workspace preview</main>;
+}

--- a/test/benchmarks/web-delivery-integrity-missing-asset/head/package.json
+++ b/test/benchmarks/web-delivery-integrity-missing-asset/head/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "benchmark-delivery-integrity",
+  "private": true,
+  "scripts": {
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@vitejs/plugin-react": "latest",
+    "vite": "latest"
+  }
+}

--- a/test/benchmarks/web-delivery-integrity-missing-asset/head/src/pages/workspace-preview.tsx
+++ b/test/benchmarks/web-delivery-integrity-missing-asset/head/src/pages/workspace-preview.tsx
@@ -1,0 +1,7 @@
+export function WorkspacePreview() {
+  return (
+    <main>
+      <img src="/media/workspace-preview.webp" alt="Workspace preview" />
+    </main>
+  );
+}

--- a/test/change-intent.test.mjs
+++ b/test/change-intent.test.mjs
@@ -5097,6 +5097,181 @@ test("diff evidence keeps merged target-branch changes outside the QA evidence b
   assert.equal(qa.execution.status, "not-run");
 });
 
+test("QA routes a local-only referenced asset to delivery integrity before optional E2E", async (t) => {
+  const root = await makeRepo(t);
+  const sourceFile = "src/profile/ProfileCard.tsx";
+  const assetFile = "src/profile/assets/profile-card.webp";
+  await write(root, "package.json", JSON.stringify({
+    scripts: {
+      build: "node -e \"process.exit(0)\"",
+    },
+  }, null, 2) + "\n");
+  await write(root, sourceFile, "export function ProfileCard() { return <section>Profile</section>; }\n");
+  commit(root, "chore: baseline");
+  branch(root, "feat/profile-card-image");
+
+  await write(
+    root,
+    sourceFile,
+    "export function ProfileCard() { return <img src=\"./assets/profile-card.webp\" alt=\"Profile\" />; }\n",
+  );
+  git(root, "add", sourceFile);
+  git(root, "commit", "-m", "feat: show the profile card image");
+  await write(root, assetFile, "local-only-image\n");
+
+  const analysis = await analyze(root, [sourceFile]);
+  const integrityEvidence = analysis.intents.flatMap((intent) => intent.evidence).filter((item) =>
+    item.symbol === "delivery-integrity:uncommitted-asset"
+  );
+  assert.equal(integrityEvidence.length, 1);
+  assert.equal(integrityEvidence[0].file, sourceFile);
+  assert.equal(integrityEvidence[0].startLine, 1);
+  assert.match(integrityEvidence[0].value, /workspace but is absent from the committed head/i);
+  assert.ok(analysis.intents.flatMap((intent) => intent.scenarios).some((scenario) =>
+    scenario.title === "Committed artifacts and validation history remain intact" &&
+    scenario.priority === "critical"
+  ));
+
+  const qa = await generateQaDraft(root, { base: "main", head: "HEAD" });
+  assert.ok(qa.flows.some((flow) => flow.verificationMode === "delivery-integrity"));
+  assert.equal(qa.readiness.basis, "repository-validation");
+  assert.equal(qa.readiness.automationApplicable, false);
+  assert.match(qa.route.command ?? "", /run build$/);
+  assert.equal(qa.execution.status, "not-run");
+});
+
+test("delivery integrity reports when a referenced asset is absent from both Git and workspace", async (t) => {
+  const root = await makeRepo(t);
+  const sourceFile = "src/catalog/CatalogBanner.tsx";
+  await write(root, sourceFile, "export function CatalogBanner() { return <section>Catalog</section>; }\n");
+  commit(root, "chore: baseline");
+  branch(root, "feat/catalog-banner");
+  await write(
+    root,
+    sourceFile,
+    "export function CatalogBanner() { return <img src=\"/media/catalog-banner.png\" alt=\"Catalog\" />; }\n",
+  );
+  commit(root, "feat: show the catalog banner");
+
+  const analysis = await analyze(root, [sourceFile]);
+  const evidence = analysis.intents.flatMap((intent) => intent.evidence).find((item) =>
+    item.symbol === "delivery-integrity:missing-asset"
+  );
+  assert.ok(evidence);
+  assert.match(evidence.value, /absent from both the committed head and workspace at public\/media\/catalog-banner\.png/i);
+});
+
+test("delivery integrity accepts committed, remote, and declared generated assets", async (t) => {
+  const root = await makeRepo(t);
+  const sourceFile = "src/landing/LandingHero.tsx";
+  await write(root, "package.json", JSON.stringify({
+    scripts: {
+      "generate:assets": "node scripts/generate-assets.js --output public/generated",
+    },
+  }, null, 2) + "\n");
+  await write(root, ".gitignore", "public/generated/\n");
+  await write(root, sourceFile, "export function LandingHero() { return <main>Landing</main>; }\n");
+  commit(root, "chore: baseline");
+  branch(root, "feat/landing-assets");
+  await write(root, "src/landing/assets/hero.svg", "<svg></svg>\n");
+  await write(
+    root,
+    sourceFile,
+    [
+      "import hero from './assets/hero.svg';",
+      "export function LandingHero() {",
+      "  return <main><img src={hero} alt=\"Landing\" /><img src=\"https://cdn.example.test/remote.webp\" alt=\"Remote\" /><img src=\"/generated/card.png\" alt=\"Generated\" /></main>;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  commit(root, "feat: show landing assets");
+
+  const analysis = await analyze(root, [sourceFile]);
+  assert.equal(
+    analysis.intents.flatMap((intent) => intent.evidence).some((item) =>
+      item.symbol?.startsWith("delivery-integrity:")
+    ),
+    false,
+  );
+});
+
+test("delivery integrity traces history-rewriting validation commands to exact workflow lines", async (t) => {
+  const root = await makeRepo(t);
+  const workflowFile = ".github/workflows/validate.yml";
+  await write(root, workflowFile, [
+    "name: Validate",
+    "jobs:",
+    "  verify:",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - uses: actions/checkout@v4",
+    "      - run: npm test",
+    "",
+  ].join("\n"));
+  commit(root, "chore: baseline");
+  branch(root, "ci/rewrite-validation");
+  await write(root, workflowFile, [
+    "name: Validate",
+    "jobs:",
+    "  verify:",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - uses: actions/checkout@v4",
+    "      - run: |",
+    "          git reset --hard origin/main",
+    "          git commit --allow-empty -m 'validated'",
+    "          git push --force-with-lease origin HEAD:${GITHUB_REF_NAME}",
+    "",
+  ].join("\n"));
+  commit(root, "ci: rewrite validation branch");
+
+  const analysis = await analyze(root, [workflowFile]);
+  const integrityEvidence = analysis.intents.flatMap((intent) => intent.evidence).filter((item) =>
+    item.symbol === "delivery-integrity:history-rewrite"
+  );
+  assert.equal(integrityEvidence.length, 3);
+  assert.deepEqual(integrityEvidence.map((item) => item.startLine), [8, 9, 10]);
+  assert.ok(analysis.intents.flatMap((intent) => intent.scenarios).some((scenario) =>
+    scenario.title === "Committed artifacts and validation history remain intact"
+  ));
+
+  const qa = await generateQaDraft(root, { base: "main", head: "HEAD" });
+  assert.ok(qa.flows.some((flow) => flow.verificationMode === "delivery-integrity"));
+  assert.equal(qa.readiness.basis, "repository-validation");
+  assert.equal(qa.route.nextAction, "define-repository-command");
+  assert.equal(qa.execution.status, "not-run");
+});
+
+test("delivery integrity leaves read-only checkout and non-pushing commit workflows quiet", async (t) => {
+  const root = await makeRepo(t);
+  const workflowFile = ".github/workflows/validate.yml";
+  await write(root, workflowFile, "name: Validate\n");
+  commit(root, "chore: baseline");
+  branch(root, "ci/safe-validation");
+  await write(root, workflowFile, [
+    "name: Validate",
+    "jobs:",
+    "  verify:",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - uses: actions/checkout@v4",
+    "      - uses: actions/cache@v4",
+    "      - run: git diff --exit-code",
+    "      - run: git commit --allow-empty -m 'local artifact'",
+    "",
+  ].join("\n"));
+  commit(root, "ci: validate without rewriting the branch");
+
+  const analysis = await analyze(root, [workflowFile]);
+  assert.equal(
+    analysis.intents.flatMap((intent) => intent.evidence).some((item) =>
+      item.symbol === "delivery-integrity:history-rewrite"
+    ),
+    false,
+  );
+});
+
 async function analyze(root, files) {
   const addedDiffEvidence = await collectAddedDiffEvidence(root, { base: "main", head: "HEAD" });
   const addedDiffText = addedDiffTextFromEvidence(addedDiffEvidence);


### PR DESCRIPTION
## Summary

Surface delivery-integrity failures before optional E2E gaps when a change references an uncommitted asset or rewrites validation history.

## Behavioral Contract

QAMap must route commit-backed asset and destructive workflow risks to repository validation before proposing product automation. Remote assets, committed assets, declared generated assets, and read-only workflow commands remain quiet.

## Evidence

Closes #198.

Positive cases:
- A changed local asset reference is absent from the Git head.
- A workflow force-pushes rewritten validation history.

Negative controls:
- Committed, remote, and declared generated assets.
- Read-only checkout and non-pushing workflow commands.

## Checks

- [x] Focused regression test
- [x] `pnpm test`
- [x] `pnpm bench:ci` for inference, routing, trace, or output
- [ ] `pnpm bench:execution` for E2E compiler or execution fixtures
- [ ] `pnpm scan` for scanner, security, or repository policy
- [ ] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
- [ ] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

`pnpm bench:execution`, `pnpm scan`, plugin checks, and documentation checks are N/A because this change does not alter the compiler, scanner, plugin package, or public documentation. QAMap selected the focused analyzer test but did not include the changed benchmark contract; that action-selection gap is recorded privately for follow-up.
