### PR TITLE
Feat: flag divergent user-facing copy for the same data across surfaces

### DIFF
--- a/bench.config.json
+++ b/bench.config.json
@@ -557,6 +557,29 @@
       }
     },
     {
+      "name": "web-divergent-surface-copy",
+      "fixture": "test/benchmarks/web-divergent-surface-copy",
+      "commitMessage": "feat: show shipping status on order confirmation",
+      "expect": {
+        "runner": "playwright",
+        "minFlows": 1,
+        "minChangeIntents": 1,
+        "minDiffAnchoredFlows": 1,
+        "mustReachFiles": [
+          "src/pages/confirmation.tsx"
+        ],
+        "mustNameIntents": [
+          "show shipping status"
+        ],
+        "mustIncludeQaScenarios": [
+          "Divergent copy for the same data across surfaces"
+        ],
+        "maxBlankActions": 0,
+        "maxGenericTitles": 0,
+        "maxAgentBytes": 8192
+      }
+    },
+    {
       "name": "web-validation-recovery",
       "fixture": "test/benchmarks/web-validation-recovery",
       "commitMessage": "fix: defer feedback email validation until first field exit and clear stale errors",

--- a/src/change-intent.ts
+++ b/src/change-intent.ts
@@ -287,10 +287,17 @@ export async function analyzeChangeIntents(
     options,
     changedSourceRoles,
   );
+  const divergentSurfaceCopyEvidence = await collectDivergentSurfaceCopyEvidence(
+    root,
+    gitRoot,
+    options,
+    changedSourceRoles,
+  );
   const riskEvidence = uniqueEvidence([
     ...deliveryIntegrityEvidence,
     ...runtimeActivationEvidence,
     ...unscopedAccountStorageEvidence,
+    ...divergentSurfaceCopyEvidence,
     ...collectDiffRiskEvidence(options.addedDiffEvidence ?? {}, changedSourceRoles),
     ...collectRemovalContractEvidence(
       options.changedFiles,
@@ -1955,6 +1962,25 @@ function buildIntentQaScenarios(
     ], ["Account switch on one device", "Session expiry then re-login", "Same account in a second tab"], unscopedStorageEvidence));
   }
 
+  const divergentCopyEvidence = evidence.filter((item) =>
+    item.kind === "diff" &&
+    item.side === "head" &&
+    item.relation === "direct" &&
+    (item.sourceRole === undefined || item.sourceRole === "product") &&
+    /nearly duplicates/i.test(item.value)
+  );
+  if (divergentCopyEvidence.length > 0) {
+    scenarios.push(makeScenario(intentId, "divergent-surface-copy", "primary", "recommended", "Divergent copy for the same data across surfaces", [
+      "Prepare one record whose state renders on both surfaces named in the evidence.",
+    ], [
+      "Open the changed surface and the existing surface side by side for the same record.",
+      "Read the paired labels together as a user would when moving between the two screens.",
+    ], [
+      "Verify both surfaces describe the same data or policy with the same wording, or that the difference is an intentional state distinction.",
+      "Verify a shared constant or source of truth backs the label when the surfaces are meant to agree.",
+    ], ["Same record in two states", "Copy edited on only one surface later", "Localized variants"], divergentCopyEvidence));
+  }
+
   const stateReentryEvidence = scenarioEvidenceFor(
     productLifecycle,
     productEvidence,
@@ -2886,6 +2912,172 @@ function resolveStorageKeyText(keyExpression: string, content: string): string {
     if (declaration) return declaration[2];
   }
   return keyExpression;
+}
+
+/** 짧은 상태·행동 라벨을 그리는 컴포넌트 — 같은 데이터를 화면마다 다르게 부르는 사고가 나는 자리 */
+const labelLikeCopyPattern =
+  /<((?:[A-Za-z][\w.]*?)?(?:Badge|Tag|Chip|Pill|Label|Status|Caption|Hint|Tooltip|Toast|Button|Cta|Banner|Notice|Alert|Callout))\b[^>]*>\s*(?:\{\s*(["'`])([^"'`{}]+)\2\s*\}|([^<{}][^<{}]*?))\s*<\/\1\s*>/g;
+
+/** 사용자에게 그대로 읽히는 속성 — 속성 이름이 곧 표면 종류다 */
+const labelPropCopyPattern =
+  /\b(label|title|placeholder|aria-label|alt)=(?:"([^"{}]{2,})"|'([^'{}]{2,})'|\{\s*["'`]([^"'`{}]{2,})["'`]\s*\})/g;
+
+const userFacingFilePattern = /\.(?:tsx|jsx|vue|svelte)$/i;
+const nonProductCopyPathPattern =
+  /(?:^|\/)(?:node_modules|dist|build|coverage|__tests__|__mocks__|fixtures?|stories|storybook|e2e)\/|\.(?:test|spec|stories|story)\.[jt]sx?$/i;
+const MAX_COPY_CORPUS_FILES = 400;
+const MAX_COPY_CORPUS_BYTES = 200 * 1024;
+const MAX_COPY_FINDINGS_PER_FILE = 5;
+
+interface SurfaceCopy {
+  component: string;
+  text: string;
+  tokens: string[];
+  normalized: string;
+  file: string;
+  line: number;
+}
+
+/**
+ * 같은 데이터나 정책을 화면마다 다른 문구로 그리는 변경 — 한 화면은 "결제 확인 후 발송",
+ * 다른 화면은 "주문 완료 시 발송". 문자열 하나하나는 멀쩡해 파일 단위 리뷰가 놓치고,
+ * 사용자는 정책이 서로 모순된다고 읽는다. diff 가 라벨성 문구를 더하거나 고칠 때 프로젝트의
+ * 기존 문구와 근사 중복이면 두 위치를 함께 지목해 공유 상수 추출이나 의도 확인을 권한다.
+ *
+ * 보수적으로 잡는다: 한 줄 JSX 안의 라벨성 컴포넌트(배지·칩·버튼 등)와 사용자 노출 속성만,
+ * 같은 컴포넌트 종류끼리, 다른 파일에 있는 것만, 그리고 첫 단어가 같거나 토큰 겹침이 높을
+ * 때만. 말뭉치는 라벨성 문구가 실제로 더해진 diff 에서만 읽어 비용을 묶는다.
+ */
+async function collectDivergentSurfaceCopyEvidence(
+  root: string,
+  gitRoot: string,
+  options: ChangeIntentAnalysisOptions,
+  changedSourceRoles: ReturnType<typeof classifyChangedSourceRoles>,
+): Promise<ChangeIntentEvidence[]> {
+  const candidates: Array<{ copy: SurfaceCopy; hunk: AddedDiffHunk; sourceRole: ChangeSourceRole }> = [];
+
+  for (const [file, hunks] of Object.entries(options.addedDiffEvidence ?? {})) {
+    if (!userFacingFilePattern.test(file) || nonProductCopyPathPattern.test(file)) continue;
+    const sourceRole = changedSourceRoles[file]?.role ??
+      classifyChangeSourceRole(file, diffTextForRoleClassification(hunks)).role;
+    if (sourceRole !== "product") continue;
+    for (const hunk of hunks) {
+      for (const line of hunk.lines) {
+        for (const copy of extractSurfaceCopy(line.text, file, line.line)) {
+          candidates.push({ copy, hunk, sourceRole });
+        }
+      }
+    }
+  }
+  if (candidates.length === 0) return [];
+
+  const changedFiles = new Set(Object.keys(options.addedDiffEvidence ?? {}));
+  const corpus = await readSurfaceCopyCorpus(root, gitRoot, options);
+  const evidence: ChangeIntentEvidence[] = [];
+  const perFile = new Map<string, number>();
+
+  for (const { copy, hunk, sourceRole } of candidates) {
+    const count = perFile.get(copy.file) ?? 0;
+    if (count >= MAX_COPY_FINDINGS_PER_FILE) continue;
+    let best: { other: SurfaceCopy; score: number } | undefined;
+    for (const other of corpus) {
+      if (other.file === copy.file || other.component !== copy.component) continue;
+      // 변경된 다른 파일의 옛 본문은 말뭉치에 남아 있을 수 있다 — diff 가 함께 고친 곳은 제외
+      if (changedFiles.has(other.file)) continue;
+      const score = surfaceCopyDivergence(copy, other);
+      if (score === undefined) continue;
+      if (!best || score > best.score) best = { other, score };
+    }
+    if (!best) continue;
+    perFile.set(copy.file, count + 1);
+    evidence.push(diffRiskEvidence(
+      copy.file,
+      hunk,
+      copy.line,
+      `divergent-copy:${copy.component}`,
+      `Changed line renders ${copy.component} copy "${copy.text}" that nearly duplicates "${best.other.text}" in ${best.other.file}:${best.other.line}; confirm the divergence is intentional or extract a shared constant.`,
+      "head",
+      sourceRole,
+    ));
+  }
+
+  return uniqueEvidence(evidence);
+}
+
+/** 한 줄에서 사용자 노출 문구를 뽑는다 — 컴포넌트 이름(또는 속성 이름)이 표면 종류다 */
+function extractSurfaceCopy(text: string, file: string, line: number): SurfaceCopy[] {
+  if (/^(?:\s*(?:\/\/|#|\*)|.*\b(?:describe|it|test)\s*\()/.test(text)) return [];
+  const found: SurfaceCopy[] = [];
+  for (const match of text.matchAll(labelLikeCopyPattern)) {
+    const raw = (match[3] ?? match[4] ?? "").trim();
+    const component = match[1].split(".").pop() ?? match[1];
+    const copy = toSurfaceCopy(component, raw, file, line);
+    if (copy) found.push(copy);
+  }
+  for (const match of text.matchAll(labelPropCopyPattern)) {
+    const raw = (match[2] ?? match[3] ?? match[4] ?? "").trim();
+    const copy = toSurfaceCopy(match[1], raw, file, line);
+    if (copy) found.push(copy);
+  }
+  return found;
+}
+
+function toSurfaceCopy(component: string, raw: string, file: string, line: number): SurfaceCopy | undefined {
+  const tokens = raw
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .split(/\s+/)
+    .filter(Boolean);
+  // 한 단어짜리(아이콘 라벨·숫자)와 문단(설명문)은 "같은 데이터의 다른 이름"이 아니다
+  if (tokens.length < 2 || tokens.length > 8) return undefined;
+  return { component, text: raw, tokens, normalized: tokens.join(" "), file, line };
+}
+
+/**
+ * 두 문구가 같은 자리를 다르게 부르는지 — 동일 문구는 공유 상수라 제외. 첫 단어가 같으면
+ * 같은 슬롯으로 보고("Ships after…" / "Ships when…"), 아니면 토큰 겹침 0.6 이상일 때만.
+ */
+function surfaceCopyDivergence(a: SurfaceCopy, b: SurfaceCopy): number | undefined {
+  if (a.normalized === b.normalized) return undefined;
+  const shared = a.tokens.filter((token) => b.tokens.includes(token)).length;
+  const jaccard = shared / new Set([...a.tokens, ...b.tokens]).size;
+  if (a.tokens[0] === b.tokens[0]) return 1 + jaccard;
+  return jaccard >= 0.6 ? jaccard : undefined;
+}
+
+/** 프로젝트의 기존 사용자 노출 문구 — head 리비전(또는 작업트리)의 제품 UI 파일에서 읽는다 */
+async function readSurfaceCopyCorpus(
+  root: string,
+  gitRoot: string,
+  options: ChangeIntentAnalysisOptions,
+): Promise<SurfaceCopy[]> {
+  const relativeRoot = toPosixPath(path.relative(gitRoot, root)).replace(/^\.\/+|\/+$/g, "");
+  const prefix = relativeRoot ? `${relativeRoot}/` : "";
+  let listed: string[] = [];
+  try {
+    const { stdout } = options.includeWorkingTree
+      ? await execFileAsync("git", ["ls-files", "-z"], { cwd: root, maxBuffer: 4 * 1024 * 1024 })
+      : await execFileAsync("git", ["ls-tree", "-r", "--name-only", "-z", options.head], { cwd: gitRoot, maxBuffer: 4 * 1024 * 1024 });
+    listed = stdout.split("\0").filter(Boolean);
+  } catch {
+    return [];
+  }
+  const files = listed
+    .map((entry) => toPosixPath(entry))
+    .filter((entry) => options.includeWorkingTree || entry.startsWith(prefix))
+    .map((entry) => (options.includeWorkingTree ? entry : entry.slice(prefix.length)))
+    .filter((entry) => userFacingFilePattern.test(entry) && !nonProductCopyPathPattern.test(entry))
+    .slice(0, MAX_COPY_CORPUS_FILES);
+
+  const corpus: SurfaceCopy[] = [];
+  for (const file of files) {
+    const content = await readRuntimeActivationHeadText(root, gitRoot, file, `${prefix}${file}`, options);
+    if (!content || content.length > MAX_COPY_CORPUS_BYTES) continue;
+    content.split(/\r?\n/).forEach((text, index) => {
+      corpus.push(...extractSurfaceCopy(text, file, index + 1));
+    });
+  }
+  return corpus;
 }
 
 async function collectDeliveryIntegrityEvidence(

--- a/test/benchmarks/web-divergent-surface-copy/base/index.html
+++ b/test/benchmarks/web-divergent-surface-copy/base/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/test/benchmarks/web-divergent-surface-copy/base/package.json
+++ b/test/benchmarks/web-divergent-surface-copy/base/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "benchmark-web-divergent-surface-copy",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "test:e2e": "playwright test --reporter=dot"
+  },
+  "dependencies": {
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.61.1",
+    "vite": "7.0.0"
+  }
+}

--- a/test/benchmarks/web-divergent-surface-copy/base/playwright.config.ts
+++ b/test/benchmarks/web-divergent-surface-copy/base/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  use: {
+    baseURL: "http://127.0.0.1:4175",
+  },
+  webServer: {
+    command: "npm run dev -- --host 127.0.0.1 --port 4175",
+    url: "http://127.0.0.1:4175/terms",
+    reuseExistingServer: false,
+  },
+});

--- a/test/benchmarks/web-divergent-surface-copy/base/src/main.tsx
+++ b/test/benchmarks/web-divergent-surface-copy/base/src/main.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { SummaryPage } from "./pages/summary";
+
+createRoot(document.getElementById("root")!).render(<SummaryPage />);

--- a/test/benchmarks/web-divergent-surface-copy/base/src/pages/summary.tsx
+++ b/test/benchmarks/web-divergent-surface-copy/base/src/pages/summary.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { Badge } from "../ui/badge";
+
+export function SummaryPage() {
+  return (
+    <section>
+      <h1>Order summary</h1>
+      <Badge>Ships after payment clears</Badge>
+    </section>
+  );
+}

--- a/test/benchmarks/web-divergent-surface-copy/base/src/ui/badge.tsx
+++ b/test/benchmarks/web-divergent-surface-copy/base/src/ui/badge.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export function Badge({ children }: { children: React.ReactNode }) {
+  return <span className="badge">{children}</span>;
+}

--- a/test/benchmarks/web-divergent-surface-copy/head/src/main.tsx
+++ b/test/benchmarks/web-divergent-surface-copy/head/src/main.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { SummaryPage } from "./pages/summary";
+import { ConfirmationPage } from "./pages/confirmation";
+
+const page = location.hash === "#confirmed" ? <ConfirmationPage /> : <SummaryPage />;
+createRoot(document.getElementById("root")!).render(page);

--- a/test/benchmarks/web-divergent-surface-copy/head/src/pages/confirmation.tsx
+++ b/test/benchmarks/web-divergent-surface-copy/head/src/pages/confirmation.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { Badge } from "../ui/badge";
+
+export function ConfirmationPage() {
+  return (
+    <section>
+      <h1>Order confirmed</h1>
+      <Badge>Ships when the order completes</Badge>
+    </section>
+  );
+}

--- a/test/change-intent.test.mjs
+++ b/test/change-intent.test.mjs
@@ -5632,3 +5632,129 @@ function branch(root, name) {
 function git(root, ...args) {
   execFileSync("git", args, { cwd: root, stdio: "ignore" });
 }
+
+test("near-duplicate badge copy on a new surface is flagged against the existing surface", async (t) => {
+  const root = await makeRepo(t);
+  const summaryFile = "src/pages/summary.tsx";
+  const confirmationFile = "src/pages/confirmation.tsx";
+  await write(root, summaryFile, [
+    "import { Badge } from '../ui/badge';",
+    "export function SummaryCard() {",
+    "  return <Badge>Ships after payment clears</Badge>;",
+    "}",
+    "",
+  ].join("\n"));
+  commit(root, "chore: baseline");
+  branch(root, "feat/order-confirmation");
+  await write(root, confirmationFile, [
+    "import { Badge } from '../ui/badge';",
+    "export function ConfirmationScreen() {",
+    "  return <Badge>Ships when the order completes</Badge>;",
+    "}",
+    "",
+  ].join("\n"));
+  commit(root, "feat: add order confirmation screen");
+
+  const analysis = await analyze(root, [confirmationFile]);
+  const copyEvidence = analysis.intents.flatMap((intent) => intent.evidence).filter((item) =>
+    item.symbol === "divergent-copy:Badge"
+  );
+  assert.deepEqual(copyEvidence.map((item) => [item.file, item.startLine]), [[confirmationFile, 3]]);
+  assert.match(
+    copyEvidence[0].value,
+    /"Ships when the order completes" that nearly duplicates "Ships after payment clears" in src\/pages\/summary\.tsx:3/,
+  );
+  assert.ok(analysis.intents.flatMap((intent) => intent.scenarios).some((scenario) =>
+    /divergent copy for the same data/i.test(scenario.title)
+  ));
+});
+
+test("near-duplicate action labels across toolbars are flagged", async (t) => {
+  const root = await makeRepo(t);
+  const ordersFile = "src/features/orders/Toolbar.tsx";
+  const historyFile = "src/features/history/Toolbar.tsx";
+  await write(root, ordersFile, [
+    "import { Button } from '../../ui/button';",
+    "export function OrdersToolbar() {",
+    "  return <Button>Search orders</Button>;",
+    "}",
+    "",
+  ].join("\n"));
+  commit(root, "chore: baseline");
+  branch(root, "feat/history-toolbar");
+  await write(root, historyFile, [
+    "import { Button } from '../../ui/button';",
+    "export function HistoryToolbar() {",
+    "  return <Button aria-label=\"Search purchases\">Search purchases</Button>;",
+    "}",
+    "",
+  ].join("\n"));
+  commit(root, "feat: add purchase history toolbar");
+
+  const analysis = await analyze(root, [historyFile]);
+  const copyEvidence = analysis.intents.flatMap((intent) => intent.evidence).filter((item) =>
+    item.symbol?.startsWith("divergent-copy:")
+  );
+  assert.deepEqual(copyEvidence.map((item) => item.symbol), ["divergent-copy:Button"]);
+  assert.match(copyEvidence[0].value, /"Search purchases" that nearly duplicates "Search orders" in src\/features\/orders\/Toolbar\.tsx:3/);
+});
+
+test("identical, unrelated, same-file, and non-label copy is not flagged", async (t) => {
+  const root = await makeRepo(t);
+  const summaryFile = "src/pages/summary.tsx";
+  const sharedFile = "src/pages/receipt.tsx";
+  const unrelatedFile = "src/pages/returns.tsx";
+  const proseFile = "src/pages/help.tsx";
+  const sameFile = "src/pages/checkout.tsx";
+  await write(root, summaryFile, [
+    "import { Badge } from '../ui/badge';",
+    "export function SummaryCard() {",
+    "  return <Badge>Ships after payment clears</Badge>;",
+    "}",
+    "",
+  ].join("\n"));
+  commit(root, "chore: baseline");
+  branch(root, "feat/more-surfaces");
+  await write(root, sharedFile, [
+    "import { Badge } from '../ui/badge';",
+    "export function Receipt() {",
+    "  return <Badge>Ships after payment clears</Badge>;",
+    "}",
+    "",
+  ].join("\n"));
+  await write(root, unrelatedFile, [
+    "import { Badge } from '../ui/badge';",
+    "export function Returns() {",
+    "  return <Badge>Free returns within thirty days</Badge>;",
+    "}",
+    "",
+  ].join("\n"));
+  await write(root, proseFile, [
+    "export function Help() {",
+    "  return <p>Ships when the order completes and the courier confirms pickup.</p>;",
+    "}",
+    "",
+  ].join("\n"));
+  await write(root, sameFile, [
+    "import { Badge } from '../ui/badge';",
+    "export function Checkout() {",
+    "  return (",
+    "    <>",
+    "      <Badge>Ready for pickup today</Badge>",
+    "      <Badge>Ready for pickup tomorrow</Badge>",
+    "    </>",
+    "  );",
+    "}",
+    "",
+  ].join("\n"));
+  commit(root, "feat: add receipt, returns, help, and checkout surfaces");
+
+  const analysis = await analyze(root, [sharedFile, unrelatedFile, proseFile, sameFile]);
+  const copyEvidence = analysis.intents.flatMap((intent) => intent.evidence).filter((item) =>
+    item.symbol?.startsWith("divergent-copy:")
+  );
+  assert.deepEqual(copyEvidence, []);
+  assert.ok(!analysis.intents.flatMap((intent) => intent.scenarios).some((scenario) =>
+    /divergent copy/i.test(scenario.title)
+  ));
+});


### PR DESCRIPTION
## Summary

The same data or policy rendered with different labels on different surfaces — "Ships after payment clears" on a summary card, "Ships when the order completes" on the confirmation screen — reads to users as contradictory policy. Each string looks fine in isolation, so per-file review misses the divergence. QAMap now compares label-like copy a diff adds or edits against the existing copy elsewhere in the project, reports the pair with both locations, and plans a side-by-side comparison.

## Behavioral Contract

When a diff adds a user-facing string inside a label-like component (`Badge`, `Tag`, `Chip`, `Pill`, `Label`, `Status`, `Caption`, `Hint`, `Tooltip`, `Toast`, `Button`, `Cta`, `Banner`, `Notice`, `Alert`, `Callout`, with or without a namespace prefix) or in a user-facing prop (`label`, `title`, `placeholder`, `aria-label`, `alt`) of a product UI file, QAMap reads the project's existing copy of the same component family from other product UI files at the head revision. If an existing string is not identical but starts with the same token or shares at least 60% of its tokens, QAMap emits diff risk evidence (`divergent-copy:<Component>`) anchored to the added line, naming both strings and the existing file and line, and adds the QA scenario "Divergent copy for the same data across surfaces".

Identical strings, strings in the same file, strings from different component families, prose outside label-like components, single-word labels, and paragraphs over eight tokens are not flagged. The corpus is only read when the diff actually adds label-like copy, is capped at 400 files and 200 KB per file, and excludes test, story, fixture, and build paths. Findings are capped at five per changed file and only the best-matching existing string is reported per added string.

## Evidence

Closes #213.

- Minimized fixture: `test/benchmarks/web-divergent-surface-copy` — an order confirmation page adds `<Badge>Ships when the order completes</Badge>` while the summary page already renders `<Badge>Ships after payment clears</Badge>`; contract pins the intent, reached file, and the new scenario title.
- Focused regression: the new badge is flagged against the existing surface with both strings and the existing `file:line` in the evidence, anchored to the added line.
- Second unrelated positive: a purchase-history toolbar adds `<Button>Search purchases</Button>` beside an existing `<Button>Search orders</Button>` in another feature.
- Negative controls: identical copy on a second surface (shared wording), unrelated badge copy, near-duplicate prose inside a `<p>`, and two similar badges inside one file — none flagged, scenario absent.

## Checks

- [x] Focused regression test
- [x] `pnpm test`
- [x] `pnpm bench:ci` for inference, routing, trace, or output
- [ ] `pnpm bench:execution` for E2E compiler or execution fixtures
- [ ] `pnpm scan` for scanner, security, or repository policy
- [ ] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
- [ ] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

`pnpm scan` (0 findings), `pnpm bench:context` (10/10), `pnpm plugin:check`, and `pnpm plugin:smoke` also pass locally; marked N/A above because this change touches none of those surfaces. The detector is deliberately narrow: single-line JSX only, same component family only, other files only. Multi-line JSX children, copy assembled from template literals or i18n keys, and strings that share meaning without sharing a leading token remain review work. The existing surface is read from the head revision, so a surface that the same diff rewrote is excluded from the corpus to avoid matching stale text.