### PR TITLE
Feat: trace runtime activation and deployment boundaries

### DIFF
--- a/bench.config.json
+++ b/bench.config.json
@@ -2,6 +2,29 @@
   "$comment": "Committed quality contract. Each fixture is materialized as a temporary Git repository with a main baseline and one PR change.",
   "targets": [
     {
+      "name": "service-runtime-activation-startup",
+      "fixture": "test/benchmarks/service-runtime-activation-startup",
+      "commitMessage": "feat: configure digest worker activation",
+      "expect": {
+        "readinessBasis": "repository-validation",
+        "automationApplicable": false,
+        "minFlows": 1,
+        "minChangeIntents": 1,
+        "minReasoningTraces": 1,
+        "maxUntraceableRequiredScenarios": 0,
+        "mustReachFiles": ["src/workers/digest-worker.ts"],
+        "mustNameFlows": ["runtime activation"],
+        "mustIncludeLifecycle": ["startup environment value", "guarded side effect"],
+        "mustIncludeQaScenarios": ["Startup configuration reaches the guarded side effect only after restart"],
+        "mustFindIntentEvidence": ["DIGEST_WORKER_ENABLED", "queue.enqueue"],
+        "mustTraceScenarioFiles": ["src/workers/digest-worker.ts"],
+        "mustRecommendCommands": ["validate:config"],
+        "maxBlankActions": 0,
+        "maxGenericTitles": 0,
+        "maxAgentBytes": 4096
+      }
+    },
+    {
       "name": "web-delivery-integrity-missing-asset",
       "fixture": "test/benchmarks/web-delivery-integrity-missing-asset",
       "commitMessage": "feat: show the updated workspace preview",

--- a/schema/qamap-agent.schema.json
+++ b/schema/qamap-agent.schema.json
@@ -629,7 +629,7 @@
           "draft": { "type": "string", "description": "Path of the fallback draft artifact for this flow. When verificationMode is present, run existing repository evidence first instead of generating it by default." },
           "verificationMode": {
             "type": "string",
-            "enum": ["command-contract", "analysis-rule", "schema-graph", "transformation-contract", "existing-test-evidence", "configuration", "documentation", "generated-artifact"],
+            "enum": ["command-contract", "analysis-rule", "delivery-integrity", "runtime-activation", "schema-graph", "transformation-contract", "existing-test-evidence", "configuration", "documentation", "generated-artifact"],
             "description": "Why this flow should validate existing evidence instead of generating a new product-journey E2E draft."
           },
           "runnable": {

--- a/src/change-intent.ts
+++ b/src/change-intent.ts
@@ -275,8 +275,15 @@ export async function analyzeChangeIntents(
     options,
     changedSourceRoles,
   );
+  const runtimeActivationEvidence = await collectRuntimeActivationEvidence(
+    root,
+    gitRoot,
+    options,
+    changedSourceRoles,
+  );
   const riskEvidence = uniqueEvidence([
     ...deliveryIntegrityEvidence,
+    ...runtimeActivationEvidence,
     ...collectDiffRiskEvidence(options.addedDiffEvidence ?? {}, changedSourceRoles),
     ...collectRemovalContractEvidence(
       options.changedFiles,
@@ -815,13 +822,17 @@ function buildDiffOnlyIntent(
     item.sourceRole === "analysis-rule" || item.sourceRole === "command"
   );
   const deliveryIntegrityEvidence = riskEvidence.filter(isDeliveryIntegrityEvidence);
+  const runtimeActivationEvidence = riskEvidence.filter(isRuntimeActivationEvidence);
   const lifecycle = limitLifecycleStages([
     ...lifecycleFromCodeSignals(codeSignals),
     ...lifecycleFromSourceRoles(roleEvidence),
     ...lifecycleFromDeliveryIntegrityEvidence(deliveryIntegrityEvidence),
+    ...lifecycleFromRuntimeActivationEvidence(runtimeActivationEvidence),
   ]);
   const stageKinds = new Set(lifecycle.map((stage) => stage.kind));
-  const hasRecognizedSourceRole = roleEvidence.length > 0 || deliveryIntegrityEvidence.length > 0;
+  const hasRecognizedSourceRole = roleEvidence.length > 0 ||
+    deliveryIntegrityEvidence.length > 0 ||
+    runtimeActivationEvidence.length > 0;
   const hasSymbolAnnotation = annotationEvidence.length > 0;
   if (
     (!hasRecognizedSourceRole && !hasSymbolAnnotation && (lifecycle.length < 3 || stageKinds.size < 3)) ||
@@ -833,10 +844,13 @@ function buildDiffOnlyIntent(
     ...codeSignals.map((signal) => signal.file),
     ...roleEvidence.map((item) => item.file ?? "").filter(Boolean),
     ...deliveryIntegrityEvidence.map((item) => item.file ?? "").filter(Boolean),
+    ...runtimeActivationEvidence.map((item) => item.file ?? "").filter(Boolean),
   ]).slice(0, maxIntentFiles);
   const annotatedFlow = firstQaAnnotationFlow(annotationEvidence);
   const titleSubject = deliveryIntegrityEvidence.length > 0
     ? "Delivery integrity"
+    : runtimeActivationEvidence.length > 0
+    ? "Runtime activation"
     : annotatedFlow
     ? humanizeIdentifier(annotatedFlow)
     : diffIntentSubject(files[0], roleEvidence[0]?.sourceRole, roleEvidence);
@@ -989,6 +1003,7 @@ function buildLifecycle(
   stages.push(...lifecycleFromDetectedRiskEvidence(roleEvidence));
   stages.push(...lifecycleFromSourceRoles(roleEvidence));
   stages.push(...lifecycleFromDeliveryIntegrityEvidence(roleEvidence.filter(isDeliveryIntegrityEvidence)));
+  stages.push(...lifecycleFromRuntimeActivationEvidence(roleEvidence.filter(isRuntimeActivationEvidence)));
 
   return limitLifecycleStages(removeRedundantOutcomeTimingTriggers(stages));
 }
@@ -1310,6 +1325,73 @@ function buildIntentQaScenarios(
     deliveryIntegrity.rationale =
       "The changed source or workflow can produce a branch that works locally but cannot be reproduced safely from the committed review evidence; resolve this delivery blocker before optional product automation.";
     scenarios.push(deliveryIntegrity);
+  }
+
+  const runtimeActivationEvidence = evidence.filter(isRuntimeActivationEvidence);
+  for (const mechanism of ["code-defined", "startup-environment", "runtime-fetched"] as const) {
+    const mechanismEvidence = runtimeActivationEvidence.filter((item) =>
+      item.symbol?.startsWith(`runtime-activation:${mechanism}:`)
+    );
+    if (mechanismEvidence.length === 0) continue;
+    const sourceEvidence = mechanismEvidence.filter((item) => item.symbol?.endsWith(":source"));
+    const guardEvidence = mechanismEvidence.filter((item) => item.symbol?.endsWith(":guard"));
+    const sideEffectEvidence = mechanismEvidence.filter((item) => item.symbol?.endsWith(":side-effect"));
+    const mechanismTitle = mechanism === "code-defined"
+      ? "Code-defined activation reaches the guarded side effect only after delivery"
+      : mechanism === "startup-environment"
+      ? "Startup configuration reaches the guarded side effect only after restart"
+      : "Runtime-fetched activation changes the guarded side effect without restart";
+    const activation = makeScenario(
+      intentId,
+      `runtime-activation:${mechanism}`,
+      "state-transition",
+      "critical",
+      mechanismTitle,
+      mechanism === "code-defined"
+        ? ["Prepare the previous and changed code-defined activation values in clean checkouts."]
+        : mechanism === "startup-environment"
+        ? ["Prepare disabled and enabled environment values before process startup."]
+        : ["Prepare runtime flag responses for disabled, enabled, unavailable, and stale states."],
+      mechanism === "code-defined"
+        ? [
+            "Run the guarded entry with the previous code-defined value and the changed value.",
+            "Use the repository's normal build or deployment validation to prove which revision can become active.",
+          ]
+        : mechanism === "startup-environment"
+        ? [
+            "Start the process with activation disabled and exercise the guarded entry.",
+            "Change the value, restart through the repository's normal runtime path, and exercise the same entry again.",
+          ]
+        : [
+            "Exercise the guarded entry while the runtime flag is disabled.",
+            "Change the fetched flag response without restarting and exercise the same entry again.",
+          ],
+      mechanism === "code-defined"
+        ? [
+            "Verify the disabled revision produces no guarded side effect.",
+            "Verify the changed revision produces the intended side effect exactly once after the normal delivery boundary.",
+          ]
+        : mechanism === "startup-environment"
+        ? [
+            "Verify the disabled startup state produces no guarded side effect.",
+            "Verify changing configuration without a restart does not misrepresent the already running process state.",
+            "Verify the restarted enabled state produces the intended side effect exactly once.",
+          ]
+        : [
+            "Verify the disabled response produces no guarded side effect.",
+            "Verify the enabled response produces the intended side effect exactly once without a restart.",
+            "Verify unavailable or stale flag responses follow the repository-defined fallback instead of being assumed enabled.",
+          ],
+      mechanism === "runtime-fetched"
+        ? ["Flag provider unavailable", "Stale runtime response", "Repeated enabled evaluation"]
+        : ["Activation still disabled", "Activation changed without required boundary", "Repeated guarded entry"],
+      uniqueEvidence([...sourceEvidence, ...guardEvidence, ...sideEffectEvidence]),
+    );
+    activation.rationale = mechanism === "runtime-fetched"
+      ? "Located source evidence connects a runtime-fetched activation value to a guard and side effect. The repository proves the lookup path, but not the external environment's current value."
+      : "Located source evidence connects the changed activation value to a guard and side effect, so QA must prove both disabled and enabled states at the repository-backed activation boundary.";
+    activation.reviewRequired = mechanism === "runtime-fetched";
+    scenarios.push(activation);
   }
 
   const retiredSurfaceEvidence = productEvidence.filter((item) =>
@@ -2741,6 +2823,233 @@ async function collectDeliveryIntegrityEvidence(
   return uniqueEvidence(evidence);
 }
 
+type RuntimeActivationMechanism = "code-defined" | "startup-environment" | "runtime-fetched";
+
+interface RuntimeActivationSource {
+  mechanism: RuntimeActivationMechanism;
+  variable: string;
+  key: string;
+}
+
+async function collectRuntimeActivationEvidence(
+  root: string,
+  gitRoot: string,
+  options: ChangeIntentAnalysisOptions,
+  changedSourceRoles: ReturnType<typeof classifyChangedSourceRoles>,
+): Promise<ChangeIntentEvidence[]> {
+  const relativeRoot = toPosixPath(path.relative(gitRoot, root)).replace(/^\.\/+|\/+$/g, "");
+  const evidence: ChangeIntentEvidence[] = [];
+
+  for (const [file, hunks] of Object.entries(options.addedDiffEvidence ?? {})) {
+    const sourceRole = changedSourceRoles[file]?.role ??
+      classifyChangeSourceRole(file, diffTextForRoleClassification(hunks)).role;
+    if (sourceRole !== "product" && sourceRole !== "configuration") {
+      continue;
+    }
+    const repositoryFile = relativeRoot ? `${relativeRoot}/${file}` : file;
+    const content = await readRuntimeActivationHeadText(root, gitRoot, file, repositoryFile, options);
+    if (!content) continue;
+    const sourceLines = content.split(/\r?\n/);
+
+    for (const hunk of hunks) {
+      for (const line of hunk.lines) {
+        const source = parseRuntimeActivationSource(line.text);
+        if (!source) continue;
+        const guard = findConnectedActivationGuard(sourceLines, source, line.line);
+        if (!guard) continue;
+        const sideEffect = findGuardedActivationSideEffect(sourceLines, guard.line);
+        if (!sideEffect) continue;
+        const prefix = `runtime-activation:${source.mechanism}`;
+        evidence.push(
+          diffRiskEvidence(
+            file,
+            hunk,
+            line.line,
+            `${prefix}:source`,
+            runtimeActivationSourceDescription(source),
+            "head",
+            sourceRole,
+          ),
+          runtimeActivationSourceEvidence(
+            file,
+            guard.line,
+            `${prefix}:guard`,
+            `Guard ${guard.expression} reads activation source ${source.variable || source.key}.`,
+            sourceRole,
+          ),
+          runtimeActivationSourceEvidence(
+            file,
+            sideEffect.line,
+            `${prefix}:side-effect`,
+            `Guarded path invokes side effect ${sideEffect.symbol}.`,
+            sourceRole,
+          ),
+        );
+      }
+    }
+  }
+
+  return uniqueEvidence(evidence);
+}
+
+async function readRuntimeActivationHeadText(
+  root: string,
+  gitRoot: string,
+  file: string,
+  repositoryFile: string,
+  options: ChangeIntentAnalysisOptions,
+): Promise<string | undefined> {
+  try {
+    if (options.includeWorkingTree) {
+      return await readFile(path.join(root, file), "utf8");
+    }
+    return (await execFileAsync(
+      "git",
+      ["show", `${options.head}:${repositoryFile}`],
+      { cwd: gitRoot, maxBuffer: 512 * 1024 },
+    )).stdout;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseRuntimeActivationSource(text: string): RuntimeActivationSource | undefined {
+  const withoutStrings = sourceOutsideStringLiterals(text);
+  if (/^(?:\s*(?:\/\/|#|\*)|.*\b(?:describe|it|test)\s*\()/.test(text)) {
+    return undefined;
+  }
+  const variable = text.match(/\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=/)?.[1] ?? "";
+  const runtimeFetch = text.match(
+    /\b(?:isEnabled|getFlag|getBoolean|variation|evaluate)\s*\(\s*["'`]([^"'`]+)["'`]/i,
+  ) ?? text.match(
+    /\b(?:remoteConfig|featureFlags?|flagClient|featureClient)\b[^\n]*\b(?:get|fetch|read)\s*\(\s*["'`]([^"'`]+)["'`]/i,
+  );
+  if (runtimeFetch && (/\bawait\b/.test(withoutStrings) || /\bremoteConfig|featureFlags?|flagClient|featureClient\b/i.test(withoutStrings))) {
+    return {
+      mechanism: "runtime-fetched",
+      variable: variable || runtimeFetch[1],
+      key: runtimeFetch[1],
+    };
+  }
+  const environment = text.match(/\bprocess\.env\.([A-Z][A-Z0-9_]*)\b/) ??
+    text.match(/\bprocess\.env\[\s*["'`]([A-Z][A-Z0-9_]*)["'`]\s*\]/) ??
+    text.match(/\bimport\.meta\.env\.([A-Z][A-Z0-9_]*)\b/) ??
+    text.match(/\bDeno\.env\.get\(\s*["'`]([A-Z][A-Z0-9_]*)["'`]\s*\)/) ??
+    text.match(/\bgetenv\(\s*["'`]([A-Z][A-Z0-9_]*)["'`]\s*\)/);
+  if (environment && variable) {
+    return {
+      mechanism: "startup-environment",
+      variable,
+      key: environment[1],
+    };
+  }
+  const literal = text.match(
+    /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*(?:enabled|active|flag|feature)[A-Za-z0-9_$]*|(?:ENABLE|FEATURE|ACTIVATE)_[A-Z0-9_]+)\s*=\s*(true|false)\b/i,
+  );
+  if (literal) {
+    return {
+      mechanism: "code-defined",
+      variable: literal[1],
+      key: literal[1],
+    };
+  }
+  return undefined;
+}
+
+function findConnectedActivationGuard(
+  lines: string[],
+  source: RuntimeActivationSource,
+  sourceLine: number,
+): { line: number; expression: string } | undefined {
+  const needles = uniqueStrings([source.variable, source.key]).filter(Boolean);
+  const start = Math.max(0, sourceLine - 1);
+  const end = Math.min(lines.length, start + 80);
+  const sourceDepth = braceDepthBeforeLine(lines, start);
+  for (let index = start; index < end; index += 1) {
+    if (index > start && sourceDepth > 0 && braceDepthBeforeLine(lines, index) < sourceDepth) {
+      break;
+    }
+    const line = lines[index];
+    if (!needles.some((needle) => line.includes(needle))) continue;
+    const guard = line.match(/\bif\s*\((.+)\)/) ??
+      line.match(/\b(?:return|const|let|var)\b[^\n]*(\b[A-Za-z_$][\w$]*\b)\s*(?:&&|\?)/);
+    if (guard) {
+      return { line: index + 1, expression: stripTerminalPunctuation(guard[1].trim()) };
+    }
+  }
+  return undefined;
+}
+
+function findGuardedActivationSideEffect(
+  lines: string[],
+  guardLine: number,
+): { line: number; symbol: string } | undefined {
+  const start = Math.max(0, guardLine - 1);
+  const end = Math.min(lines.length, start + 32);
+  const guardDepth = braceDepthBeforeLine(lines, start);
+  const guardText = sourceOutsideStringLiterals(lines[start]);
+  const guardedBlock = /\bif\s*\([^)]*\)\s*\{/.test(guardText);
+  for (let index = start; index < end; index += 1) {
+    const depthBefore = braceDepthBeforeLine(lines, index);
+    if (
+      index > start &&
+      ((guardedBlock && depthBefore <= guardDepth) || (!guardedBlock && guardDepth > 0 && depthBefore < guardDepth))
+    ) {
+      break;
+    }
+    const line = sourceOutsideStringLiterals(lines[index]);
+    const match = line.match(
+      /\b((?:[A-Za-z_$][\w$]*\.)*(?:enqueue|dispatch|publish|emit|send|schedule|register|spawn|createJob|createTask|createMessage|createNotification))\s*\(/i,
+    ) ?? line.match(
+      /\b([A-Za-z_$][\w$]*\.(?:add|enqueue|dispatch|publish|emit|send|schedule|register))\s*\(/i,
+    );
+    if (match) {
+      return { line: index + 1, symbol: match[1] };
+    }
+  }
+  return undefined;
+}
+
+function braceDepthBeforeLine(lines: string[], targetIndex: number): number {
+  let depth = 0;
+  for (let index = 0; index < targetIndex; index += 1) {
+    const line = sourceOutsideStringLiterals(lines[index]).replace(/\/\/.*$/, "");
+    depth += (line.match(/\{/g) ?? []).length;
+    depth -= (line.match(/\}/g) ?? []).length;
+  }
+  return Math.max(0, depth);
+}
+
+function runtimeActivationSourceDescription(source: RuntimeActivationSource): string {
+  if (source.mechanism === "code-defined") {
+    return `Changed code-defined activation value ${source.variable} guards a located side effect.`;
+  }
+  if (source.mechanism === "startup-environment") {
+    return `Changed startup environment value ${source.key} is captured by ${source.variable} before a guarded side effect.`;
+  }
+  return `Changed runtime-fetched activation key ${source.key} is captured by ${source.variable} before a guarded side effect.`;
+}
+
+function runtimeActivationSourceEvidence(
+  file: string,
+  line: number,
+  symbol: string,
+  value: string,
+  sourceRole: ChangeSourceRole,
+): ChangeIntentEvidence {
+  return {
+    kind: "source",
+    value,
+    sourceRole,
+    file,
+    symbol,
+    relation: "supporting",
+    side: "head",
+    startLine: line,
+    endLine: line,
+  };
+}
+
 function literalLocalAssetReferences(text: string): string[] {
   const trimmed = text.trim();
   if (/^(?:\/\/|#|\*|<!--)/.test(trimmed)) {
@@ -2911,6 +3220,69 @@ function lifecycleFromDeliveryIntegrityEvidence(
       "delivery-integrity:result",
     ),
   ];
+}
+
+function isRuntimeActivationEvidence(evidence: ChangeIntentEvidence): boolean {
+  return evidence.symbol?.startsWith("runtime-activation:") ?? false;
+}
+
+function lifecycleFromRuntimeActivationEvidence(
+  evidence: ChangeIntentEvidence[],
+): BehaviorLifecycleStage[] {
+  const stages: BehaviorLifecycleStage[] = [];
+  for (const mechanism of ["code-defined", "startup-environment", "runtime-fetched"] as const) {
+    const mechanismEvidence = evidence.filter((item) =>
+      item.symbol?.startsWith(`runtime-activation:${mechanism}:`)
+    );
+    if (mechanismEvidence.length === 0) continue;
+    const files = uniqueStrings(mechanismEvidence.map((item) => item.file ?? "").filter(Boolean));
+    const source = mechanismEvidence.filter((item) => item.symbol?.endsWith(":source"));
+    const guard = mechanismEvidence.filter((item) => item.symbol?.endsWith(":guard"));
+    const sideEffect = mechanismEvidence.filter((item) => item.symbol?.endsWith(":side-effect"));
+    stages.push(
+      createLifecycleStage(
+        "condition",
+        mechanism === "code-defined"
+          ? "A code-defined activation value controls the guarded path."
+          : mechanism === "startup-environment"
+          ? "A startup environment value controls the guarded path."
+          : "A runtime-fetched activation value controls the guarded path.",
+        "high",
+        source,
+        files,
+        `runtime-activation:${mechanism}:condition`,
+      ),
+      createLifecycleStage(
+        "action",
+        "Evaluate the connected activation guard.",
+        "high",
+        guard,
+        files,
+        `runtime-activation:${mechanism}:action`,
+      ),
+      createLifecycleStage(
+        "side-effect",
+        "Invoke the guarded side effect only while activation is enabled.",
+        "high",
+        sideEffect,
+        files,
+        `runtime-activation:${mechanism}:effect`,
+      ),
+      createLifecycleStage(
+        "observable-outcome",
+        mechanism === "code-defined"
+          ? "Observe the guarded effect only from the delivered enabled revision."
+          : mechanism === "startup-environment"
+          ? "Observe the guarded effect only after the enabled value is loaded by a restarted process."
+          : "Observe the guarded effect follow the latest fetched value without restarting.",
+        mechanism === "runtime-fetched" ? "medium" : "high",
+        mechanismEvidence,
+        files,
+        `runtime-activation:${mechanism}:result`,
+      ),
+    );
+  }
+  return stages;
 }
 
 async function filePathExists(file: string): Promise<boolean> {

--- a/src/qa.ts
+++ b/src/qa.ts
@@ -229,6 +229,7 @@ type QaVerificationMode =
   | "command-contract"
   | "analysis-rule"
   | "delivery-integrity"
+  | "runtime-activation"
   | "schema-graph"
   | "transformation-contract"
   | "existing-test-evidence"
@@ -385,10 +386,20 @@ export async function generateQaDraft(rootInput: string, options: QaDraftOptions
   const candidateCommandsWithoutInsufficientTests = candidateCommands.filter((command) =>
     ![...runtimeGapTestFiles].some((testFile) => focusedCommandTargetsFile(command, testFile))
   );
+  const runtimeActivationValidationCommands = flows.some((flow) =>
+    flow.verificationMode === "runtime-activation"
+  )
+    ? await discoverRuntimeActivationValidationCommands(root)
+    : [];
   const routedCandidateCommands = flows.some((flow) => flow.verificationMode === "schema-graph")
     ? candidateCommandsWithoutInsufficientTests.filter(isMigrationGraphValidationCommand)
     : flows.some((flow) => flow.verificationMode === "delivery-integrity")
       ? candidateCommandsWithoutInsufficientTests.filter(isDeliveryIntegrityValidationCommand)
+      : flows.some((flow) => flow.verificationMode === "runtime-activation")
+        ? uniqueStrings([
+            ...runtimeActivationValidationCommands,
+            ...candidateCommandsWithoutInsufficientTests.filter(isRuntimeActivationValidationCommand),
+          ])
       : candidateCommandsWithoutInsufficientTests;
   const suggestedCommands = await preferLocallyRunnableValidationCommands(root, routedCandidateCommands);
   const missingEvidence = uniqueMissingEvidence([
@@ -3643,6 +3654,8 @@ function qaFlowFromDraftFile(file: E2eDraftFile): QaDraftFlow {
   return {
     title: verificationMode === "delivery-integrity"
       ? "Delivery integrity verification"
+      : verificationMode === "runtime-activation"
+      ? "Runtime activation boundary verification"
       : file.flowTitle,
     source: formatDraftSource(file.source),
     draftPath: file.path,
@@ -3902,6 +3915,9 @@ function buildFlowReasons(file: E2eDraftFile): string[] {
   if (verificationMode === "delivery-integrity") {
     return ["The branch may not reproduce safely from committed evidence; resolve missing artifacts or history-rewriting validation before optional product automation."];
   }
+  if (verificationMode === "runtime-activation") {
+    return ["A located activation source controls a guarded side effect; verify disabled and enabled states at the repository-backed restart, delivery, or runtime-fetch boundary before optional product automation."];
+  }
   if (verificationMode === "schema-graph") {
     return ["The changed migration dependency diverges from the target branch graph; restore one leaf and validate the deployment order instead of inventing a product journey."];
   }
@@ -4112,6 +4128,11 @@ function verificationModeForDraftFile(file: E2eDraftFile): QaVerificationMode | 
   )) {
     return "delivery-integrity";
   }
+  if (file.qaScenarios?.some((scenario) =>
+    scenario.evidence.some((source) => source.symbol?.startsWith("runtime-activation:"))
+  )) {
+    return "runtime-activation";
+  }
   const scenarioSourceRoles = (file.qaScenarios ?? [])
     .flatMap((scenario) => scenario.evidence)
     .map((source) => source.sourceRole)
@@ -4141,6 +4162,9 @@ function formatVerificationMode(mode: QaVerificationMode): string {
   if (mode === "delivery-integrity") {
     return "clean-checkout artifact and workflow history verification";
   }
+  if (mode === "runtime-activation") {
+    return "runtime activation boundary verification";
+  }
   if (mode === "schema-graph") {
     return "migration graph and deployment-order verification";
   }
@@ -4161,6 +4185,59 @@ function formatVerificationMode(mode: QaVerificationMode): string {
 
 function isDeliveryIntegrityValidationCommand(command: string): boolean {
   return /\b(?:actionlint|archive|build|bundle|export|pack|package|workflow)\b/i.test(command);
+}
+
+function isRuntimeActivationValidationCommand(command: string): boolean {
+  return /\b(?:activation|config|configuration|deploy|environment|feature[-_:]?flags?|integration|job|runtime|scheduler|startup|worker)\b/i.test(
+    command,
+  );
+}
+
+async function discoverRuntimeActivationValidationCommands(root: string): Promise<string[]> {
+  try {
+    const parsed = JSON.parse(await readFile(path.join(root, "package.json"), "utf8")) as {
+      packageManager?: unknown;
+      scripts?: Record<string, unknown>;
+    };
+    const scripts = Object.entries(parsed.scripts ?? {})
+      .filter((entry): entry is [string, string] => typeof entry[1] === "string" && entry[1].trim().length > 0)
+      .filter(([name, command]) => isRuntimeActivationValidationScript(name, command))
+      .sort(([leftName], [rightName]) =>
+        runtimeActivationValidationScriptRank(leftName) - runtimeActivationValidationScriptRank(rightName) ||
+        leftName.localeCompare(rightName)
+      )
+      .slice(0, 3);
+    const packageManager = await runtimeActivationPackageManager(root, parsed.packageManager);
+    return scripts.map(([name]) =>
+      name === "test" ? `${packageManager} test` : `${packageManager} run ${name}`
+    );
+  } catch {
+    return [];
+  }
+}
+
+function isRuntimeActivationValidationScript(name: string, command: string): boolean {
+  const boundary = "(?:activation|config|configuration|deploy|environment|feature[-_:]?flags?|integration|job|runtime|scheduler|startup|worker)";
+  const validation = "(?:check|dry|lint|plan|smoke|test|validate|verify)";
+  return new RegExp(`(?:${boundary}.*${validation}|${validation}.*${boundary})`, "i").test(`${name} ${command}`) &&
+    !/^(?:deploy|release|publish|start)(?:$|:)/i.test(name);
+}
+
+function runtimeActivationValidationScriptRank(name: string): number {
+  if (/(?:^|:)(?:check|validate|verify|plan)(?:$|:)/i.test(name)) return 0;
+  if (/(?:^|:)(?:test|smoke|lint)(?:$|:)/i.test(name)) return 1;
+  return 2;
+}
+
+async function runtimeActivationPackageManager(root: string, declared: unknown): Promise<string> {
+  if (typeof declared === "string") {
+    const manager = declared.split("@")[0];
+    if (["npm", "pnpm", "yarn", "bun"].includes(manager)) return manager;
+  }
+  if (await pathExists(path.join(root, "pnpm-lock.yaml"))) return "pnpm";
+  if (await pathExists(path.join(root, "yarn.lock"))) return "yarn";
+  if (await pathExists(path.join(root, "bun.lock")) || await pathExists(path.join(root, "bun.lockb"))) return "bun";
+  return "npm";
 }
 
 function isMigrationGraphValidationCommand(command: string): boolean {

--- a/test/benchmarks/service-runtime-activation-startup/base/package.json
+++ b/test/benchmarks/service-runtime-activation-startup/base/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "runtime-activation-fixture",
+  "private": true,
+  "scripts": {
+    "validate:config": "node scripts/validate-config.js"
+  }
+}

--- a/test/benchmarks/service-runtime-activation-startup/base/scripts/validate-config.js
+++ b/test/benchmarks/service-runtime-activation-startup/base/scripts/validate-config.js
@@ -1,0 +1,1 @@
+process.exit(0);

--- a/test/benchmarks/service-runtime-activation-startup/base/src/workers/digest-worker.ts
+++ b/test/benchmarks/service-runtime-activation-startup/base/src/workers/digest-worker.ts
@@ -1,0 +1,6 @@
+const digestWorkerEnabled = false;
+
+export function createDigest(queue, accountId) {
+  if (!digestWorkerEnabled) return;
+  queue.enqueue("digest", { accountId });
+}

--- a/test/benchmarks/service-runtime-activation-startup/head/package.json
+++ b/test/benchmarks/service-runtime-activation-startup/head/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "runtime-activation-fixture",
+  "private": true,
+  "scripts": {
+    "validate:config": "node scripts/validate-config.js"
+  }
+}

--- a/test/benchmarks/service-runtime-activation-startup/head/scripts/validate-config.js
+++ b/test/benchmarks/service-runtime-activation-startup/head/scripts/validate-config.js
@@ -1,0 +1,1 @@
+process.exit(0);

--- a/test/benchmarks/service-runtime-activation-startup/head/src/workers/digest-worker.ts
+++ b/test/benchmarks/service-runtime-activation-startup/head/src/workers/digest-worker.ts
@@ -1,0 +1,6 @@
+const digestWorkerEnabled = process.env.DIGEST_WORKER_ENABLED === "1";
+
+export function createDigest(queue, accountId) {
+  if (!digestWorkerEnabled) return;
+  queue.enqueue("digest", { accountId });
+}

--- a/test/change-intent.test.mjs
+++ b/test/change-intent.test.mjs
@@ -5272,6 +5272,177 @@ test("delivery integrity leaves read-only checkout and non-pushing commit workfl
   );
 });
 
+test("runtime activation routes a code-defined guard through delivery validation", async (t) => {
+  const root = await makeRepo(t);
+  const sourceFile = "src/workers/preview-worker.ts";
+  await write(root, "package.json", JSON.stringify({
+    scripts: {
+      "validate:config": "node scripts/validate-config.js",
+    },
+  }, null, 2) + "\n");
+  await write(root, "scripts/validate-config.js", "process.exit(0);\n");
+  await write(root, sourceFile, [
+    "const previewJobsEnabled = false;",
+    "export function createPreviewJob(queue, payload) {",
+    "  if (!previewJobsEnabled) return;",
+    "  queue.enqueue('preview', payload);",
+    "}",
+    "",
+  ].join("\n"));
+  commit(root, "chore: baseline");
+  branch(root, "feat/preview-job-activation");
+  await write(root, sourceFile, [
+    "const previewJobsEnabled = true;",
+    "export function createPreviewJob(queue, payload) {",
+    "  if (!previewJobsEnabled) return;",
+    "  queue.enqueue('preview', payload);",
+    "}",
+    "",
+  ].join("\n"));
+  commit(root, "feat: enable preview job creation");
+
+  const analysis = await analyze(root, [sourceFile]);
+  const activationEvidence = analysis.intents.flatMap((intent) => intent.evidence).filter((item) =>
+    item.symbol?.startsWith("runtime-activation:code-defined:")
+  );
+  assert.deepEqual(activationEvidence.map((item) => item.startLine), [1, 3, 4]);
+  assert.ok(analysis.intents.flatMap((intent) => intent.scenarios).some((scenario) =>
+    /code-defined activation.*after delivery/i.test(scenario.title) &&
+    scenario.priority === "critical"
+  ));
+
+  const qa = await generateQaDraft(root, { base: "main", head: "HEAD" });
+  assert.ok(qa.flows.some((flow) => flow.verificationMode === "runtime-activation"));
+  assert.equal(qa.readiness.basis, "repository-validation");
+  assert.equal(qa.readiness.automationApplicable, false);
+  assert.match(qa.route.command ?? "", /validate:config/);
+  assert.equal(qa.execution.status, "not-run");
+});
+
+test("runtime activation distinguishes startup environment state from live configuration", async (t) => {
+  const root = await makeRepo(t);
+  const sourceFile = "src/workers/digest-worker.ts";
+  await write(root, sourceFile, [
+    "const digestWorkerEnabled = false;",
+    "export function createDigest(queue, accountId) {",
+    "  if (!digestWorkerEnabled) return;",
+    "  queue.enqueue('digest', { accountId });",
+    "}",
+    "",
+  ].join("\n"));
+  commit(root, "chore: baseline");
+  branch(root, "feat/digest-worker-config");
+  await write(root, sourceFile, [
+    "const digestWorkerEnabled = process.env.DIGEST_WORKER_ENABLED === '1';",
+    "export function createDigest(queue, accountId) {",
+    "  if (!digestWorkerEnabled) return;",
+    "  queue.enqueue('digest', { accountId });",
+    "}",
+    "",
+  ].join("\n"));
+  commit(root, "feat: configure digest worker activation");
+
+  const analysis = await analyze(root, [sourceFile]);
+  const scenario = analysis.intents.flatMap((intent) => intent.scenarios).find((candidate) =>
+    /only after restart/i.test(candidate.title)
+  );
+  assert.ok(scenario);
+  assert.ok(scenario.assertions.some((assertion) => /without a restart/i.test(assertion)));
+  assert.ok(scenario.evidence.some((item) =>
+    item.symbol === "runtime-activation:startup-environment:source" &&
+    item.startLine === 1
+  ));
+});
+
+test("runtime activation keeps live flag state external and does not require restart", async (t) => {
+  const root = await makeRepo(t);
+  const sourceFile = "src/indexing/document-indexer.ts";
+  await write(root, sourceFile, [
+    "export async function indexDocument(featureFlags, jobs, documentId) {",
+    "  const indexingEnabled = false;",
+    "  if (!indexingEnabled) return;",
+    "  jobs.enqueue('index-document', { documentId });",
+    "}",
+    "",
+  ].join("\n"));
+  commit(root, "chore: baseline");
+  branch(root, "feat/runtime-indexing-flag");
+  await write(root, sourceFile, [
+    "export async function indexDocument(featureFlags, jobs, documentId) {",
+    "  const indexingEnabled = await featureFlags.isEnabled('document-indexing');",
+    "  if (!indexingEnabled) return;",
+    "  jobs.enqueue('index-document', { documentId });",
+    "}",
+    "",
+  ].join("\n"));
+  commit(root, "feat: evaluate document indexing at runtime");
+
+  const analysis = await analyze(root, [sourceFile]);
+  const scenario = analysis.intents.flatMap((intent) => intent.scenarios).find((candidate) =>
+    /without restart/i.test(candidate.title)
+  );
+  assert.ok(scenario);
+  assert.equal(scenario.reviewRequired, true);
+  assert.match(scenario.rationale, /not the external environment's current value/i);
+  assert.ok(scenario.assertions.some((assertion) => /unavailable or stale flag responses/i.test(assertion)));
+  assert.ok(scenario.evidence.some((item) =>
+    item.symbol === "runtime-activation:runtime-fetched:side-effect" &&
+    item.startLine === 4
+  ));
+});
+
+test("runtime activation ignores enablement vocabulary in documentation", async (t) => {
+  const root = await makeRepo(t);
+  const file = "docs/worker-rollout.md";
+  await write(root, file, "# Worker rollout\n");
+  commit(root, "chore: baseline");
+  branch(root, "docs/worker-rollout");
+  await write(root, file, [
+    "# Worker rollout",
+    "const workerEnabled = true;",
+    "if (workerEnabled) queue.enqueue('worker');",
+    "Restart or redeploy after enabling the feature flag.",
+    "",
+  ].join("\n"));
+  commit(root, "docs: explain worker rollout");
+
+  const analysis = await analyze(root, [file]);
+  assert.equal(
+    analysis.intents.flatMap((intent) => intent.evidence).some((item) =>
+      item.symbol?.startsWith("runtime-activation:")
+    ),
+    false,
+  );
+});
+
+test("runtime activation does not connect a guard to a side effect in another scope", async (t) => {
+  const root = await makeRepo(t);
+  const file = "src/workers/archive-worker.ts";
+  await write(root, file, "export const archiveWorkerEnabled = false;\n");
+  commit(root, "chore: baseline");
+  branch(root, "feat/archive-worker-setting");
+  await write(root, file, [
+    "const archiveWorkerEnabled = true;",
+    "export function canArchive() {",
+    "  if (!archiveWorkerEnabled) return false;",
+    "  return true;",
+    "}",
+    "export function unrelatedDispatch(queue, payload) {",
+    "  queue.enqueue('archive', payload);",
+    "}",
+    "",
+  ].join("\n"));
+  commit(root, "feat: expose archive worker availability");
+
+  const analysis = await analyze(root, [file]);
+  assert.equal(
+    analysis.intents.flatMap((intent) => intent.evidence).some((item) =>
+      item.symbol?.startsWith("runtime-activation:")
+    ),
+    false,
+  );
+});
+
 async function analyze(root, files) {
   const addedDiffEvidence = await collectAddedDiffEvidence(root, { base: "main", head: "HEAD" });
   const addedDiffText = addedDiffTextFromEvidence(addedDiffEvidence);

--- a/test/schema-graph.test.mjs
+++ b/test/schema-graph.test.mjs
@@ -188,6 +188,8 @@ test("agent schema lists every repository verification mode emitted by QAMap", a
   const schema = JSON.parse(await readFile(new URL("../schema/qamap-agent.schema.json", import.meta.url), "utf8"));
   const modes = schema.properties.flows.items.properties.verificationMode.enum;
 
+  assert.ok(modes.includes("delivery-integrity"));
+  assert.ok(modes.includes("runtime-activation"));
   assert.ok(modes.includes("schema-graph"));
   assert.ok(modes.includes("transformation-contract"));
 });


### PR DESCRIPTION
## Summary

Trace activation sources to their connected guard and side effect, then distinguish code delivery, process restart, and runtime-fetched flag boundaries.

## Behavioral Contract

QAMap should produce activation QA only when a changed code-defined value, startup environment value, or runtime-fetched flag is connected to a guard and a located side effect. It should prove disabled and enabled behavior without claiming that an external environment was changed, restarted, or deployed.

## Evidence

Closes #199.

Positive cases:
- A code-defined flag guards background work.
- An environment value is captured at process startup.
- A runtime-fetched flag changes without restart.

Negative controls:
- Enablement vocabulary in documentation.
- A guard and side effect in unrelated lexical scopes.

## Checks

- [x] Focused regression test
- [x] `pnpm test`
- [x] `pnpm bench:ci` for inference, routing, trace, or output
- [ ] `pnpm bench:execution` for E2E compiler or execution fixtures
- [ ] `pnpm scan` for scanner, security, or repository policy
- [ ] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
- [ ] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

The runtime-fetched path remains review-required because repository evidence cannot prove an external provider's current value. QAMap selects only safe repository validation scripts whose names express checking, validation, planning, smoke, or test intent. Execution benchmarks, scanner checks, plugin checks, and documentation checks are N/A for this change.
