### PR TITLE
Chore: prepare 0.4.14 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qamap",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "Turn PR changes into traceable local QA decisions and optional automation handoffs without an LLM call.",
   "author": {
     "name": "IvoryCanvas",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qamap",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "Turn PR changes into traceable local QA decisions and optional automation handoffs without an LLM call.",
   "author": {
     "name": "IvoryCanvas",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,25 @@
 # Changelog
 
-## Unreleased
+## 0.4.14 - 2026-08-20
+
+### Added
+
+- Added delivery-integrity evidence for local-only or missing referenced assets and history-rewriting validation commands. These risks now route through repository validation before optional E2E work.
+- Added runtime-activation evidence that joins supported guards, configuration sources, runtime side effects, and startup, reload, restart, and deployment boundaries.
+- Added a versioned `qamap.context` contract that separates stable repository QA facts from the current pull request delta, with deterministic block identities and a recoverable full report.
+- Added a provider-neutral context reuse benchmark for identical reruns, related pull requests, reviewed manifest corrections, validation changes, behavior changes, volatile run metadata, and unrelated repositories.
 
 ### Fixed
 
 - Long pull requests now keep independent behavior-bearing commit groups separate when they share only broad package vocabulary. Exact changed files or an explicit issue reference can still connect commits into one lifecycle, and human output discloses intent counts when a report is shortened.
+- Removed UI is now treated as an absence contract instead of an executable entry point, while formatting-only UI hunks stay contextual and real React or Vue state transitions remain eligible for QA.
 
 ### Changed
 
 - Documented the shared Node.js 20+ runtime contract, the actively supported LTS recommendation, and verified npm, pnpm, Yarn, and Bun installation and repeat-use commands in both READMEs.
 - Linked the English and Korean plugin guidance directly to OpenAI's official installation steps instead of the general Plugins overview.
 - Reorganized both READMEs so the local CLI and package installation form the primary setup path, while the ChatGPT and Codex plugin has a separate, explicit installation entry point.
+- Added the context reuse benchmark to CI and the release gate while keeping context reuse separate from QA correctness, provider token accounting, or fixed cost-reduction claims.
 
 ## 0.4.13 - 2026-08-11
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -21,6 +21,10 @@ QAMap은 현재 브랜치의 커밋과 코드 변경, 저장소 구조, 기존 �
 분석 과정에서 소스 코드를 외부로 보내거나 별도의 LLM을 호출하지 않습니다.
 처음 사용할 때 설정 파일이나 테스트 실행 환경이 없어도 됩니다.
 
+에이전트가 사용할 때는 여러 PR에서 반복되는 저장소 QA 정보와 이번 PR의
+변경 내용을 따로 전달합니다. 같은 정보가 유지되는지는 식별자로 확인할 수
+있지만, QAMap을 호출한 에이전트의 모델 사용량까지 0이 되는 것은 아닙니다.
+
 ## 설치하고 실행하기
 
 터미널에서 직접 사용하려면 로컬 CLI를 실행하세요. ChatGPT나 Codex에서
@@ -59,7 +63,7 @@ npx --yes @ivorycanvas/qamap@latest qa
 짧은 스크립트와 다른 실행 방법은
 [반복해서 CLI 사용하기](#반복해서-cli-사용하기)에서 확인할 수 있습니다.
 
-### ChatGPT·Codex 플러그인
+### ChatGPT와 Codex 플러그인
 
 에이전트가 PR 검토나 테스트 계획 중에 QAMap을 호출하도록 하려면
 플러그인을 설치하세요.
@@ -67,7 +71,7 @@ npx --yes @ivorycanvas/qamap@latest qa
 [![OpenAI 플러그인 디렉터리에서 QAMap 설치](docs/assets/openai-plugin-directory-badge.svg)](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629)
 
 [QAMap 플러그인 페이지](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629)
-· [OpenAI 공식 설치 안내](https://learn.chatgpt.com/docs/plugins#install-and-use-a-plugin)
+| [OpenAI 공식 설치 안내](https://learn.chatgpt.com/docs/plugins#install-and-use-a-plugin)
 
 1. QAMap 플러그인 페이지를 엽니다.
 2. **+**를 눌러 설치합니다.
@@ -83,7 +87,7 @@ npx --yes @ivorycanvas/qamap@latest qa
 | 출력 영역 | 확인할 내용 |
 | --- | --- |
 | **Change** | 이번 변경에서 달라졌을 가능성이 높은 동작 |
-| **Verify before merge** | 병합 전에 확인할 정상·실패·경계값·상태 변화 |
+| **Verify before merge** | 병합 전에 확인할 정상, 실패, 경계값, 상태 변화 |
 | **Evidence** | 판단에 사용한 커밋, 파일, 코드 위치 |
 | **Next** | 지금 실행할 검증 또는 검토할 자동화 초안 |
 
@@ -95,6 +99,11 @@ npx --yes @ivorycanvas/qamap@latest qa
 지원하는 저장소 구조에서는 변경된 화면이나 진입점부터 실제로 필요한
 모듈과 실행 조건까지 따라갑니다. 테스트가 그 조건을 모의 처리로
 우회했다면 완전한 검증 근거로 보지 않습니다.
+
+변경 파일이 없는 이미지를 참조하거나 검증 작업이 공유 이력을 바꿀 수
+있다면 E2E보다 먼저 배포 무결성 문제로 알려줍니다. 지원하는 활성화 설정은
+조건문과 설정 출처, 실제 실행 동작, 재시작 또는 새로고침 필요 여부를 함께
+근거로 남깁니다.
 
 ## 실제 실행 예시
 
@@ -186,7 +195,7 @@ Corepack으로 관리되는 패키지 매니저는 저장소의 `packageManager`
 | 26 | 통과 | 검증 당시 Current 버전이며 운영 환경은 LTS 권장 |
 
 정확한 버전과 패키지 매니저 범위는
-[릴리스 검증 기록](docs/release-validation.md#unreleased---2026-08-11)에서
+[패키지 매니저 호환성 기록](docs/release-validation.md#package-manager-compatibility---2026-08-11)에서
 확인할 수 있습니다.
 
 ### 자주 쓰는 CLI 옵션
@@ -273,7 +282,7 @@ QAMap은 아직 `1.0` 이전입니다. 정적 분석만으로 제품의 모든 �
 없으므로 제안된 QA 항목은 사람이 검토해야 합니다. 저장소의 검증 명령
 하나가 통과해도 제품 전체 QA가 통과했다는 뜻은 아닙니다.
 
-릴리스 전 공개 벤치마크에서는 여러 웹·모바일 프레임워크, API·CLI,
+릴리스 전 공개 벤치마크에서는 여러 웹 및 모바일 프레임워크와 API, CLI,
 모노레포, 테스트가 없는 저장소와 오탐 대조 사례를 함께 확인합니다.
 자세한 범위와 결과는 영문 [벤치마크 문서](docs/benchmarking.md)에서 볼 수
 있습니다.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ existing tests, and diff evidence to answer:
 QAMap itself makes no cloud analysis, source upload, or additional LLM call. A
 manifest and test runner are optional.
 
+For agent integrations, QAMap keeps reusable repository QA facts separate from
+the current pull request delta. Stable identifiers make repeated context visible
+without claiming that the calling agent uses no model tokens.
+
 ## Install And Run
 
 Choose the local CLI for any repository, or
@@ -68,7 +72,7 @@ test planning.
 </a>
 
 [Install the QAMap plugin](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629)
-· [OpenAI's official plugin installation steps](https://learn.chatgpt.com/docs/plugins#install-and-use-a-plugin)
+| [OpenAI's official plugin installation steps](https://learn.chatgpt.com/docs/plugins#install-and-use-a-plugin)
 
 1. Open the QAMap listing.
 2. Select **+**.
@@ -93,6 +97,11 @@ draft is never reported as a passing test.
 For supported runtime contracts, QAMap can trace a changed entry point through
 local imports to a required provider. A test that mocks away that prerequisite
 is disclosed as incomplete evidence instead of being promoted as proof.
+
+Delivery checks run before optional E2E work when the diff references a missing
+asset or a validation workflow can rewrite shared history. Supported activation
+changes also retain the guard, configuration source, runtime side effect, and
+restart or reload boundary that must be verified.
 
 Cleanup-only commits remain visible as provenance but do not become standalone
 QA requirements. Unrelated issue tags and lifecycle stages stay separate. When
@@ -198,7 +207,7 @@ lines on 2026-08-11. The install command is the same for every line.
 | 24 | Passed | Supported LTS at the time of validation |
 | 26 | Passed | Current release at the time of validation; prefer LTS for production |
 
-See the [release validation receipt](docs/release-validation.md#unreleased---2026-08-11)
+See the [package-manager compatibility receipt](docs/release-validation.md#package-manager-compatibility---2026-08-11)
 for exact versions and package-manager coverage.
 
 </details>

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -4,7 +4,7 @@
 > public release. Older released sections are preserved as historical receipts
 > and are not required reading for contributors or users.
 
-## Unreleased - 2026-08-11
+## Package Manager Compatibility - 2026-08-11
 
 The public `@ivorycanvas/qamap@0.4.13` package was installed and exercised in
 isolated temporary projects before expanding the README installation guidance.
@@ -25,6 +25,44 @@ These results establish package installation and CLI smoke compatibility, not
 a new runtime guarantee beyond the declared Node.js `>=20` engine contract.
 Node.js 20 is upstream EOL, so the README recommends an actively supported LTS
 release even though the compatibility smoke still passes.
+
+## 0.4.14 - 2026-08-20
+
+QAMap 0.4.14 strengthens the path from a pull request diff to the evidence a
+reviewer or coding agent should trust before optional E2E work. Independent
+behavior-bearing commits remain separate, retired UI becomes an absence
+contract, and formatting-only UI changes stay contextual instead of creating a
+product risk.
+
+The release also adds two pre-automation boundaries. Delivery-integrity checks
+surface local-only or missing assets and validation commands that can rewrite
+shared history. Runtime-activation checks join supported guards, configuration
+sources, side effects, and startup, reload, restart, or deployment requirements.
+Both routes retain exact source evidence and keep product execution `not-run`.
+
+Agent handoffs now separate stable repository QA facts from the current pull
+request delta through the versioned `qamap.context` contract. A deterministic,
+provider-neutral benchmark records UTF-8 bytes, block reuse, invalidation
+reasons, and compact payload size. It does not equate context reuse with QA
+correctness, model-token usage, or a fixed cost reduction.
+
+| Gate | Candidate result |
+| --- | --- |
+| `pnpm release:check` | Passed end to end |
+| `pnpm test` | 382/382 passing |
+| `pnpm scan` | 0 findings |
+| `pnpm bench:ci` | 33/33 committed static recommendation contracts passing |
+| `pnpm bench:context` | 10/10 context identity and reuse checks passing |
+| `pnpm bench:execution` | 3/3 execution contracts passing; all three seeded regressions caught |
+| Coverage | Lines 90.30%, branches 87.06%, functions 95.80% |
+| Plugin package smoke | Packed 195 files, installed the current 0.4.14 artifact in isolation, and produced one intent with one exact evidence trace |
+| Package preview | `pnpm pack --dry-run` passes for `@ivorycanvas/qamap@0.4.14`; 195 files packed |
+
+The release gate proves deterministic selection, packaging, and known seeded
+regressions in public fixtures. It does not prove the correctness of an
+arbitrary user repository, and it does not turn a generated scenario or draft
+into executed QA. npm publication, the Git tag, the GitHub Release, and any new
+OpenAI directory version remain separate post-merge actions.
 
 ## 0.4.13 - 2026-08-11
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,48 +36,42 @@ Before treating the next public release as ready, the golden demo must satisfy t
 
 There is no fixed end date or patch count for `0.4.x`. QAMap will remain on compatible patch releases while real repositories still expose material gaps in change intent, affected-flow selection, scenario evidence, or automation-draft quality. `0.5.x` is not the next scheduled milestone; it is a release bar that must be earned by a stable, explicitly approved execution contract and evidence from repeated use outside the maintainer's repositories.
 
-### Current Focus After 0.4.13
+### Current Focus After 0.4.14
 
-The OpenAI Plugin Directory is now a real first-run surface, so the next patches
-prioritize recommendation quality over adding another distribution channel or
-runner name. The current generalized work queue is:
+The OpenAI Plugin Directory is a real first-run surface, so the next patches
+continue to prioritize recommendation quality over another distribution channel
+or runner name. The current generalized work queue is:
 
-1. Keep long-lived and recently synchronized branches inside the real PR
-   evidence boundary. The first merge-aware implementation now selects the
-   branch's latest first-parent non-merge work commit instead of target-only
-   hunks imported by a baseline sync; broader multi-remote histories remain a
-   continuing regression surface.
-2. Trace runtime prerequisites across reused code. The first adapter now joins
-   a changed React or Next.js entry point, a bounded local import chain, an
-   explicit fail-fast context hook, and a provider-bypass wrapper branch. It
-   rejects component-mocked tests as sufficient proof. Broader dependency
-   injection, initialization, router, and non-React wrapper contracts remain
-   future adapters rather than inferred claims.
-3. Treat changed repository tests as behavior contracts. Preserve explicit
-   normalization boundaries, negative assertions, state transitions, retry
-   prohibitions, and cross-file value continuity instead of reducing them to a
-   generic request to run the suite.
-4. Extract framework-neutral presentation contracts from changed UI code. An
-   overlay becoming inline content, scroll-lock removal, responsive overflow,
-   replaced-element sizing, and inherited icon color should produce concrete
-   interaction or visual checks only when the diff carries the required
-   evidence.
-5. Keep repository workflow metadata in its own behavior class. Documentation,
-   issue forms, pull-request templates, and their contract tests must route to
-   link, schema, field, label, and template validation rather than fabricated
-   endpoint or application-launch scenarios.
-6. Prefer repository-owned validation commands from package scripts, CI
-   workflows, and adjacent test harnesses over blocked optional automation.
-   Vocabulary in a property or filename must not create a domain risk without
-   matching behavior evidence.
+1. Select every repository-owned validation contract changed by a pull request.
+   Analyzer benchmarks, public schemas and their consumers, package metadata,
+   and Changesets must not be reduced to one convenient focused test or an
+   unrelated language suite.
+2. Treat changed repository tests as behavior contracts. Preserve explicit
+   positive, negative, boundary, state-transition, retry, and invariance
+   assertions instead of reducing them to a generic request to run the suite.
+3. Trace shared semantic producers to every affected consumer. A change to a
+   mapper, copy builder, aggregate, or service rule should retain the screens,
+   history views, notifications, and exports that reuse its result when import
+   and data-flow evidence connect them.
+4. Expand runtime lifecycle modeling beyond one guard and one process. Changes
+   that control workers, webhooks, deploy reconciliation, drains, or restarts
+   should expose each execution plane and the fail-closed transition between
+   disabled and enabled states.
+5. Extract framework-neutral presentation contracts from changed UI code only
+   when the diff carries observable interaction or visual evidence. Formatting
+   and resource vocabulary must remain contextual.
+6. Keep repository workflow metadata in its own behavior class. Documentation,
+   issue forms, pull-request templates, package releases, and deployment
+   transports should route to their exact repository contract instead of a
+   fabricated product journey.
 7. Turn each real miss into a domain-neutral public fixture with a positive
-   contract and an unrelated negative control. A new shared heuristic is not
-   complete until both sides pass the static benchmark and the existing
-   execution contract remains honest.
+   contract and an unrelated negative control. A shared heuristic is incomplete
+   until both sides pass the static benchmark and existing execution contracts
+   remain honest.
 8. Re-run the published skill against unrelated repositories and compare its
-   deterministic result with independent human or agent review. Preserve
-   `not-run`, `passed`, `failed`, and `blocked` exactly; plugin availability is
-   not evidence that product QA ran.
+   deterministic result with independent review. Preserve `not-run`, `passed`,
+   `failed`, and `blocked` exactly; plugin availability is not evidence that
+   product QA ran.
 
 - Stabilize commit-range Change Intent analysis: related behavior commits, diff symbols, confidence, review requirements, lifecycle stages, and runner-independent QA scenarios.
 - Preserve a conservative diff-only intent when commit messages are not descriptive, while keeping low-confidence scenarios recommended and review-required until stronger evidence exists.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "Local zero-LLM PR QA designer that maps commit intent and diffs to traceable behavior lifecycles, QA scenarios, and optional automation drafts.",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugin/submission.json
+++ b/plugin/submission.json
@@ -73,5 +73,5 @@
       "reason": "The plugin must preserve the host's approval policy and QAMap's explicit action boundary."
     }
   ],
-  "releaseNotes": "QAMap 0.4.13 improves evidence-to-validation routing, keeps target-branch merge history out of feature intent, detects migration graph conflicts, and traces supported runtime prerequisites without treating mocked consumers as sufficient proof."
+  "releaseNotes": "QAMap 0.4.14 separates stable repository QA context from each pull request delta, traces delivery and runtime activation risks, preserves independent intents, and adds a deterministic context reuse benchmark."
 }

--- a/skills/qamap-pr-qa/SKILL.md
+++ b/skills/qamap-pr-qa/SKILL.md
@@ -21,7 +21,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
    If QAMap is not installed, disclose that the next command downloads the pinned package from the npm registry and follow the host's network approval policy before running it:
 
    ```sh
-   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.13 -- qamap qa . --base <base> --head HEAD --format agent
+   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.14 -- qamap qa . --base <base> --head HEAD --format agent
    ```
 
    This one-off form runs outside the target repository's package-manager contract, so it does not invoke Corepack or add a `packageManager` field. QAMap's analysis does not upload source code or make another LLM call. The calling agent still uses its own model tokens to invoke the skill and interpret the compact result.
@@ -37,7 +37,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
    - Use an explicit scoped pass only when a human wants to override that decision:
 
    ```sh
-   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.13 -- qamap qa <package-path> --workspace-root . --base <base> --head HEAD
+   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.14 -- qamap qa <package-path> --workspace-root . --base <base> --head HEAD
    ```
 
 4. Read and verify intent before generating code. In agent format:
@@ -60,7 +60,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
    - `run-repository-command` — when policy permits repository code execution, prefer QAMap's bounded executor so analysis and execution share one receipt:
 
      ```sh
-     npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.13 -- qamap qa run . --base <base> --head HEAD --format agent
+     npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.14 -- qamap qa run . --base <base> --head HEAD --format agent
      ```
 
      It re-analyzes the change and runs only the exact selected existing repository command. Do not substitute another command or run it again when `execution.performed` is true.
@@ -70,7 +70,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
 6. Only after a human or team accepts the scenario and automation adapter, create or preview executable coverage:
 
    ```sh
-   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.13 -- qamap e2e draft . --base <base> --head HEAD --dry-run
+   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.14 -- qamap e2e draft . --base <base> --head HEAD --dry-run
    ```
 
    If the selected adapter is absent, inspect and explicitly accept the `automation.setupCommand` proposal. Never install a runner merely because QAMap detected a web or mobile surface.
@@ -106,7 +106,7 @@ When the recommendation is wrong or too broad, do not repeatedly re-prompt for t
 If the team accepts QAMap for ongoing use, suggest this follow-up:
 
 ```sh
-npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.13 -- qamap manifest init .
+npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.14 -- qamap manifest init .
 ```
 
 Then humans should review `.qamap/manifest.yaml` and keep only durable team QA language.

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const TOOL_NAME = "QAMap";
-export const VERSION = "0.4.13";
+export const VERSION = "0.4.14";

--- a/test/contributor-workflow.test.mjs
+++ b/test/contributor-workflow.test.mjs
@@ -174,7 +174,7 @@ test("public READMEs present local setup before the optional plugin path", async
       install: "## 설치하고 실행하기",
       local: "### 로컬 CLI (권장)",
       package: "#### 반복 사용을 위해 프로젝트에 설치",
-      plugin: "### ChatGPT·Codex 플러그인",
+      plugin: "### ChatGPT와 Codex 플러그인",
       result: "## 결과 읽는 방법",
       demo: "## 실제 실행 예시",
       daily: "## 반복해서 CLI 사용하기",


### PR DESCRIPTION
## Summary

Prepare QAMap 0.4.14 by synchronizing package and plugin versions, documenting the merged QA improvements, recording the completed release gates, and updating the post-release roadmap.

## Behavioral Contract

No new analyzer behavior is introduced by this release-preparation PR. The 0.4.14 package exposes the already merged delivery-integrity, runtime-activation, intent-isolation, removed-UI, and stable agent-context behavior under one synchronized version.

The release documentation keeps static QA recommendations and generated drafts separate from executed product QA. npm publication, Git tagging, the GitHub Release, and any OpenAI directory replacement remain post-merge actions.

## Evidence

Closes #208.

Release evidence:
- 382/382 unit and integration tests passed
- 33/33 static recommendation contracts passed
- 10/10 context identity and reuse checks passed
- 3/3 execution contracts passed and caught all three seeded regressions
- coverage reached 90.30% lines, 87.06% branches, and 95.80% functions
- plugin metadata validation and isolated package smoke passed
- the 0.4.14 package preview contains 195 files

## Checks

- [x] Focused regression test
- [x] `pnpm test`
- [x] `pnpm bench:ci` for inference, routing, trace, or output
- [x] `pnpm bench:execution` for E2E compiler or execution fixtures
- [x] `pnpm scan` for scanner, security, or repository policy
- [x] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
- [x] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

The full `pnpm release:check` gate passed end to end. The focused contributor-documentation regression passed 7/7 after the final copy update, plugin submission metadata still reports version 0.4.14, and a final package dry run passed.

QAMap's static self-analysis remained `not-run` and selected only the general repository test command for this release diff. The stronger release verdict therefore comes from the repository-owned release gate above.
