### PR TITLE
Feat: detect account-scoped storage written without an owner discriminator

### DIFF
--- a/bench.config.json
+++ b/bench.config.json
@@ -534,6 +534,29 @@
       }
     },
     {
+      "name": "web-account-scoped-storage",
+      "fixture": "test/benchmarks/web-account-scoped-storage",
+      "commitMessage": "feat: persist terms acceptance after accept",
+      "expect": {
+        "runner": "playwright",
+        "minFlows": 1,
+        "minChangeIntents": 1,
+        "minDiffAnchoredFlows": 1,
+        "mustReachFiles": [
+          "src/pages/terms.tsx"
+        ],
+        "mustNameIntents": [
+          "persist terms acceptance"
+        ],
+        "mustIncludeQaScenarios": [
+          "Account switch inherits storage without an owner discriminator"
+        ],
+        "maxBlankActions": 0,
+        "maxGenericTitles": 0,
+        "maxAgentBytes": 8192
+      }
+    },
+    {
       "name": "web-validation-recovery",
       "fixture": "test/benchmarks/web-validation-recovery",
       "commitMessage": "fix: defer feedback email validation until first field exit and clear stale errors",

--- a/src/change-intent.ts
+++ b/src/change-intent.ts
@@ -281,9 +281,16 @@ export async function analyzeChangeIntents(
     options,
     changedSourceRoles,
   );
+  const unscopedAccountStorageEvidence = await collectUnscopedAccountStorageEvidence(
+    root,
+    gitRoot,
+    options,
+    changedSourceRoles,
+  );
   const riskEvidence = uniqueEvidence([
     ...deliveryIntegrityEvidence,
     ...runtimeActivationEvidence,
+    ...unscopedAccountStorageEvidence,
     ...collectDiffRiskEvidence(options.addedDiffEvidence ?? {}, changedSourceRoles),
     ...collectRemovalContractEvidence(
       options.changedFiles,
@@ -1929,6 +1936,25 @@ function buildIntentQaScenarios(
     ], ["Mismatched identity", "Malformed storage", "Repeated completion", "Second tab or re-entry"], scopedStorageEvidence));
   }
 
+  const unscopedStorageEvidence = evidence.filter((item) =>
+    item.kind === "diff" &&
+    item.side === "head" &&
+    item.relation === "direct" &&
+    (item.sourceRole === undefined || item.sourceRole === "product") &&
+    /without an owner discriminator/i.test(item.value)
+  );
+  if (unscopedStorageEvidence.length > 0) {
+    scenarios.push(makeScenario(intentId, "unscoped-account-storage", "state-transition", "recommended", "Account switch inherits storage without an owner discriminator", [
+      "Prepare two accounts on one browser profile with the changed flow reachable for both.",
+    ], [
+      "Complete the changed flow as the first account so the storage write lands.",
+      "Sign out, sign in as the second account, and enter the same flow.",
+    ], [
+      "Verify the second account does not inherit the first account's stored state.",
+      "Verify logout or session expiry leaves no prior-account data readable in the flow.",
+    ], ["Account switch on one device", "Session expiry then re-login", "Same account in a second tab"], unscopedStorageEvidence));
+  }
+
   const stateReentryEvidence = scenarioEvidenceFor(
     productLifecycle,
     productEvidence,
@@ -2764,6 +2790,102 @@ function collectDiffRiskEvidence(
     }
   }
   return uniqueEvidence(evidence);
+}
+
+/** 계정 스코프를 시사하는 모듈 신호 — 세션 훅, 사용자 식별자, 인증 토큰 (issue: 계정 전환 누수) */
+const accountContextPattern =
+  /\b(?:useSession|useAuth|useUser|useAccount|currentUser|session\.user|userId|user_id|accountId|account_id|ownerId|owner_id|memberId|member_id|authToken|auth_token|accessToken|access_token|isAuthenticated|isLoggedIn)\b/;
+
+/** 키 표현식·주변 문장에 실린 소유자 구분자 — 있으면 계정별로 격리된 쓰기다 */
+const ownerDiscriminatorPattern =
+  /\b(?:ownerId|owner_id|userId|user_id|accountId|account_id|memberId|member_id|profileId|profile_id|uid)\b|\$\{[^}]*(?:user|owner|account|member|profile|uid)[^}]*\}/i;
+
+/** 계정 의미가 없는 기기 단위 값 — 소유자 없이 저장해도 안전한 키 이름 */
+const deviceScopedKeyPattern =
+  /\b(?:theme|locale|language|lang|dark|light|contrast|zoom|banner|dismissed?|tooltip|coachmark|onboarding|tour|ab[-_]?test|experiment|debug)\b/i;
+
+/** 웹 스토리지 쓰기 — 값 표현식은 제한하지 않는다 (JSON.stringify(...) 인자도 잡는다) */
+const clientStorageWritePattern =
+  /\b(?:(?:window|globalThis)\s*\.\s*)?(localStorage|sessionStorage)\s*\.\s*setItem\s*\(\s*([^,]+),/;
+
+/**
+ * 계정 스코프 데이터를 소유자 구분자 없이 웹 스토리지에 쓰는 변경 — 한 브라우저에서
+ * 계정을 바꾸면 다음 계정이 이전 계정의 초안·동의 플래그·권한 캐시를 물려받는다.
+ * 단일 계정 QA 는 통과하고 계정 전환에서만 터지는 부류라, diff 가 이런 쓰기를 더할 때
+ * 위험 증거로 승격해 계정 전환 시나리오를 계획에 올린다.
+ *
+ * 판정은 세 겹이다: (1) 추가 라인이 스토리지 쓰기다, (2) 모듈 전문이 인증 사용자를
+ * 참조한다(계정 스코프 정황), (3) 키 표현식과 쓰기 문장 어디에도 소유자 구분자가 없다.
+ * 기기 단위 값(테마·언어·배너 닫힘)은 계정 의미가 없어 키 이름으로 면제한다.
+ */
+async function collectUnscopedAccountStorageEvidence(
+  root: string,
+  gitRoot: string,
+  options: ChangeIntentAnalysisOptions,
+  changedSourceRoles: ReturnType<typeof classifyChangedSourceRoles>,
+): Promise<ChangeIntentEvidence[]> {
+  const relativeRoot = toPosixPath(path.relative(gitRoot, root)).replace(/^\.\/+|\/+$/g, "");
+  const evidence: ChangeIntentEvidence[] = [];
+
+  for (const [file, hunks] of Object.entries(options.addedDiffEvidence ?? {})) {
+    const sourceRole = changedSourceRoles[file]?.role ??
+      classifyChangeSourceRole(file, diffTextForRoleClassification(hunks)).role;
+    if (sourceRole !== "product") {
+      continue;
+    }
+    const hasWrite = hunks.some((hunk) => hunk.lines.some((line) => clientStorageWritePattern.test(line.text)));
+    if (!hasWrite) continue;
+
+    const repositoryFile = relativeRoot ? `${relativeRoot}/${file}` : file;
+    const content = await readRuntimeActivationHeadText(root, gitRoot, file, repositoryFile, options);
+    if (!content || !accountContextPattern.test(content)) continue;
+    const sourceLines = content.split(/\r?\n/);
+
+    for (const hunk of hunks) {
+      for (const line of hunk.lines) {
+        if (/^(?:\s*(?:\/\/|#|\*)|.*\b(?:describe|it|test)\s*\()/.test(line.text)) continue;
+        const write = line.text.match(clientStorageWritePattern);
+        if (!write) continue;
+        const keyExpression = write[2].trim();
+        const keyText = resolveStorageKeyText(keyExpression, content);
+        if (deviceScopedKeyPattern.test(keyText) || deviceScopedKeyPattern.test(keyExpression)) continue;
+        // 쓰기 문장 주변까지 본다 — 페이로드의 ownerId 가 다음 줄에 걸치는 경우
+        const statement = sourceLines.slice(Math.max(0, line.line - 1), line.line + 3).join("\n");
+        if (
+          ownerDiscriminatorPattern.test(keyExpression) ||
+          ownerDiscriminatorPattern.test(keyText) ||
+          ownerDiscriminatorPattern.test(statement)
+        ) {
+          continue;
+        }
+        evidence.push(diffRiskEvidence(
+          file,
+          hunk,
+          line.line,
+          `account-scoped-storage:${write[1]}`,
+          `Changed line writes account-scoped data to ${write[1]} without an owner discriminator for key ${keyText}.`,
+          "head",
+          sourceRole,
+        ));
+      }
+    }
+  }
+
+  return uniqueEvidence(evidence);
+}
+
+/** setItem 첫 인자를 사람이 읽을 키로 — 리터럴은 내용물, 식별자는 모듈 내 선언을 따라간다 */
+function resolveStorageKeyText(keyExpression: string, content: string): string {
+  const literal = keyExpression.match(/^["'`]([^"'`]*)["'`]$/);
+  if (literal) return literal[1];
+  const identifier = keyExpression.match(/^[A-Za-z_$][\w$]*$/);
+  if (identifier) {
+    const declaration = content.match(
+      new RegExp(`\\b${identifier[0]}\\s*=\\s*(["'\`])([^"'\`]*)\\1`),
+    );
+    if (declaration) return declaration[2];
+  }
+  return keyExpression;
 }
 
 async function collectDeliveryIntegrityEvidence(

--- a/test/benchmarks/web-account-scoped-storage/base/index.html
+++ b/test/benchmarks/web-account-scoped-storage/base/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/test/benchmarks/web-account-scoped-storage/base/package.json
+++ b/test/benchmarks/web-account-scoped-storage/base/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "benchmark-web-account-scoped-storage",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "test:e2e": "playwright test --reporter=dot"
+  },
+  "dependencies": {
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.61.1",
+    "vite": "7.0.0"
+  }
+}

--- a/test/benchmarks/web-account-scoped-storage/base/playwright.config.ts
+++ b/test/benchmarks/web-account-scoped-storage/base/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  use: {
+    baseURL: "http://127.0.0.1:4175",
+  },
+  webServer: {
+    command: "npm run dev -- --host 127.0.0.1 --port 4175",
+    url: "http://127.0.0.1:4175/terms",
+    reuseExistingServer: false,
+  },
+});

--- a/test/benchmarks/web-account-scoped-storage/base/src/auth/session.ts
+++ b/test/benchmarks/web-account-scoped-storage/base/src/auth/session.ts
@@ -1,0 +1,8 @@
+export interface Session {
+  userId: number;
+  displayName: string;
+}
+
+export function useSession(): Session {
+  return { userId: 1, displayName: "member" };
+}

--- a/test/benchmarks/web-account-scoped-storage/base/src/main.tsx
+++ b/test/benchmarks/web-account-scoped-storage/base/src/main.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { TermsPage } from "./pages/terms";
+
+createRoot(document.getElementById("root")!).render(<TermsPage />);

--- a/test/benchmarks/web-account-scoped-storage/base/src/pages/terms.tsx
+++ b/test/benchmarks/web-account-scoped-storage/base/src/pages/terms.tsx
@@ -1,0 +1,17 @@
+import React, { useState } from "react";
+import { useSession } from "../auth/session";
+
+export function TermsPage() {
+  const session = useSession();
+  const [accepted, setAccepted] = useState(false);
+
+  return (
+    <main>
+      <h1>Terms for {session.displayName}</h1>
+      <button data-testid="terms-accept" onClick={() => setAccepted(true)} type="button">
+        Accept terms
+      </button>
+      {accepted ? <p>Terms accepted</p> : null}
+    </main>
+  );
+}

--- a/test/benchmarks/web-account-scoped-storage/head/src/pages/terms.tsx
+++ b/test/benchmarks/web-account-scoped-storage/head/src/pages/terms.tsx
@@ -1,0 +1,26 @@
+import React, { useState } from "react";
+import { useSession } from "../auth/session";
+
+const ACCEPTED_KEY = "terms:accepted-at:v1";
+
+export function TermsPage() {
+  const session = useSession();
+  const [accepted, setAccepted] = useState(
+    () => window.localStorage.getItem(ACCEPTED_KEY) !== null,
+  );
+
+  function acceptTerms() {
+    window.localStorage.setItem(ACCEPTED_KEY, new Date().toISOString());
+    setAccepted(true);
+  }
+
+  return (
+    <main>
+      <h1>Terms for {session.displayName}</h1>
+      <button data-testid="terms-accept" onClick={acceptTerms} type="button">
+        Accept terms
+      </button>
+      {accepted ? <p>Terms accepted</p> : null}
+    </main>
+  );
+}

--- a/test/change-intent.test.mjs
+++ b/test/change-intent.test.mjs
@@ -5300,6 +5300,129 @@ test("delivery integrity leaves read-only checkout and non-pushing commit workfl
   );
 });
 
+test("account-scoped storage write without an owner discriminator is flagged", async (t) => {
+  const root = await makeRepo(t);
+  const sourceFile = "src/features/terms/acceptance.ts";
+  await write(root, sourceFile, [
+    "import { useSession } from '../auth/session';",
+    "const ACCEPTED_KEY = 'terms:accepted-at:v1';",
+    "export function readAcceptance() {",
+    "  return localStorage.getItem(ACCEPTED_KEY);",
+    "}",
+    "",
+  ].join("\n"));
+  commit(root, "chore: baseline");
+  branch(root, "feat/persist-terms-acceptance");
+  await write(root, sourceFile, [
+    "import { useSession } from '../auth/session';",
+    "const ACCEPTED_KEY = 'terms:accepted-at:v1';",
+    "export function saveAcceptance() {",
+    "  localStorage.setItem(ACCEPTED_KEY, new Date().toISOString());",
+    "}",
+    "export function readAcceptance() {",
+    "  return localStorage.getItem(ACCEPTED_KEY);",
+    "}",
+    "",
+  ].join("\n"));
+  commit(root, "feat: persist terms acceptance");
+
+  const analysis = await analyze(root, [sourceFile]);
+  const storageEvidence = analysis.intents.flatMap((intent) => intent.evidence).filter((item) =>
+    item.symbol?.startsWith("account-scoped-storage:")
+  );
+  assert.deepEqual(storageEvidence.map((item) => item.startLine), [4]);
+  assert.match(storageEvidence[0].value, /without an owner discriminator for key terms:accepted-at:v1/);
+  assert.ok(analysis.intents.flatMap((intent) => intent.scenarios).some((scenario) =>
+    /account switch inherits storage/i.test(scenario.title)
+  ));
+});
+
+test("account-scoped sessionStorage draft in a second surface is flagged", async (t) => {
+  const root = await makeRepo(t);
+  const sourceFile = "src/pages/checkout/draft.tsx";
+  await write(root, sourceFile, [
+    "import { useUser } from '../../hooks/useUser';",
+    "export function CheckoutDraft() {",
+    "  const user = useUser();",
+    "  return null;",
+    "}",
+    "",
+  ].join("\n"));
+  commit(root, "chore: baseline");
+  branch(root, "feat/persist-checkout-draft");
+  await write(root, sourceFile, [
+    "import { useUser } from '../../hooks/useUser';",
+    "export function CheckoutDraft() {",
+    "  const user = useUser();",
+    "  const persist = (draft) => {",
+    "    sessionStorage.setItem('checkout:draft', JSON.stringify(draft));",
+    "  };",
+    "  return null;",
+    "}",
+    "",
+  ].join("\n"));
+  commit(root, "feat: persist checkout draft");
+
+  const analysis = await analyze(root, [sourceFile]);
+  const storageEvidence = analysis.intents.flatMap((intent) => intent.evidence).filter((item) =>
+    item.symbol?.startsWith("account-scoped-storage:")
+  );
+  assert.equal(storageEvidence.length, 1);
+  assert.match(storageEvidence[0].value, /sessionStorage without an owner discriminator for key checkout:draft/);
+});
+
+test("owner-scoped and device-scoped storage writes are not flagged", async (t) => {
+  const root = await makeRepo(t);
+  const scopedFile = "src/features/terms/acceptance.ts";
+  const themeFile = "src/features/settings/theme.ts";
+  const anonymousFile = "src/features/visit/counter.ts";
+  await write(root, scopedFile, [
+    "import { useSession } from '../auth/session';",
+    "const ACCEPTED_KEY = 'terms:accepted-at:v1';",
+    "export {};",
+    "",
+  ].join("\n"));
+  await write(root, themeFile, [
+    "import { useSession } from '../auth/session';",
+    "export {};",
+    "",
+  ].join("\n"));
+  await write(root, anonymousFile, "export {};\n");
+  commit(root, "chore: baseline");
+  branch(root, "feat/storage-negative-controls");
+  await write(root, scopedFile, [
+    "import { useSession } from '../auth/session';",
+    "const ACCEPTED_KEY = 'terms:accepted-at:v1';",
+    "export function saveAcceptance(userId) {",
+    "  localStorage.setItem(ACCEPTED_KEY, JSON.stringify({ ownerId: userId, at: Date.now() }));",
+    "}",
+    "",
+  ].join("\n"));
+  await write(root, themeFile, [
+    "import { useSession } from '../auth/session';",
+    "export function saveTheme(theme) {",
+    "  localStorage.setItem('app:theme', theme);",
+    "}",
+    "",
+  ].join("\n"));
+  await write(root, anonymousFile, [
+    "export function saveVisitCount(count) {",
+    "  localStorage.setItem('visit:count', String(count));",
+    "}",
+    "",
+  ].join("\n"));
+  commit(root, "feat: owner-scoped acceptance, theme, and visit counter");
+
+  const analysis = await analyze(root, [scopedFile, themeFile, anonymousFile]);
+  const storageEvidence = analysis.intents.flatMap((intent) => intent.evidence).filter((item) =>
+    item.symbol?.startsWith("account-scoped-storage:")
+  );
+  assert.deepEqual(storageEvidence, []);
+  assert.ok(!analysis.intents.flatMap((intent) => intent.scenarios).some((scenario) =>
+    /account switch inherits storage/i.test(scenario.title)
+  ));
+});
+
 test("runtime activation routes a code-defined guard through delivery validation", async (t) => {
   const root = await makeRepo(t);
   const sourceFile = "src/workers/preview-worker.ts";


### PR DESCRIPTION
## Summary

Client-side persistence written for account-scoped data without an owner discriminator survives account switches: the second account inherits the first account's drafts, acceptance flags, or cached entitlements. This class of defect passes single-account QA and only surfaces on account switch or session expiry, so per-file review rarely catches it. QAMap now promotes such writes to risk evidence and plans the account-switch scenario.

## Behavioral Contract

When a diff adds a `localStorage`/`sessionStorage` write in a product module whose full text references an authenticated user (session hook, user id, auth token), and neither the key expression, the resolved key literal, nor the surrounding write statement carries an owner discriminator, QAMap emits diff risk evidence (`account-scoped-storage:<storage>`) anchored to the write line and adds the QA scenario "Account switch inherits storage without an owner discriminator" (account switch, session expiry then re-login, second tab).

Writes stay unflagged when the key or nearby payload carries an owner discriminator (`ownerId`, `userId`, template interpolation over user/account identifiers), when the key names a device-scoped value (theme, locale, dismissed banner), or when the module has no authenticated-user reference. Detection reads the changed file's head text through the same path as runtime-activation tracing; unified-0 diffs alone cannot see the surrounding auth context.

## Evidence

Closes #212.

- Minimized fixture: `test/benchmarks/web-account-scoped-storage` — a terms page using a session hook gains `localStorage.setItem("terms:accepted-at:v1", ...)` with no owner scope; contract pins the intent, reached file, and the new scenario title.
- Focused regression: flagged write resolves the key through a module constant and anchors `startLine` to the added write.
- Second unrelated positive: a checkout draft page persisting `sessionStorage` under a `useUser` hook (relaxed value expression — `JSON.stringify(...)` payloads match).
- Negative controls: owner-scoped payload (`{ ownerId: userId, ... }`), device-scoped `app:theme` key inside an authenticated module, and an anonymous visit counter with no auth reference — none flagged, scenario absent.

## Checks

- [x] Focused regression test
- [x] `pnpm test`
- [x] `pnpm bench:ci` for inference, routing, trace, or output
- [ ] `pnpm bench:execution` for E2E compiler or execution fixtures
- [ ] `pnpm scan` for scanner, security, or repository policy
- [ ] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
- [ ] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

`pnpm scan` (0 findings), `pnpm bench:context` (10/10), `pnpm plugin:check`, and `pnpm plugin:smoke` also pass locally; they are marked N/A above because this change touches none of those surfaces. The detector is intentionally conservative: string-literal and single-identifier keys only (identifier keys resolve through a same-module literal assignment), module-level auth signals limited to explicit hooks/identifiers/tokens, and the existing generic "Scoped persisted context isolation and cleanup" scenario still fires alongside the new one — the two answer different questions (cleanup semantics vs cross-account inheritance). Dynamic keys built outside the module and auth context imported behind aliases remain review work.