### PR TITLE
Feat: run drafted E2E scenarios through a declared executor with fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added `qamap e2e run <scenario-id>`, which executes one compiled scenario through an executor the repository declares in `qamap.config.json`, materializes the fixtures declared for that scenario, and returns a receipt with pass/fail per assertion, timing, and failure-only artifacts. Receipts persist under `.qamap/runs/e2e` and reruns of the same id are compared instead of re-driven.
+- Added `executors`, `fixtures`, and `scenarioFixtures` configuration, and `qamap qa` now marks which drafted scenarios are executable with the declared executor and fixtures.
+- Added account-scoped storage evidence for client storage writes that carry no owner discriminator, with an account-switch QA scenario.
+- Added divergent-copy evidence that pairs a new label with a near-duplicate label on another surface and plans a side-by-side comparison.
+
 ## 0.4.14 - 2026-08-20
 
 ### Added

--- a/README.ko.md
+++ b/README.ko.md
@@ -220,6 +220,7 @@ npx --yes @ivorycanvas/qamap@latest qa --format markdown
 | `qamap qa` | 코드 변경을 동작, 위험, 근거, QA 항목에 연결 | 아니요 |
 | `qamap qa run` | QAMap이 고른 기존 검증 명령 하나를 명시적으로 실행 | 예 |
 | `qamap e2e draft . --dry-run` | Playwright, Maestro, CLI, API, 수동 점검표 초안을 미리 보기 | 아니요 |
+| `qamap e2e run <scenario-id>` | `qamap.config.json` 에 선언한 실행기와 픽스처로 컴파일된 시나리오 하나를 실행하고, 영수증을 저장해 이전 실행과 비교합니다. | 예, 선언한 실행기와 시드 훅 |
 
 화면 요소 식별자, 테스트 데이터, Playwright, Maestro, 테스트 실행 환경이
 없어도 중요한 QA 항목을 숨기지 않습니다. 먼저 무엇을 확인해야 하는지

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ npx --yes @ivorycanvas/qamap@latest qa --format markdown
 | `qamap qa` | Maps the diff to behavior, risk, evidence, and QA scenarios. | No |
 | `qamap qa run` | Runs one existing repository validation selected by QAMap. | Yes, explicitly |
 | `qamap e2e draft . --dry-run` | Previews optional Playwright, Maestro, CLI, API, or manual automation. | No |
+| `qamap e2e run <scenario-id>` | Executes one compiled scenario through the executor and fixtures declared in `qamap.config.json`, then stores and compares the receipt. | Yes, the declared executor and seed hooks |
 
 QAMap does not hide an important QA scenario because a repository lacks a
 selector, fixture, Playwright, Maestro, or test runner. Those are automation

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -225,7 +225,14 @@ This keeps first-run setup light while allowing one human correction to improve 
 
 `qamap qa` remains static and read-only. It must not execute scanned project code.
 
-Future execution belongs to an explicit `qamap verify` mode with a visible execution plan. The intended safeguards are:
+Execution happens only through two explicit commands. `qamap qa run` executes one
+existing repository validation command. `qamap e2e run <scenario-id>` executes one
+compiled scenario through an executor the repository declared in `qamap.config.json`,
+after materializing the fixtures declared for that scenario id, and reports pass/fail
+per assertion, timing, and failure-only artifacts. Fixtures and artifacts live under
+`.qamap/tmp`, receipts under `.qamap/runs/e2e`, and a missing executor, missing
+fixture, or uncompiled scenario yields a `blocked` receipt rather than a pass. The
+safeguards both commands share are:
 
 - generated tests live in an operating-system temporary directory by default;
 - target repository files are not modified unless a separate write command is requested;

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -101,6 +101,7 @@ That means QAMap is most valuable when it becomes the team's verification base: 
 | `qamap e2e plan . --base origin/main --head HEAD --record-history` | Save a compact local run snapshot under `.qamap/runs/` while keeping JSON/Markdown output usable. |
 | `qamap e2e setup . --runner playwright` | Explicitly apply the accepted runner setup and create the first changed-flow E2E draft without overwriting existing files. |
 | `qamap e2e draft . --base origin/main --head HEAD --dry-run` | Preview generated Maestro, Playwright, or manual E2E drafts without writing files. |
+| `qamap e2e run scenario:1a2b3c4d5e6f . --base origin/main --head HEAD` | Execute one compiled scenario through the executor declared in `qamap.config.json`, after materializing its declared fixtures; prints a receipt with pass/fail per assertion, timing, and failure-only artifacts, and compares it to the previous receipt for the same id. |
 | `qamap e2e draft . --base origin/main --head HEAD` | Write generated Maestro, Playwright, or manual E2E drafts with flow language, readiness summaries, and action items. |
 | `qamap manifest init .` | Create a baseline `.qamap/manifest.yaml` with inferred domains, flows, anchors, checks, source, and confidence. |
 | `qamap manifest validate .` | Check whether `.qamap/manifest.yaml` is present, parseable, anchored to real files, and ready to shape PR evidence. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,18 @@ qamap scan . --config ./qamap.config.json
   "ignoreRules": ["QM011"],
   "maxFiles": 2000,
   "validationCommands": ["make test", "make lint"],
+  "executors": {
+    "web": {
+      "runner": "playwright",
+      "command": ["pnpm", "exec", "playwright", "test", "{file}", "--grep", "{grep}", "--reporter=json"]
+    }
+  },
+  "fixtures": {
+    "geo-photo": { "kind": "file", "path": "fixtures/geo-photo.jpg" }
+  },
+  "scenarioFixtures": {
+    "scenario:1a2b3c4d5e6f": ["geo-photo"]
+  },
   "severity": {
     "QM007": "info"
   }
@@ -42,6 +54,9 @@ qamap scan . --config ./qamap.config.json
 | `maxFiles` | `number` | Maximum number of files QAMap inspects. CLI `--max-files` takes precedence. |
 | `severity` | `Record<string, Severity>` | Overrides severity for specific rule ids. |
 | `validationCommands` | `string[]` | Adds project-specific validation commands to `test-plan`, `eval`, `verify`, and GitHub Action reports. |
+| `executors` | `object` | Repository-owned scenario executors for `qamap e2e run`. Each entry has a `runner` (`playwright` parses the JSON reporter, `command` reads only the exit code), an argument-vector `command` run without a shell that must reference `{file}` and may use `{grep}`, `{scenarioId}`, `{fixtureDir}`, `{artifactDir}`, plus optional `cwd`, `timeoutMs`, `artifactDirectory`, and `env`. |
+| `fixtures` | `object` | Declared fixtures keyed by id: `{ "kind": "file", "path": "fixtures/geo-photo.jpg" }` copies a repository file into the run's fixture directory; `{ "kind": "seed", "command": ["node", "scripts/seed.mjs"] }` runs a seed hook without a shell. Paths and working directories must stay inside the repository. |
+| `scenarioFixtures` | `object` | Scenario id to the fixture ids it needs. A compiled scenario with a configured executor and declared fixtures is reported as executable by `qamap qa` and can be run with `qamap e2e run`. |
 
 ## Notes
 

--- a/execution-bench.config.json
+++ b/execution-bench.config.json
@@ -44,7 +44,23 @@
       ],
       "fixedOutputIncludes": [
         "2 passed"
-      ]
+      ],
+      "scenarioRun": {
+        "scenarioTitle": "Duplicate renewal request",
+        "executor": {
+          "runner": "playwright",
+          "command": [
+            "pnpm",
+            "exec",
+            "playwright",
+            "test",
+            "{file}",
+            "--grep",
+            "{grep}",
+            "--reporter=json"
+          ]
+        }
+      }
     },
     {
       "name": "web-persisted-state-restoration",

--- a/schema/qamap.schema.json
+++ b/schema/qamap.schema.json
@@ -43,6 +43,41 @@
         "minLength": 1
       },
       "uniqueItems": true
+    },
+    "executors": {
+      "type": "object",
+      "description": "Repository-owned scenario executors that qamap e2e run may invoke. QAMap never bundles a browser.",
+      "propertyNames": {
+        "pattern": "^[a-z][a-z0-9-]*$"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/executor"
+      }
+    },
+    "fixtures": {
+      "type": "object",
+      "description": "Declared fixtures that qamap e2e run materializes before invoking an executor.",
+      "propertyNames": {
+        "pattern": "^[a-z][a-z0-9-]*$"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/fixture"
+      }
+    },
+    "scenarioFixtures": {
+      "type": "object",
+      "description": "Scenario id to the fixture ids it needs. A scenario with an executor and declared fixtures becomes executable.",
+      "propertyNames": {
+        "pattern": "^scenario:[a-f0-9]{6,}$"
+      },
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "uniqueItems": true
+      }
     }
   },
   "$defs": {
@@ -52,7 +87,120 @@
     },
     "severity": {
       "type": "string",
-      "enum": ["info", "low", "medium", "high"]
+      "enum": [
+        "info",
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    "executor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "runner",
+        "command"
+      ],
+      "properties": {
+        "runner": {
+          "type": "string",
+          "enum": [
+            "playwright",
+            "command"
+          ],
+          "description": "How QAMap reads the result: playwright parses the JSON reporter, command reads only the exit code."
+        },
+        "command": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Argument vector run without a shell. Tokens: {file}, {grep}, {scenarioId}, {fixtureDir}, {artifactDir}."
+        },
+        "cwd": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timeoutMs": {
+          "type": "integer",
+          "minimum": 1000
+        },
+        "artifactDirectory": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Where failure-only artifacts are collected. Defaults to .qamap/tmp/e2e-run/<scenario>/artifacts."
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "fixture": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "path"
+          ],
+          "properties": {
+            "kind": {
+              "const": "file"
+            },
+            "path": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Repository-relative file copied into the fixture directory."
+            },
+            "target": {
+              "type": "string",
+              "minLength": 1
+            },
+            "description": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "command"
+          ],
+          "properties": {
+            "kind": {
+              "const": "seed"
+            },
+            "command": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": "Seed hook run without a shell before the executor."
+            },
+            "cwd": {
+              "type": "string",
+              "minLength": 1
+            },
+            "timeoutMs": {
+              "type": "integer",
+              "minimum": 1000
+            },
+            "description": {
+              "type": "string"
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/scripts/execution-bench.mjs
+++ b/scripts/execution-bench.mjs
@@ -8,7 +8,7 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
-import { generateE2eDraft } from "../dist/index.js";
+import { generateE2eDraft, runE2eScenario } from "../dist/index.js";
 
 const execFileAsync = promisify(execFile);
 const args = process.argv.slice(2);
@@ -53,12 +53,19 @@ for (const contract of config.contracts) {
     const regression = await runCommand(contract.validateCommand, prepared.repositoryRoot);
     assertExpectedFailure(contract, regression);
     await assertArtifactDigest(prepared.repositoryRoot, generatedFiles, artifactDigest, "regression run");
+    const scenarioRegression = await runScenarioContract(contract, draft, prepared.repositoryRoot, "failed");
 
     await copyLayer(prepared.fixtureRoot, contract.fixedOverlay, prepared.repositoryRoot);
     await assertArtifactDigest(prepared.repositoryRoot, generatedFiles, artifactDigest, "fixed overlay");
     const fixedAfter = await runCommand(contract.validateCommand, prepared.repositoryRoot);
     assertExpectedPass(contract, fixedAfter, "restored fixed head");
     await assertArtifactDigest(prepared.repositoryRoot, generatedFiles, artifactDigest, "fixed run");
+    const scenarioFixed = await runScenarioContract(contract, draft, prepared.repositoryRoot, "passed");
+    if (scenarioRegression && scenarioFixed && scenarioFixed.comparison?.verdict !== "recovered") {
+      throw new Error(
+        `scenario run comparison expected recovered, got ${scenarioFixed.comparison?.verdict ?? "none"}`,
+      );
+    }
 
     results.push({
       name: contract.name,
@@ -69,6 +76,15 @@ for (const contract of config.contracts) {
       regression: contract.regressionName,
       fixedEvidence: firstMatchingLine(fixedAfter.output, contract.fixedOutputIncludes),
       failureEvidence: firstMatchingLine(regression.output, contract.regressionOutputIncludes),
+      scenarioRun: scenarioFixed
+        ? {
+            scenarioId: scenarioFixed.scenarioId,
+            regression: scenarioRegression.receipt.status,
+            fixed: scenarioFixed.receipt.status,
+            verdict: scenarioFixed.comparison?.verdict,
+            assertions: scenarioFixed.receipt.assertions.length,
+          }
+        : undefined,
       tempRoot: keep ? prepared.tempRoot : undefined,
     });
   } catch (error) {
@@ -94,6 +110,12 @@ for (const result of results) {
   console.log(`- PASS ${result.name}`);
   console.log(`  generated: ${result.generatedFiles} file(s), ${result.compiledScenarios} compiled scenario(s)`);
   console.log(`  artifact unchanged: sha256:${result.artifactDigest}`);
+  if (result.scenarioRun) {
+    console.log(
+      `  scenario run: ${result.scenarioRun.regression} on regression, ${result.scenarioRun.fixed} on fix, ` +
+        `${result.scenarioRun.verdict} (${result.scenarioRun.assertions} assertion(s))`,
+    );
+  }
   console.log(`  regression caught: ${result.regression}`);
   if (result.failureEvidence) console.log(`  failure evidence: ${result.failureEvidence}`);
   if (result.fixedEvidence) console.log(`  fixed evidence: ${result.fixedEvidence}`);
@@ -212,6 +234,43 @@ async function runRequiredCommand(command, cwd, label) {
   if (result.code !== 0) {
     throw new Error(`${label} failed (${formatCommand(command)}):\n${tail(result.output)}`);
   }
+}
+
+/**
+ * Optional contract: execute the compiled scenario through qamap e2e run with the
+ * contract's executor declaration and require the receipt status for this phase.
+ * Proves the receipt itself tells the seeded regression from the fix.
+ */
+async function runScenarioContract(contract, draft, repositoryRoot, expectedStatus) {
+  if (!contract.scenarioRun) {
+    return undefined;
+  }
+  const receipt = draft.files
+    .flatMap((file) => file.scenarioAutomation)
+    .find((candidate) => candidate.title === contract.scenarioRun.scenarioTitle && candidate.status === "compiled");
+  if (!receipt) {
+    throw new Error(`scenario run could not find a compiled scenario titled ${contract.scenarioRun.scenarioTitle}`);
+  }
+  // Resolve the scenario from the committed range so its id stays stable while the
+  // overlays change the working tree the executor actually runs against.
+  const result = await runE2eScenario(repositoryRoot, receipt.scenarioId, {
+    base: "main",
+    head: "HEAD",
+    includeWorkingTree: false,
+    output: contract.output ?? "tests/e2e",
+    config: { executors: { benchmark: contract.scenarioRun.executor }, fixtures: {}, scenarioFixtures: {} },
+    executor: "benchmark",
+  });
+  if (result.receipt.status !== expectedStatus) {
+    throw new Error(
+      `scenario run expected ${expectedStatus} but received ${result.receipt.status}` +
+        (result.receipt.status === "blocked" ? `: ${result.receipt.reason}` : ""),
+    );
+  }
+  if (result.receipt.assertions.length === 0) {
+    throw new Error("scenario run produced no assertions");
+  }
+  return result;
 }
 
 async function runCommand(command, cwd) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,6 +61,7 @@ import type { QAMapConfig } from "./types.js";
 import type { Severity } from "./types.js";
 import { VERSION } from "./version.js";
 import type { E2eRunnerName } from "./e2e.js";
+import { formatMarkdownE2eRun, runE2eScenario } from "./e2e-run.js";
 import type { GitHubActionMode } from "./github.js";
 
 type OutputFormat = "text" | "json" | "markdown" | "sarif" | "agent";
@@ -96,6 +97,7 @@ interface ParsedOptions {
   agent?: boolean;
   scripts?: boolean;
   timeoutMs?: number;
+  executor?: string;
 }
 
 async function main(argv: string[]): Promise<number> {
@@ -245,10 +247,15 @@ async function main(argv: string[]): Promise<number> {
       printE2eHelp();
       return 0;
     }
-    if (subcommand !== "plan" && subcommand !== "draft" && subcommand !== "setup") {
+    if (subcommand !== "plan" && subcommand !== "draft" && subcommand !== "setup" && subcommand !== "run") {
       throw new Error(`Unknown e2e subcommand: ${subcommand}`);
     }
-    const options = parseOptions(subcommandRest);
+    // e2e run takes the scenario id as its first positional before the optional path
+    const scenarioId = subcommand === "run" ? subcommandRest[0] : undefined;
+    if (subcommand === "run" && (!scenarioId || scenarioId.startsWith("-"))) {
+      throw new Error("e2e run requires a scenario id, for example: qamap e2e run scenario:1a2b3c4d5e6f");
+    }
+    const options = parseOptions(subcommand === "run" ? subcommandRest.slice(1) : subcommandRest);
     const loadedConfig = await loadOptionsConfig(options);
     const e2eOptions = {
       base: options.base,
@@ -267,6 +274,22 @@ async function main(argv: string[]): Promise<number> {
       const output = formatE2ePlanOutput(result, options.format ?? (options.json ? "json" : "markdown"));
       await printOrWrite(output, options.output);
       return 0;
+    }
+    if (subcommand === "run") {
+      const result = await runE2eScenario(options.path, scenarioId as string, {
+        ...e2eOptions,
+        config: loadedConfig.config,
+        executor: options.executor,
+        timeoutMs: options.timeoutMs,
+        output: options.output,
+      });
+      const format = options.format ?? (options.json ? "json" : "markdown");
+      if (format !== "json" && format !== "markdown") {
+        throw new Error(`e2e run supports json or markdown output, not ${format}`);
+      }
+      const output = format === "json" ? `${JSON.stringify(result, null, 2)}\n` : formatMarkdownE2eRun(result);
+      console.log(output.trimEnd());
+      return e2eRunExitCode(result.receipt);
     }
     if (subcommand === "setup") {
       const result = await setupE2eRunner(options.path, {
@@ -304,6 +327,7 @@ async function main(argv: string[]): Promise<number> {
       validationCommands: loadedConfig.config.validationCommands,
       runner: options.e2eRunner,
       manifestPath: options.manifestPath,
+      config: loadedConfig.config,
     };
     const format = options.format ?? (options.json ? "json" : "text");
     const streamCommandOutput = runValidation &&
@@ -739,6 +763,11 @@ function parseOptions(args: string[]): ParsedOptions {
       continue;
     }
 
+    if (arg === "--executor") {
+      options.executor = readValue(args, ++index, arg);
+      continue;
+    }
+
     if (arg === "--timeout-ms") {
       const value = Number.parseInt(readValue(args, ++index, arg), 10);
       if (!Number.isFinite(value) || value < 1_000) {
@@ -902,6 +931,11 @@ function formatQaDraftOutput(result: Awaited<ReturnType<typeof generateQaDraft>>
     throw new Error(`QA draft supports text, json, markdown, or agent output, not ${format}`);
   }
   return format === "markdown" ? formatMarkdownQaDraft(result) : formatTextQaDraft(result);
+}
+
+function e2eRunExitCode(receipt: Awaited<ReturnType<typeof runE2eScenario>>["receipt"]): number {
+  if (receipt.status === "passed") return 0;
+  return receipt.status === "blocked" ? 2 : 1;
 }
 
 function qaValidationExitCode(
@@ -1116,6 +1150,7 @@ Usage:
   qamap e2e plan [path] [--workspace-root <path>] [--manifest <file>] [--base <ref>] [--head <ref>] [--include-working-tree] [--record-history] [--format <format>]
   qamap e2e setup [path] [--workspace-root <path>] [--runner maestro|playwright] [--force]
   qamap e2e draft [path] [--workspace-root <path>] [--manifest <file>] [--base <ref>] [--head <ref>] [--runner maestro|playwright|manual] [--output <dir>] [--dry-run] [--force]
+  qamap e2e run <scenario-id> [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--executor <name>] [--timeout-ms <n>] [--format json|markdown]
   qamap manifest init [path] [--workspace-root <path>] [--write <file>] [--max-files <n>] [--force]
   qamap manifest validate [path] [--workspace-root <path>] [--manifest <file>] [--format <format>]
   qamap manifest explain [path] [--workspace-root <path>] [--manifest <file>] [--base <ref>] [--head <ref>] [--include-working-tree] [--format <format>]
@@ -1203,6 +1238,14 @@ Usage:
   qamap e2e plan [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--record-history] [--format <format>] [--output <file>]
   qamap e2e setup [path] [--workspace-root <path>] [--runner maestro|playwright] [--force] [--format <format>] [--output <file>]
   qamap e2e draft [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--runner maestro|playwright|manual] [--output <dir>] [--dry-run] [--force]
+  qamap e2e run <scenario-id> [path] [--workspace-root <path>] [--base <ref>] [--head <ref>] [--include-working-tree] [--executor <name>] [--timeout-ms <n>] [--output <dir>] [--format json|markdown]
+
+Execution boundary:
+  e2e run executes one compiled scenario through an executor the repository configured in
+  qamap.config.json, after materializing the fixtures declared for that scenario id. It prints
+  a receipt with pass/fail per assertion, timing, and failure-only artifacts, stores it under
+  .qamap/runs/e2e, and compares it to the previous receipt for the same id. Without a configured
+  executor or declared fixtures the receipt is blocked and nothing runs.
 
 Examples:
   qamap e2e plan . --base origin/main --head HEAD
@@ -1210,6 +1253,7 @@ Examples:
   qamap e2e setup . --runner playwright
   qamap e2e setup apps/mobile --workspace-root . --runner maestro
   qamap e2e draft . --base origin/main --head HEAD --dry-run
+  qamap e2e run scenario:1a2b3c4d5e6f . --base origin/main --head HEAD
   qamap e2e plan apps/mobile --workspace-root . --include-working-tree
 `);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { pathExists } from "./fs.js";
 import { isSeverity } from "./severity.js";
-import type { QAMapConfig, ResolvedQAMapConfig, Severity } from "./types.js";
+import type { QAMapConfig, QAMapExecutorConfig, QAMapExecutorRunner, QAMapFixtureDeclaration, ResolvedQAMapConfig, Severity } from "./types.js";
 
 const configFileNames = ["qamap.config.json", ".qamap.json"];
 
@@ -110,6 +110,18 @@ function normalizeConfig(value: unknown, configPath: string): QAMapConfig {
     config.severity = normalizeSeverityOverrides(record.severity as Record<string, unknown>);
   }
 
+  if (record.executors !== undefined) {
+    config.executors = normalizeExecutors(record.executors);
+  }
+
+  if (record.fixtures !== undefined) {
+    config.fixtures = normalizeFixtures(record.fixtures);
+  }
+
+  if (record.scenarioFixtures !== undefined) {
+    config.scenarioFixtures = normalizeScenarioFixtures(record.scenarioFixtures, config.fixtures ?? {});
+  }
+
   if (record.validationCommands !== undefined) {
     if (
       !Array.isArray(record.validationCommands) ||
@@ -132,4 +144,144 @@ function normalizeSeverityOverrides(value: Record<string, unknown>): Record<stri
     overrides[ruleId.toUpperCase()] = severity;
   }
   return overrides;
+}
+
+const executorRunners = new Set(["playwright", "command"]);
+const executorTokenPattern = /\{(file|grep|scenarioId|fixtureDir|artifactDir)\}/g;
+
+function normalizeCommandArray(value: unknown, label: string): string[] {
+  if (!Array.isArray(value) || value.length === 0 || !value.every((item) => typeof item === "string" && item.trim().length > 0)) {
+    throw new Error(`QAMap config ${label} must be a non-empty array of non-empty strings`);
+  }
+  return value.map((item) => item.trim());
+}
+
+function normalizeOptionalTimeout(value: unknown, label: string): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1_000) {
+    throw new Error(`QAMap config ${label} must be an integer of at least 1000`);
+  }
+  return value;
+}
+
+function normalizeExecutors(value: unknown): Record<string, QAMapExecutorConfig> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("QAMap config executors must be an object of executor name to executor");
+  }
+  const executors: Record<string, QAMapExecutorConfig> = {};
+  for (const [name, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (!/^[a-z][a-z0-9-]*$/.test(name)) {
+      throw new Error(`QAMap config executor name must be lowercase letters, digits, or dashes: ${name}`);
+    }
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      throw new Error(`QAMap config executor ${name} must be an object`);
+    }
+    const entry = raw as Record<string, unknown>;
+    if (typeof entry.runner !== "string" || !executorRunners.has(entry.runner)) {
+      throw new Error(`QAMap config executor ${name} runner must be playwright or command`);
+    }
+    const command = normalizeCommandArray(entry.command, `executor ${name} command`);
+    // A file token is what lets the executor target one draft; without it every run would execute everything.
+    if (!command.some((item) => /\{file\}/.test(item))) {
+      throw new Error(`QAMap config executor ${name} command must reference {file}`);
+    }
+    for (const item of command) {
+      for (const match of item.matchAll(/\{([^}]*)\}/g)) {
+        if (!`{${match[1]}}`.match(executorTokenPattern)) {
+          throw new Error(`QAMap config executor ${name} command uses unknown token {${match[1]}}`);
+        }
+      }
+    }
+    if (entry.cwd !== undefined && (typeof entry.cwd !== "string" || entry.cwd.trim().length === 0)) {
+      throw new Error(`QAMap config executor ${name} cwd must be a non-empty string`);
+    }
+    if (entry.artifactDirectory !== undefined && (typeof entry.artifactDirectory !== "string" || entry.artifactDirectory.trim().length === 0)) {
+      throw new Error(`QAMap config executor ${name} artifactDirectory must be a non-empty string`);
+    }
+    if (entry.env !== undefined) {
+      if (!entry.env || typeof entry.env !== "object" || Array.isArray(entry.env) ||
+        !Object.values(entry.env as Record<string, unknown>).every((item) => typeof item === "string")) {
+        throw new Error(`QAMap config executor ${name} env must be an object of string values`);
+      }
+    }
+    executors[name] = {
+      runner: entry.runner as QAMapExecutorRunner,
+      command,
+      ...(entry.cwd !== undefined ? { cwd: (entry.cwd as string).trim() } : {}),
+      ...(entry.timeoutMs !== undefined ? { timeoutMs: normalizeOptionalTimeout(entry.timeoutMs, `executor ${name} timeoutMs`) } : {}),
+      ...(entry.artifactDirectory !== undefined ? { artifactDirectory: (entry.artifactDirectory as string).trim() } : {}),
+      ...(entry.env !== undefined ? { env: { ...(entry.env as Record<string, string>) } } : {}),
+    };
+  }
+  return executors;
+}
+
+function normalizeFixtures(value: unknown): Record<string, QAMapFixtureDeclaration> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("QAMap config fixtures must be an object of fixture id to declaration");
+  }
+  const fixtures: Record<string, QAMapFixtureDeclaration> = {};
+  for (const [id, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (!/^[a-z][a-z0-9-]*$/.test(id)) {
+      throw new Error(`QAMap config fixture id must be lowercase letters, digits, or dashes: ${id}`);
+    }
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      throw new Error(`QAMap config fixture ${id} must be an object`);
+    }
+    const entry = raw as Record<string, unknown>;
+    const description = entry.description === undefined ? undefined : String(entry.description);
+    if (entry.kind === "file") {
+      if (typeof entry.path !== "string" || entry.path.trim().length === 0) {
+        throw new Error(`QAMap config fixture ${id} path must be a non-empty string`);
+      }
+      if (entry.target !== undefined && (typeof entry.target !== "string" || entry.target.trim().length === 0)) {
+        throw new Error(`QAMap config fixture ${id} target must be a non-empty string`);
+      }
+      fixtures[id] = {
+        kind: "file",
+        path: entry.path.trim(),
+        ...(entry.target !== undefined ? { target: (entry.target as string).trim() } : {}),
+        ...(description !== undefined ? { description } : {}),
+      };
+      continue;
+    }
+    if (entry.kind === "seed") {
+      fixtures[id] = {
+        kind: "seed",
+        command: normalizeCommandArray(entry.command, `fixture ${id} command`),
+        ...(entry.cwd !== undefined ? { cwd: String(entry.cwd).trim() } : {}),
+        ...(entry.timeoutMs !== undefined ? { timeoutMs: normalizeOptionalTimeout(entry.timeoutMs, `fixture ${id} timeoutMs`) } : {}),
+        ...(description !== undefined ? { description } : {}),
+      };
+      continue;
+    }
+    throw new Error(`QAMap config fixture ${id} kind must be file or seed`);
+  }
+  return fixtures;
+}
+
+function normalizeScenarioFixtures(
+  value: unknown,
+  fixtures: Record<string, QAMapFixtureDeclaration>,
+): Record<string, string[]> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("QAMap config scenarioFixtures must be an object of scenario id to fixture ids");
+  }
+  const bindings: Record<string, string[]> = {};
+  for (const [scenarioId, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (!/^scenario:[a-f0-9]{6,}$/.test(scenarioId)) {
+      throw new Error(`QAMap config scenarioFixtures key must be a scenario id: ${scenarioId}`);
+    }
+    if (!Array.isArray(raw) || !raw.every((item) => typeof item === "string" && item.trim().length > 0)) {
+      throw new Error(`QAMap config scenarioFixtures ${scenarioId} must be an array of fixture ids`);
+    }
+    const ids = [...new Set(raw.map((item) => item.trim()))];
+    for (const id of ids) {
+      if (!fixtures[id]) {
+        throw new Error(`QAMap config scenarioFixtures ${scenarioId} references unknown fixture ${id}`);
+      }
+    }
+    bindings[scenarioId] = ids;
+  }
+  return bindings;
 }

--- a/src/e2e-run.ts
+++ b/src/e2e-run.ts
@@ -1,0 +1,762 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { generateE2eDraft, type E2eDraftFile, type E2eDraftOptions, type E2eScenarioAutomationReceipt } from "./e2e.js";
+import { toPosixPath } from "./fs.js";
+import { captureGitState, compareGitState, terminateProcessTree } from "./qa-execution.js";
+import { neutralizeInstructionLikeValues } from "./qa-contract.js";
+import type { QaGitStateReceipt } from "./qa.js";
+import { TOOL_NAME, VERSION } from "./version.js";
+import type { QAMapConfig, QAMapExecutorConfig, QAMapFixtureDeclaration } from "./types.js";
+
+/**
+ * Scenario execution — the bounded step after `qamap e2e draft`.
+ *
+ * QAMap does not own a browser. It resolves one compiled scenario to the draft file that
+ * carries it, materializes the fixtures the repository declared for it, invokes the
+ * executor the repository configured, and turns the executor's own report into a receipt:
+ * pass/fail per assertion, timing, and artifacts only when something failed. The receipt
+ * is persisted under `.qamap/runs/e2e/<scenario>/` so a later run of the same id can be
+ * compared instead of re-driven by hand.
+ *
+ * Anything that cannot be proven is reported as `blocked`, never as a pass.
+ */
+
+export const e2eRunReceiptDirectory = ".qamap/runs/e2e";
+export const e2eRunFixtureDirectory = ".qamap/tmp/e2e-run";
+
+const defaultExecutorTimeoutMs = 300_000;
+const defaultSeedTimeoutMs = 60_000;
+const maxAssertionErrorChars = 240;
+const maxArtifacts = 12;
+
+export type E2eScenarioExecutabilityStatus =
+  | "executable"
+  | "executor-missing"
+  | "fixtures-missing"
+  | "not-compiled";
+
+export interface E2eScenarioExecutability {
+  status: E2eScenarioExecutabilityStatus;
+  executor?: string;
+  fixtureIds: string[];
+  reason: string;
+}
+
+export interface E2eRunOptions extends Omit<E2eDraftOptions, "dryRun" | "force"> {
+  config?: QAMapConfig;
+  executor?: string;
+  timeoutMs?: number;
+  /** Draft directory the executor targets; defaults to the runner's conventional output. */
+  output?: string;
+}
+
+export interface E2eAssertionResult {
+  title: string;
+  status: "passed" | "failed" | "skipped";
+  durationMs: number;
+  error?: string;
+}
+
+export interface E2eFixtureReceiptItem {
+  id: string;
+  kind: "file" | "seed";
+  status: "materialized" | "executed" | "failed";
+  sha256?: string;
+  durationMs: number;
+  reason?: string;
+}
+
+export interface E2eFixturePreparationReceipt {
+  status: "ready" | "blocked";
+  directory: string;
+  fixtures: E2eFixtureReceiptItem[];
+  reason?: string;
+}
+
+export interface E2eBlockedRunReceipt {
+  status: "blocked";
+  performed: false;
+  scope: "scenario-executor";
+  reason: string;
+  fixtures?: E2eFixturePreparationReceipt;
+}
+
+export interface E2eCompletedRunReceipt {
+  status: "passed" | "failed";
+  performed: true;
+  scope: "scenario-executor";
+  executor: string;
+  runner: QAMapExecutorConfig["runner"];
+  command: string[];
+  cwd: string;
+  exitCode?: number;
+  signal?: string;
+  durationMs: number;
+  timedOut: boolean;
+  assertions: E2eAssertionResult[];
+  artifacts: string[];
+  fixtures: E2eFixturePreparationReceipt;
+  stdoutBytes: number;
+  stderrBytes: number;
+  stdoutSha256: string;
+  stderrSha256: string;
+  gitState: QaGitStateReceipt;
+}
+
+export type E2eRunReceipt = E2eBlockedRunReceipt | E2eCompletedRunReceipt;
+
+export type E2eRunComparisonVerdict = "same" | "regressed" | "recovered" | "changed";
+
+export interface E2eRunComparison {
+  verdict: E2eRunComparisonVerdict;
+  previousStatus: E2eRunReceipt["status"];
+  currentStatus: E2eRunReceipt["status"];
+  added: string[];
+  removed: string[];
+  statusChanged: Array<{ title: string; from: E2eAssertionResult["status"]; to: E2eAssertionResult["status"] }>;
+  durationDeltaMs?: number;
+}
+
+export interface E2eRunResult {
+  tool: { name: string; version: string };
+  root: string;
+  generatedAt: string;
+  scenarioId: string;
+  title?: string;
+  flowTitle?: string;
+  specPath?: string;
+  receipt: E2eRunReceipt;
+  receiptPath?: string;
+  comparison?: E2eRunComparison;
+  nextSteps: string[];
+}
+
+interface StoredRunReceipt {
+  scenarioId: string;
+  generatedAt: string;
+  title?: string;
+  specPath?: string;
+  receipt: E2eRunReceipt;
+}
+
+/** Which scenarios `qamap e2e run` can execute right now, given the repository's configuration. */
+export function assessScenarioExecutability(
+  receipt: Pick<E2eScenarioAutomationReceipt, "scenarioId" | "status">,
+  config: Pick<QAMapConfig, "executors" | "fixtures" | "scenarioFixtures"> | undefined,
+  runner: string = "playwright",
+): E2eScenarioExecutability {
+  const fixtureIds = config?.scenarioFixtures?.[receipt.scenarioId] ?? [];
+  if (receipt.status !== "compiled") {
+    return { status: "not-compiled", fixtureIds, reason: `The scenario is ${receipt.status}; only compiled scenarios run.` };
+  }
+  const executor = selectExecutor(config?.executors, undefined, runner);
+  if (!executor) {
+    return { status: "executor-missing", fixtureIds, reason: "No executor is configured for this runner in qamap.config.json." };
+  }
+  const missing = fixtureIds.filter((id) => !config?.fixtures?.[id]);
+  if (missing.length > 0) {
+    return { status: "fixtures-missing", executor: executor.name, fixtureIds, reason: `Declared fixtures are missing: ${missing.join(", ")}.` };
+  }
+  return { status: "executable", executor: executor.name, fixtureIds, reason: "A compiled scenario, a configured executor, and declared fixtures are all present." };
+}
+
+export async function runE2eScenario(rootInput: string, scenarioIdInput: string, options: E2eRunOptions = {}): Promise<E2eRunResult> {
+  const root = path.resolve(rootInput);
+  const generatedAt = new Date().toISOString();
+  const draft = await generateE2eDraft(root, {
+    base: options.base,
+    head: options.head,
+    workspaceRoot: options.workspaceRoot,
+    includeWorkingTree: options.includeWorkingTree,
+    validationCommands: options.validationCommands,
+    runner: options.runner,
+    manifestPath: options.manifestPath,
+    output: options.output,
+    dryRun: true,
+  });
+  const located = locateScenario(draft.files, scenarioIdInput);
+  if ("error" in located) {
+    return finish(root, generatedAt, scenarioIdInput, undefined, blocked(located.error), options);
+  }
+  const { file, receipt: automation } = located;
+  const base = { title: automation.title, flowTitle: file.flowTitle, specPath: file.path };
+
+  if (automation.status !== "compiled") {
+    return finish(root, generatedAt, automation.scenarioId, base, blocked(
+      `The scenario is ${automation.status}, not compiled; run qamap e2e draft and resolve its blockers before executing it.`,
+    ), options);
+  }
+  if (!(await fileExists(path.join(root, file.path)))) {
+    return finish(root, generatedAt, automation.scenarioId, base, blocked(
+      `The draft ${file.path} is not written yet; run qamap e2e draft first.`,
+    ), options);
+  }
+  const executor = selectExecutor(options.config?.executors, options.executor, draft.runner);
+  if (!executor) {
+    return finish(root, generatedAt, automation.scenarioId, base, blocked(
+      options.executor
+        ? `No executor named ${options.executor} is configured in qamap.config.json.`
+        : `No executor is configured for the ${draft.runner} runner in qamap.config.json; add one under executors to make this scenario executable.`,
+    ), options);
+  }
+
+  const fixtureIds = options.config?.scenarioFixtures?.[automation.scenarioId] ?? [];
+  const fixtureDirectory = path.join(root, e2eRunFixtureDirectory, scenarioDirectoryName(automation.scenarioId));
+  const artifactDirectory = executor.config.artifactDirectory
+    ? path.resolve(root, executor.config.artifactDirectory)
+    : path.join(fixtureDirectory, "artifacts");
+  const fixtures = await prepareScenarioFixtures(root, fixtureIds, options.config?.fixtures ?? {}, fixtureDirectory);
+  if (fixtures.status === "blocked") {
+    return finish(root, generatedAt, automation.scenarioId, base, { ...blocked(fixtures.reason ?? "Fixture preparation failed."), fixtures }, options);
+  }
+
+  await fs.rm(artifactDirectory, { recursive: true, force: true });
+  await fs.mkdir(artifactDirectory, { recursive: true });
+  const reportPath = path.join(artifactDirectory, "executor-report.json");
+  const cwd = executor.config.cwd ? path.resolve(root, executor.config.cwd) : root;
+  const command = executor.config.command.map((token) => substituteTokens(token, {
+    file: toPosixPath(path.relative(cwd, path.join(root, file.path))) || file.path,
+    grep: grepPatternForTitle(automation.title, file.flowTitle),
+    scenarioId: automation.scenarioId,
+    fixtureDirectory,
+    artifactDirectory,
+  }));
+  const timeoutMs = options.timeoutMs ?? executor.config.timeoutMs ?? defaultExecutorTimeoutMs;
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    CI: "1",
+    FORCE_COLOR: "0",
+    NO_COLOR: "1",
+    ...executor.config.env,
+    QAMAP_SCENARIO_ID: automation.scenarioId,
+    QAMAP_FIXTURE_DIR: fixtureDirectory,
+    QAMAP_ARTIFACT_DIR: artifactDirectory,
+    PLAYWRIGHT_JSON_OUTPUT_NAME: reportPath,
+  };
+
+  const beforeGitState = await captureGitState(root);
+  const execution = await runBoundedCommand(command, cwd, timeoutMs, env);
+  const afterGitState = await captureGitState(root);
+
+  const parsed = executor.config.runner === "playwright"
+    ? await parsePlaywrightReport(reportPath, execution.stdoutText)
+    : undefined;
+  const assertions = parsed?.assertions ?? [{
+    title: "executor exit code 0",
+    status: !execution.timedOut && execution.exitCode === 0 ? "passed" as const : "failed" as const,
+    durationMs: execution.durationMs,
+    ...(execution.timedOut ? { error: `Timed out after ${timeoutMs}ms.` } : {}),
+  }];
+  const failed = execution.timedOut || execution.exitCode !== 0 || assertions.some((item) => item.status === "failed");
+  const artifacts = failed ? await collectArtifacts(root, artifactDirectory, parsed?.attachments ?? []) : [];
+
+  const receipt: E2eCompletedRunReceipt = {
+    status: failed ? "failed" : "passed",
+    performed: true,
+    scope: "scenario-executor",
+    executor: executor.name,
+    runner: executor.config.runner,
+    command,
+    cwd: toPosixPath(path.relative(root, cwd)) || ".",
+    ...(execution.exitCode !== undefined ? { exitCode: execution.exitCode } : {}),
+    ...(execution.signal ? { signal: execution.signal } : {}),
+    durationMs: execution.durationMs,
+    timedOut: execution.timedOut,
+    assertions,
+    artifacts,
+    fixtures,
+    stdoutBytes: execution.stdoutBytes,
+    stderrBytes: execution.stderrBytes,
+    stdoutSha256: execution.stdoutSha256,
+    stderrSha256: execution.stderrSha256,
+    gitState: compareGitState(beforeGitState, afterGitState),
+  };
+  return finish(root, generatedAt, automation.scenarioId, base, receipt, options);
+}
+
+export function diffE2eRunReceipts(previous: E2eRunReceipt, current: E2eRunReceipt): E2eRunComparison {
+  const previousAssertions = previous.status === "blocked" ? [] : previous.assertions;
+  const currentAssertions = current.status === "blocked" ? [] : current.assertions;
+  const previousByTitle = new Map(previousAssertions.map((item) => [item.title, item]));
+  const currentByTitle = new Map(currentAssertions.map((item) => [item.title, item]));
+  const added = currentAssertions.filter((item) => !previousByTitle.has(item.title)).map((item) => item.title);
+  const removed = previousAssertions.filter((item) => !currentByTitle.has(item.title)).map((item) => item.title);
+  const statusChanged = currentAssertions
+    .filter((item) => previousByTitle.has(item.title) && previousByTitle.get(item.title)?.status !== item.status)
+    .map((item) => ({ title: item.title, from: previousByTitle.get(item.title)!.status, to: item.status }));
+  let verdict: E2eRunComparisonVerdict = "same";
+  if (previous.status === "passed" && current.status === "failed") verdict = "regressed";
+  else if (previous.status === "failed" && current.status === "passed") verdict = "recovered";
+  else if (previous.status !== current.status || added.length > 0 || removed.length > 0 || statusChanged.length > 0) verdict = "changed";
+  const durationDeltaMs = previous.status !== "blocked" && current.status !== "blocked"
+    ? current.durationMs - previous.durationMs
+    : undefined;
+  return {
+    verdict,
+    previousStatus: previous.status,
+    currentStatus: current.status,
+    added,
+    removed,
+    statusChanged,
+    ...(durationDeltaMs !== undefined ? { durationDeltaMs } : {}),
+  };
+}
+
+export function formatMarkdownE2eRun(result: E2eRunResult): string {
+  const lines: string[] = [];
+  lines.push("# QAMap E2E Run");
+  lines.push("");
+  lines.push(`Scenario: ${result.scenarioId}`);
+  if (result.title) lines.push(`Title: ${result.title}`);
+  if (result.flowTitle) lines.push(`Flow: ${result.flowTitle}`);
+  if (result.specPath) lines.push(`Draft: ${result.specPath}`);
+  lines.push(`Status: ${result.receipt.status}`);
+  if (result.receipt.status === "blocked") {
+    lines.push(`Reason: ${result.receipt.reason}`);
+  } else {
+    const receipt = result.receipt;
+    lines.push(`Executor: ${receipt.executor} (${receipt.runner})`);
+    lines.push(`Duration: ${receipt.durationMs}ms${receipt.timedOut ? " (timed out)" : ""}`);
+    if (receipt.exitCode !== undefined) lines.push(`Exit code: ${receipt.exitCode}`);
+    lines.push(`Git-observable worktree changes: ${receipt.gitState.changed === null ? "unknown" : receipt.gitState.changed ? "yes" : "no"}`);
+    lines.push("");
+    lines.push("## Assertions");
+    lines.push("");
+    for (const assertion of receipt.assertions) {
+      lines.push(`- [${assertion.status}] ${assertion.title} (${assertion.durationMs}ms)${assertion.error ? ` — ${assertion.error}` : ""}`);
+    }
+    if (receipt.fixtures.fixtures.length > 0) {
+      lines.push("");
+      lines.push("## Fixtures");
+      lines.push("");
+      for (const fixture of receipt.fixtures.fixtures) {
+        lines.push(`- ${fixture.id} (${fixture.kind}): ${fixture.status}${fixture.sha256 ? ` sha256 ${fixture.sha256.slice(0, 12)}` : ""}`);
+      }
+    }
+    if (receipt.artifacts.length > 0) {
+      lines.push("");
+      lines.push("## Failure Artifacts");
+      lines.push("");
+      for (const artifact of receipt.artifacts) lines.push(`- ${artifact}`);
+    }
+  }
+  if (result.comparison) {
+    lines.push("");
+    lines.push("## Compared To Previous Run");
+    lines.push("");
+    lines.push(`Verdict: ${result.comparison.verdict} (${result.comparison.previousStatus} -> ${result.comparison.currentStatus})`);
+    for (const change of result.comparison.statusChanged) {
+      lines.push(`- ${change.title}: ${change.from} -> ${change.to}`);
+    }
+    for (const title of result.comparison.added) lines.push(`- added: ${title}`);
+    for (const title of result.comparison.removed) lines.push(`- removed: ${title}`);
+    if (result.comparison.durationDeltaMs !== undefined) {
+      lines.push(`- duration delta: ${result.comparison.durationDeltaMs >= 0 ? "+" : ""}${result.comparison.durationDeltaMs}ms`);
+    }
+  }
+  if (result.receiptPath) {
+    lines.push("");
+    lines.push(`Receipt: ${result.receiptPath}`);
+  }
+  if (result.nextSteps.length > 0) {
+    lines.push("");
+    lines.push("## Next Steps");
+    lines.push("");
+    for (const step of result.nextSteps) lines.push(`- ${step}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+// ── internals ───────────────────────────────────────────────────────────────
+
+function blocked(reason: string): E2eBlockedRunReceipt {
+  return { status: "blocked", performed: false, scope: "scenario-executor", reason };
+}
+
+async function finish(
+  root: string,
+  generatedAt: string,
+  scenarioId: string,
+  base: { title?: string; flowTitle?: string; specPath?: string } | undefined,
+  receipt: E2eRunReceipt,
+  options: E2eRunOptions,
+): Promise<E2eRunResult> {
+  const result: E2eRunResult = {
+    tool: { name: TOOL_NAME, version: VERSION },
+    root,
+    generatedAt,
+    scenarioId,
+    ...(base ?? {}),
+    receipt,
+    nextSteps: [],
+  };
+  if (receipt.status !== "blocked") {
+    const previous = await readLatestReceipt(root, scenarioId);
+    if (previous) {
+      result.comparison = diffE2eRunReceipts(previous.receipt, receipt);
+    }
+    result.receiptPath = await writeRunReceipt(root, {
+      scenarioId,
+      generatedAt,
+      title: base?.title,
+      specPath: base?.specPath,
+      receipt,
+    });
+  }
+  result.nextSteps = nextStepsFor(result, options);
+  return neutralizeInstructionLikeValues(result).value;
+}
+
+function nextStepsFor(result: E2eRunResult, options: E2eRunOptions): string[] {
+  const receipt = result.receipt;
+  if (receipt.status === "blocked") {
+    return [receipt.reason, "Nothing was executed; the scenario stays review evidence until the blocker is resolved."];
+  }
+  const steps: string[] = [];
+  if (receipt.status === "failed") {
+    steps.push("Inspect the failed assertions and the failure artifacts, fix the behavior, then rerun the same scenario id to compare receipts.");
+  } else {
+    steps.push("Keep this receipt as evidence; rerun the same scenario id after the next change to compare instead of re-driving the flow.");
+  }
+  if (receipt.gitState.changed) {
+    steps.push("The executor changed tracked or untracked files; review those changes before trusting the run.");
+  }
+  if (options.includeWorkingTree) {
+    steps.push("The draft was resolved against the working tree; commit before treating this receipt as pull request evidence.");
+  }
+  return steps;
+}
+
+function locateScenario(
+  files: E2eDraftFile[],
+  input: string,
+): { file: E2eDraftFile; receipt: E2eScenarioAutomationReceipt } | { error: string } {
+  const needle = input.trim();
+  const candidates: Array<{ file: E2eDraftFile; receipt: E2eScenarioAutomationReceipt }> = [];
+  for (const file of files) {
+    for (const receipt of file.scenarioAutomation ?? []) {
+      const id = receipt.scenarioId;
+      const hash = id.replace(/^scenario:/, "");
+      if (id === needle || `scenario:${needle}` === id || (needle.length >= 6 && hash.startsWith(needle.replace(/^scenario:/, "")))) {
+        candidates.push({ file, receipt });
+      }
+    }
+  }
+  const unique = candidates.filter((candidate, index) =>
+    candidates.findIndex((other) => other.receipt.scenarioId === candidate.receipt.scenarioId) === index
+  );
+  if (unique.length === 1) return unique[0];
+  if (unique.length > 1) {
+    return { error: `The id ${needle} matches ${unique.length} scenarios; pass the full scenario id.` };
+  }
+  return { error: `No drafted scenario matches ${needle}; run qamap qa or qamap e2e draft --dry-run to list scenario ids.` };
+}
+
+function selectExecutor(
+  executors: Record<string, QAMapExecutorConfig> | undefined,
+  requested: string | undefined,
+  runner: string,
+): { name: string; config: QAMapExecutorConfig } | undefined {
+  if (!executors) return undefined;
+  if (requested) {
+    const config = executors[requested];
+    return config ? { name: requested, config } : undefined;
+  }
+  const matching = Object.entries(executors).filter(([, config]) => config.runner === runner || config.runner === "command");
+  const preferred = matching.find(([, config]) => config.runner === runner) ?? matching[0];
+  return preferred ? { name: preferred[0], config: preferred[1] } : undefined;
+}
+
+function scenarioDirectoryName(scenarioId: string): string {
+  return scenarioId.replace(/^scenario:/, "").replace(/[^a-z0-9]/gi, "");
+}
+
+function substituteTokens(
+  token: string,
+  values: { file: string; grep: string; scenarioId: string; fixtureDirectory: string; artifactDirectory: string },
+): string {
+  return token
+    .replaceAll("{file}", values.file)
+    .replaceAll("{grep}", values.grep)
+    .replaceAll("{scenarioId}", values.scenarioId)
+    .replaceAll("{fixtureDir}", values.fixtureDirectory)
+    .replaceAll("{artifactDir}", values.artifactDirectory);
+}
+
+/** Playwright routes a scenario as `test("<flow>: <scenario>")`; grep by the scenario title alone so the primary flow test does not match. */
+function grepPatternForTitle(title: string, _flowTitle: string): string {
+  return escapeRegExp(title.replaceAll('"', "'"));
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function prepareScenarioFixtures(
+  root: string,
+  fixtureIds: string[],
+  declarations: Record<string, QAMapFixtureDeclaration>,
+  directory: string,
+): Promise<E2eFixturePreparationReceipt> {
+  await fs.rm(directory, { recursive: true, force: true });
+  await fs.mkdir(directory, { recursive: true });
+  const items: E2eFixtureReceiptItem[] = [];
+  for (const id of fixtureIds) {
+    const declaration = declarations[id];
+    const startedAt = Date.now();
+    if (!declaration) {
+      items.push({ id, kind: "file", status: "failed", durationMs: 0, reason: `Fixture ${id} is not declared in qamap.config.json.` });
+      continue;
+    }
+    if (declaration.kind === "file") {
+      const source = resolveInside(root, declaration.path);
+      const target = resolveInside(directory, declaration.target ?? path.basename(declaration.path));
+      if (!source || !target) {
+        items.push({ id, kind: "file", status: "failed", durationMs: 0, reason: `Fixture ${id} path must stay inside the repository.` });
+        continue;
+      }
+      try {
+        await fs.mkdir(path.dirname(target), { recursive: true });
+        await fs.copyFile(source, target);
+        items.push({ id, kind: "file", status: "materialized", sha256: await hashFile(target), durationMs: Date.now() - startedAt });
+      } catch (error) {
+        items.push({ id, kind: "file", status: "failed", durationMs: Date.now() - startedAt, reason: `Fixture ${id} could not be copied: ${errorMessage(error)}` });
+      }
+      continue;
+    }
+    const cwd = declaration.cwd ? resolveInside(root, declaration.cwd) : root;
+    if (!cwd) {
+      items.push({ id, kind: "seed", status: "failed", durationMs: 0, reason: `Fixture ${id} cwd must stay inside the repository.` });
+      continue;
+    }
+    const execution = await runBoundedCommand(declaration.command, cwd, declaration.timeoutMs ?? defaultSeedTimeoutMs, {
+      ...process.env,
+      CI: "1",
+      QAMAP_FIXTURE_DIR: directory,
+    });
+    if (execution.timedOut || execution.exitCode !== 0) {
+      items.push({
+        id,
+        kind: "seed",
+        status: "failed",
+        durationMs: execution.durationMs,
+        reason: execution.timedOut ? `Fixture ${id} seed hook timed out.` : `Fixture ${id} seed hook exited with ${execution.exitCode ?? "a signal"}.`,
+      });
+      continue;
+    }
+    items.push({ id, kind: "seed", status: "executed", durationMs: execution.durationMs });
+  }
+  const failed = items.filter((item) => item.status === "failed");
+  return {
+    status: failed.length > 0 ? "blocked" : "ready",
+    directory: toPosixPath(path.relative(root, directory)),
+    fixtures: items,
+    ...(failed.length > 0 ? { reason: failed.map((item) => item.reason).join(" ") } : {}),
+  };
+}
+
+interface BoundedExecution {
+  exitCode?: number;
+  signal?: string;
+  durationMs: number;
+  timedOut: boolean;
+  stdoutBytes: number;
+  stderrBytes: number;
+  stdoutSha256: string;
+  stderrSha256: string;
+  stdoutText: string;
+}
+
+const maxRetainedStdoutBytes = 8 * 1024 * 1024;
+
+/** Argument-vector spawn without a shell, bounded by a timeout that kills the whole process tree. */
+async function runBoundedCommand(command: string[], cwd: string, timeoutMs: number, env: NodeJS.ProcessEnv): Promise<BoundedExecution> {
+  const [file, ...args] = command;
+  const startedAt = Date.now();
+  const stdoutHash = createHash("sha256");
+  const stderrHash = createHash("sha256");
+  const stdoutChunks: Buffer[] = [];
+  let retained = 0;
+  let stdoutBytes = 0;
+  let stderrBytes = 0;
+  let timedOut = false;
+  return new Promise((resolve) => {
+    const child = spawn(file, args, { cwd, env, stdio: ["ignore", "pipe", "pipe"], detached: process.platform !== "win32" });
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdoutBytes += chunk.length;
+      stdoutHash.update(chunk);
+      if (retained < maxRetainedStdoutBytes) {
+        stdoutChunks.push(chunk);
+        retained += chunk.length;
+      }
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderrBytes += chunk.length;
+      stderrHash.update(chunk);
+    });
+    let spawnError: Error | undefined;
+    child.once("error", (error) => {
+      spawnError = error;
+    });
+    let forceKill: ReturnType<typeof setTimeout> | undefined;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      terminateProcessTree(child.pid, child, "SIGTERM");
+      forceKill = setTimeout(() => terminateProcessTree(child.pid, child, "SIGKILL"), 2_000);
+      forceKill.unref();
+    }, timeoutMs);
+    child.once("close", (exitCode, signal) => {
+      clearTimeout(timer);
+      if (forceKill) clearTimeout(forceKill);
+      resolve({
+        ...(exitCode !== null ? { exitCode } : spawnError ? { exitCode: 127 } : {}),
+        ...(signal ? { signal } : {}),
+        durationMs: Date.now() - startedAt,
+        timedOut,
+        stdoutBytes,
+        stderrBytes,
+        stdoutSha256: stdoutHash.digest("hex"),
+        stderrSha256: stderrHash.digest("hex"),
+        stdoutText: Buffer.concat(stdoutChunks).toString("utf8"),
+      });
+    });
+  });
+}
+
+interface ParsedExecutorReport {
+  assertions: E2eAssertionResult[];
+  attachments: string[];
+}
+
+/** Playwright's JSON reporter: nested suites -> specs -> tests -> results. Only the last result of each test counts. */
+async function parsePlaywrightReport(reportPath: string, stdoutText: string): Promise<ParsedExecutorReport | undefined> {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(await fs.readFile(reportPath, "utf8"));
+  } catch {
+    const start = stdoutText.indexOf("{");
+    if (start < 0) return undefined;
+    try {
+      raw = JSON.parse(stdoutText.slice(start));
+    } catch {
+      return undefined;
+    }
+  }
+  if (!raw || typeof raw !== "object") return undefined;
+  const assertions: E2eAssertionResult[] = [];
+  const attachments: string[] = [];
+  const walk = (suite: Record<string, unknown>, prefix: string[]): void => {
+    const title = typeof suite.title === "string" && suite.title.trim() ? [...prefix, suite.title.trim()] : prefix;
+    for (const spec of asArray(suite.specs)) {
+      const specTitle = typeof spec.title === "string" ? spec.title : "untitled";
+      for (const test of asArray(spec.tests)) {
+        const results = asArray(test.results);
+        const last = results[results.length - 1];
+        const status = normalizePlaywrightStatus(typeof last?.status === "string" ? last.status : undefined);
+        const error = last?.error && typeof last.error === "object" && typeof (last.error as Record<string, unknown>).message === "string"
+          ? String((last.error as Record<string, unknown>).message).replace(/\[[0-9;]*m/g, "").slice(0, maxAssertionErrorChars)
+          : undefined;
+        const projectName = typeof test.projectName === "string" && test.projectName ? ` [${test.projectName}]` : "";
+        assertions.push({
+          title: [...title.filter((part) => !/\.(spec|test)\.[jt]sx?$/.test(part)), specTitle].join(" > ") + projectName,
+          status,
+          durationMs: typeof last?.duration === "number" ? Math.round(last.duration) : 0,
+          ...(status === "failed" && error ? { error } : {}),
+        });
+        if (status === "failed") {
+          for (const attachment of asArray(last?.attachments)) {
+            if (typeof attachment.path === "string") attachments.push(attachment.path);
+          }
+        }
+      }
+    }
+    for (const child of asArray(suite.suites)) walk(child, title);
+  };
+  for (const suite of asArray((raw as Record<string, unknown>).suites)) walk(suite, []);
+  if (assertions.length === 0) return undefined;
+  return { assertions, attachments };
+}
+
+function normalizePlaywrightStatus(status: string | undefined): E2eAssertionResult["status"] {
+  if (status === "passed") return "passed";
+  if (status === "skipped") return "skipped";
+  return "failed";
+}
+
+function asArray(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value) ? value.filter((item): item is Record<string, unknown> => !!item && typeof item === "object") : [];
+}
+
+async function collectArtifacts(root: string, artifactDirectory: string, reported: string[]): Promise<string[]> {
+  const found = new Set<string>();
+  for (const candidate of reported) {
+    const absolute = path.isAbsolute(candidate) ? candidate : path.join(root, candidate);
+    if (await fileExists(absolute)) found.add(toPosixPath(path.relative(root, absolute)));
+  }
+  for (const absolute of await listFilesUnder(artifactDirectory)) {
+    if (path.basename(absolute) === "executor-report.json") continue;
+    found.add(toPosixPath(path.relative(root, absolute)));
+  }
+  return [...found].sort().slice(0, maxArtifacts);
+}
+
+async function listFilesUnder(directory: string, depth = 0): Promise<string[]> {
+  if (depth > 6) return [];
+  let entries;
+  try {
+    entries = await fs.readdir(directory, { withFileTypes: true });
+  } catch {
+    return []; // No artifact directory means the executor produced nothing beyond its report.
+  }
+  const files: string[] = [];
+  for (const entry of entries) {
+    const absolute = path.join(directory, entry.name);
+    if (entry.isFile()) files.push(absolute);
+    else if (entry.isDirectory()) files.push(...(await listFilesUnder(absolute, depth + 1)));
+  }
+  return files;
+}
+
+async function readLatestReceipt(root: string, scenarioId: string): Promise<StoredRunReceipt | undefined> {
+  try {
+    const raw = JSON.parse(await fs.readFile(path.join(root, e2eRunReceiptDirectory, scenarioDirectoryName(scenarioId), "latest.json"), "utf8"));
+    return raw && typeof raw === "object" && raw.receipt ? raw as StoredRunReceipt : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function writeRunReceipt(root: string, stored: StoredRunReceipt): Promise<string> {
+  const directory = path.join(root, e2eRunReceiptDirectory, scenarioDirectoryName(stored.scenarioId));
+  await fs.mkdir(directory, { recursive: true });
+  const fileName = `${stored.generatedAt.replace(/[:.]/g, "-")}.json`;
+  const text = `${JSON.stringify(stored, null, 2)}\n`;
+  await fs.writeFile(path.join(directory, fileName), text, "utf8");
+  await fs.writeFile(path.join(directory, "latest.json"), text, "utf8");
+  return toPosixPath(path.relative(root, path.join(directory, fileName)));
+}
+
+function resolveInside(root: string, relative: string): string | undefined {
+  const resolved = path.resolve(root, relative);
+  const relation = path.relative(root, resolved);
+  if (relation.startsWith("..") || path.isAbsolute(relation)) return undefined;
+  return resolved;
+}
+
+async function fileExists(file: string): Promise<boolean> {
+  try {
+    return (await fs.stat(file)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function hashFile(file: string): Promise<string> {
+  return createHash("sha256").update(await fs.readFile(file)).digest("hex");
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/e2e.ts
+++ b/src/e2e.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from "node:fs";
+import type { E2eScenarioExecutability } from "./e2e-run.js";
 import path from "node:path";
 import YAML from "yaml";
 import { analyzeBehaviorGraph, createInferredFlowBehaviorAdapter } from "./behavior.js";
@@ -375,6 +376,8 @@ export type E2eScenarioAutomationStatus = "compiled" | "partial" | "not-compiled
 
 export interface E2eScenarioAutomationReceipt {
   scenarioId: string;
+  /** Present once qamap qa has checked the repository's executor and fixture declarations. */
+  executable?: E2eScenarioExecutability;
   title: string;
   kind: IntentQaScenario["kind"];
   priority: IntentQaScenario["priority"];

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,14 @@ export {
 } from "./qa.js";
 export { formatMarkdownQaValidation, runQaValidation } from "./qa-execution.js";
 export {
+  assessScenarioExecutability,
+  diffE2eRunReceipts,
+  e2eRunFixtureDirectory,
+  e2eRunReceiptDirectory,
+  formatMarkdownE2eRun,
+  runE2eScenario,
+} from "./e2e-run.js";
+export {
   evaluateQaCapabilities,
   isInstructionLikeRepositoryText,
   neutralizeInstructionLikeValues,
@@ -376,6 +384,17 @@ export type {
   QaVerificationStatus,
 } from "./qa.js";
 export type { RunQaValidationOptions } from "./qa-execution.js";
+export type {
+  E2eAssertionResult,
+  E2eBlockedRunReceipt,
+  E2eCompletedRunReceipt,
+  E2eFixturePreparationReceipt,
+  E2eRunComparison,
+  E2eRunOptions,
+  E2eRunReceipt,
+  E2eRunResult,
+  E2eScenarioExecutability,
+} from "./e2e-run.js";
 export type {
   QaActionApproval,
   QaActionContract,

--- a/src/qa-execution.ts
+++ b/src/qa-execution.ts
@@ -313,14 +313,14 @@ async function executeSelectedCommand(
   });
 }
 
-interface GitStateSnapshot {
+export interface GitStateSnapshot {
   fingerprint: string;
   entries: Map<string, string>;
   head: string;
   branch: string;
 }
 
-async function captureGitState(root: string): Promise<GitStateSnapshot | undefined> {
+export async function captureGitState(root: string): Promise<GitStateSnapshot | undefined> {
   try {
     const [statusOutput, headOutput, branchOutput] = await Promise.all([
       runGitForState(root, ["status", "--porcelain=v1", "-z", "--untracked-files=all"]),
@@ -353,7 +353,7 @@ async function captureGitState(root: string): Promise<GitStateSnapshot | undefin
   }
 }
 
-function compareGitState(
+export function compareGitState(
   before: GitStateSnapshot | undefined,
   after: GitStateSnapshot | undefined,
 ): QaGitStateReceipt {
@@ -493,7 +493,7 @@ function sha256(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
-function terminateProcessTree(
+export function terminateProcessTree(
   pid: number | undefined,
   child: ReturnType<typeof spawn>,
   signal: NodeJS.Signals,

--- a/src/qa.ts
+++ b/src/qa.ts
@@ -1,4 +1,6 @@
 import { constants as fsConstants } from "node:fs";
+import { assessScenarioExecutability } from "./e2e-run.js";
+import type { QAMapConfig } from "./types.js";
 import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 import {
@@ -56,6 +58,8 @@ import { TOOL_NAME, VERSION } from "./version.js";
 
 export interface QaDraftOptions extends Omit<E2eDraftOptions, "dryRun" | "output"> {
   automaticWorkspaceScope?: boolean;
+  /** Executor and fixture declarations from qamap.config.json; marks which drafted scenarios qamap e2e run can execute now. */
+  config?: Pick<QAMapConfig, "executors" | "fixtures" | "scenarioFixtures">;
 }
 
 export interface QaDraftResult {
@@ -520,7 +524,7 @@ export async function generateQaDraft(rootInput: string, options: QaDraftOptions
       neutralizedValues: 0,
     },
     readiness,
-    flows,
+    flows: annotateExecutableScenarios(flows, options.config, draft.runner),
     missingEvidence,
     prChecklist: buildPrChecklist(
       draft,
@@ -1771,6 +1775,7 @@ function buildAgentQaSummary(
               id: receipt.scenarioId,
               decision: receipt.decision,
               status: receipt.status,
+              ...(receipt.executable?.status === "executable" ? { executable: true } : {}),
             })),
         evidence: flow.why.slice(0, 2).map((reason) => truncateForAgent(reason)),
       };
@@ -3427,6 +3432,15 @@ function appendQaDecisionLayers(
   if (nextCommand) {
     lines.push(`- Repository command: \`${escapeMarkdownInline(nextCommand)}\` (selected but not run by QAMap).`);
   }
+  const executableScenarios = [...automationByScenario.values()]
+    .map((entry) => entry.receipt)
+    .filter((receipt) => receipt.executable?.status === "executable")
+    .slice(0, 6);
+  for (const receipt of executableScenarios) {
+    lines.push(
+      `- Executable now: \`qamap e2e run ${receipt.scenarioId}\` for ${escapeMarkdownInline(receipt.title)} (executor ${receipt.executable?.executor}; not run by qamap qa).`,
+    );
+  }
   for (const flow of staticRunnableFlows.slice(0, 4)) {
     lines.push(
       `- Static-runnable draft: \`${escapeMarkdownInline(flow.draftPath)}\` for ${escapeMarkdownInline(flow.title)}; self-checks passed, target application not executed.`,
@@ -3463,6 +3477,9 @@ function appendQaDecisionLayers(
       }
       if (!verificationMode && automation?.blockers[0]) {
         lines.push(`  - Automation gap: ${escapeMarkdownInline(automation.blockers[0])}`);
+      }
+      if (automation?.executable?.status === "executable") {
+        lines.push(`  - Executable now: qamap e2e run ${scenario.id} (executor ${automation.executable.executor})`);
       }
     }
   }
@@ -4529,4 +4546,20 @@ function escapeMarkdownInline(value: string): string {
 
 function plainText(value: string): string {
   return value.replaceAll("`", "'").replace(/\s+/g, " ").trim();
+}
+
+/** Attach the executor and fixture check to each drafted scenario so qa can say which ones run now. */
+function annotateExecutableScenarios(
+  flows: QaDraftFlow[],
+  config: QaDraftOptions["config"],
+  runner: string,
+): QaDraftFlow[] {
+  if (!config?.executors) return flows;
+  return flows.map((flow) => ({
+    ...flow,
+    scenarioAutomation: flow.scenarioAutomation.map((receipt) => ({
+      ...receipt,
+      executable: assessScenarioExecutability(receipt, config, runner),
+    })),
+  }));
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,7 +60,30 @@ export interface QAMapConfig {
   maxFiles?: number;
   severity?: Record<string, Severity>;
   validationCommands?: string[];
+  executors?: Record<string, QAMapExecutorConfig>;
+  fixtures?: Record<string, QAMapFixtureDeclaration>;
+  scenarioFixtures?: Record<string, string[]>;
 }
+
+export type QAMapExecutorRunner = "playwright" | "command";
+
+/**
+ * A repository-owned scenario executor. QAMap never bundles a browser; it invokes
+ * the command the repository already uses and reads the result it produces.
+ * Tokens: {file} draft path, {grep} scenario title pattern, {scenarioId}, {fixtureDir}, {artifactDir}.
+ */
+export interface QAMapExecutorConfig {
+  runner: QAMapExecutorRunner;
+  command: string[];
+  cwd?: string;
+  timeoutMs?: number;
+  artifactDirectory?: string;
+  env?: Record<string, string>;
+}
+
+export type QAMapFixtureDeclaration =
+  | { kind: "file"; path: string; target?: string; description?: string }
+  | { kind: "seed"; command: string[]; cwd?: string; timeoutMs?: number; description?: string };
 
 export interface ResolvedQAMapConfig {
   path?: string;

--- a/test/cli-help.test.mjs
+++ b/test/cli-help.test.mjs
@@ -37,6 +37,7 @@ test("full help preserves advanced and compatibility commands", () => {
 
   assert.match(output, /qamap scan \[path\]/);
   assert.match(output, /qamap verify \[path\]/);
+  assert.match(output, /qamap e2e run <scenario-id> \[path\]/);
   assert.match(output, /qamap flows suggest \[path\]/);
   assert.match(output, /qamap domains suggest \[path\]/);
 });
@@ -47,4 +48,11 @@ test("QA help explains the analysis and execution boundary", () => {
   assert.match(output, /maps diff -> affected behavior -> risk -> scenario -> evidence/);
   assert.match(output, /Product QA and generated drafts remain marked not run/);
   assert.match(output, /executes only the selected existing\s+repository command/);
+});
+
+test("e2e help states the run execution boundary", () => {
+  const output = runCli("e2e", "--help");
+
+  assert.match(output, /qamap e2e run <scenario-id> \[path\]/);
+  assert.match(output, /Without a configured\s+executor or declared fixtures the receipt is blocked and nothing runs/);
 });

--- a/test/e2e-run.test.mjs
+++ b/test/e2e-run.test.mjs
@@ -1,0 +1,345 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, readFile, writeFile, cp, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+import {
+  assessScenarioExecutability,
+  diffE2eRunReceipts,
+  formatMarkdownE2eRun,
+  generateE2eDraft,
+  generateQaDraft,
+  runE2eScenario,
+} from "../dist/index.js";
+import { loadConfig } from "../dist/config.js";
+
+const execFileAsync = promisify(execFile);
+const cliPath = path.resolve("dist/cli.js");
+const fixtureRoot = path.resolve("test/benchmarks/web-symbol-annotated-renewal");
+
+/** Playwright-shaped executor stand-in: honours the JSON report path, fixture and artifact directories, and a mode file. */
+const fakeRunnerSource = `
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const [, , file, grep] = process.argv;
+const mode = (await fs.readFile("runner-mode.txt", "utf8")).trim();
+const fixtureDir = process.env.QAMAP_FIXTURE_DIR;
+const artifactDir = process.env.QAMAP_ARTIFACT_DIR;
+const report = process.env.PLAYWRIGHT_JSON_OUTPUT_NAME;
+if (!fixtureDir || !artifactDir || !report) {
+  throw new Error("executor environment is incomplete");
+}
+await fs.access(path.join(fixtureDir, "photo.bin"));
+const seeded = await fs.readFile(path.join(fixtureDir, "seeded.txt"), "utf8");
+if (seeded.trim() !== "seeded") throw new Error("seed hook did not run");
+const failed = mode === "fail";
+if (failed) {
+  await fs.writeFile(path.join(artifactDir, "shot.png"), "not really a png");
+}
+await fs.writeFile(report, JSON.stringify({
+  suites: [{
+    title: path.basename(file),
+    specs: [{
+      title: grep.replace(/\\\\/g, ""),
+      tests: [{
+        projectName: "chromium",
+        results: [{
+          status: failed ? "failed" : "passed",
+          duration: 12.4,
+          ...(failed ? { error: { message: "expected 1 request, received 2" }, attachments: [{ name: "screenshot", path: path.join(artifactDir, "shot.png"), contentType: "image/png" }] } : {}),
+        }],
+      }],
+    }],
+  }],
+}));
+process.exit(failed ? 1 : 0);
+`;
+
+async function makeRepository(t, configOverrides = {}) {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "qamap-e2e-run-"));
+  const root = path.join(tempRoot, "repo");
+  await mkdir(root, { recursive: true });
+  await cp(path.join(fixtureRoot, "base"), root, { recursive: true });
+  await git(root, ["init", "-b", "main"]);
+  await git(root, ["config", "user.email", "e2e-run-test@qamap.local"]);
+  await git(root, ["config", "user.name", "QAMap E2E Run Test"]);
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "baseline"]);
+  await git(root, ["switch", "-c", "feature/renewal"]);
+  await cp(path.join(fixtureRoot, "head"), root, { recursive: true, force: true });
+  await mkdir(path.join(root, "fixtures"), { recursive: true });
+  await writeFile(path.join(root, "fixtures", "photo.bin"), "binary-ish fixture bytes");
+  await writeFile(path.join(root, "fake-runner.mjs"), fakeRunnerSource);
+  await writeFile(path.join(root, "seed.mjs"), `
+import { promises as fs } from "node:fs";
+import path from "node:path";
+await fs.writeFile(path.join(process.env.QAMAP_FIXTURE_DIR, "seeded.txt"), "seeded\\n");
+`);
+  await writeFile(path.join(root, "runner-mode.txt"), "pass\n");
+  await git(root, ["add", "-A"]);
+  await git(root, ["commit", "-m", "feat: guard duplicate renewal requests"]);
+
+  const draft = await generateE2eDraft(root, { base: "main", head: "HEAD", output: "tests/e2e" });
+  const compiled = draft.files.flatMap((file) =>
+    file.scenarioAutomation.filter((receipt) => receipt.status === "compiled").map((receipt) => ({ file, receipt }))
+  );
+  assert.ok(compiled.length > 0, "the renewal fixture must compile at least one scenario");
+  const { receipt } = compiled.find((entry) => /duplicate renewal request/i.test(entry.receipt.title)) ?? compiled[0];
+
+  const config = {
+    executors: {
+      fake: { runner: "playwright", command: ["node", "fake-runner.mjs", "{file}", "{grep}"] },
+    },
+    fixtures: {
+      photo: { kind: "file", path: "fixtures/photo.bin" },
+      seeded: { kind: "seed", command: ["node", "seed.mjs"] },
+    },
+    scenarioFixtures: { [receipt.scenarioId]: ["photo", "seeded"] },
+    ...configOverrides,
+  };
+  await writeFile(path.join(root, "qamap.config.json"), `${JSON.stringify(config, null, 2)}\n`);
+  t.after(async () => {
+    // Leave temp directories for the operating system; nothing else to tear down.
+  });
+  return { root, scenarioId: receipt.scenarioId, title: receipt.title };
+}
+
+function options(root) {
+  return { base: "main", head: "HEAD", includeWorkingTree: true, output: "tests/e2e" };
+}
+
+async function loadRepoConfig(root) {
+  return (await loadConfig(root)).config;
+}
+
+async function git(cwd, args) {
+  await execFileAsync("git", args, { cwd });
+}
+
+test("e2e run executes a compiled scenario through the configured executor and stores a receipt", async (t) => {
+  const { root, scenarioId, title } = await makeRepository(t);
+  const config = await loadRepoConfig(root);
+
+  const result = await runE2eScenario(root, scenarioId, { ...options(root), config });
+
+  assert.equal(result.scenarioId, scenarioId);
+  assert.equal(result.title, title);
+  assert.match(result.specPath, /^tests\/e2e\/.+\.spec\.ts$/);
+  assert.equal(result.receipt.status, "passed");
+  assert.equal(result.receipt.performed, true);
+  assert.equal(result.receipt.executor, "fake");
+  assert.equal(result.receipt.runner, "playwright");
+  assert.equal(result.receipt.exitCode, 0);
+  assert.equal(result.receipt.timedOut, false);
+  assert.deepEqual(result.receipt.command.slice(0, 2), ["node", "fake-runner.mjs"]);
+  assert.match(result.receipt.command[2], /\.spec\.ts$/);
+  assert.equal(result.receipt.assertions.length, 1);
+  assert.equal(result.receipt.assertions[0].status, "passed");
+  assert.match(result.receipt.assertions[0].title, /\[chromium\]$/);
+  assert.ok(result.receipt.assertions[0].durationMs >= 12);
+  assert.deepEqual(result.receipt.artifacts, []);
+  assert.equal(result.receipt.fixtures.status, "ready");
+  assert.deepEqual(
+    result.receipt.fixtures.fixtures.map((item) => [item.id, item.kind, item.status]),
+    [["photo", "file", "materialized"], ["seeded", "seed", "executed"]],
+  );
+  assert.match(result.receipt.fixtures.fixtures[0].sha256, /^[a-f0-9]{64}$/);
+  assert.match(result.receipt.stdoutSha256, /^[a-f0-9]{64}$/);
+  assert.equal(result.receipt.gitState.observed, true);
+  assert.equal(result.comparison, undefined);
+  assert.match(result.receiptPath, /^\.qamap\/runs\/e2e\/[a-f0-9]+\/.+\.json$/);
+  const stored = JSON.parse(await readFile(path.join(root, ".qamap/runs/e2e", scenarioId.replace("scenario:", ""), "latest.json"), "utf8"));
+  assert.equal(stored.receipt.status, "passed");
+  assert.doesNotMatch(JSON.stringify(result), /expected 1 request/);
+
+  const markdown = formatMarkdownE2eRun(result);
+  assert.match(markdown, /# QAMap E2E Run/);
+  assert.match(markdown, /Status: passed/);
+  assert.match(markdown, /\[passed\] .*\(1[0-9]ms\)/);
+  assert.match(markdown, /photo \(file\): materialized sha256/);
+});
+
+test("a failing run keeps assertion errors and failure-only artifacts, and reruns compare receipts", async (t) => {
+  const { root, scenarioId } = await makeRepository(t);
+  const config = await loadRepoConfig(root);
+
+  const passed = await runE2eScenario(root, scenarioId, { ...options(root), config });
+  assert.equal(passed.receipt.status, "passed");
+
+  await writeFile(path.join(root, "runner-mode.txt"), "fail\n");
+  const failed = await runE2eScenario(root, scenarioId, { ...options(root), config });
+  assert.equal(failed.receipt.status, "failed");
+  assert.equal(failed.receipt.exitCode, 1);
+  assert.equal(failed.receipt.assertions[0].status, "failed");
+  assert.match(failed.receipt.assertions[0].error, /expected 1 request, received 2/);
+  assert.deepEqual(failed.receipt.artifacts, [`.qamap/tmp/e2e-run/${scenarioId.replace("scenario:", "")}/artifacts/shot.png`]);
+  assert.equal(failed.comparison.verdict, "regressed");
+  assert.deepEqual(failed.comparison.statusChanged.map((item) => [item.from, item.to]), [["passed", "failed"]]);
+  assert.match(formatMarkdownE2eRun(failed), /Verdict: regressed \(passed -> failed\)/);
+  assert.match(formatMarkdownE2eRun(failed), /## Failure Artifacts/);
+
+  await writeFile(path.join(root, "runner-mode.txt"), "pass\n");
+  const recovered = await runE2eScenario(root, scenarioId, { ...options(root), config });
+  assert.equal(recovered.receipt.status, "passed");
+  assert.equal(recovered.comparison.verdict, "recovered");
+  assert.deepEqual(recovered.receipt.artifacts, []);
+
+  const same = await runE2eScenario(root, scenarioId, { ...options(root), config });
+  assert.equal(same.comparison.verdict, "same");
+});
+
+test("missing executor, unknown scenario, failed fixture, and uncompiled scenarios are blocked instead of passed", async (t) => {
+  const { root, scenarioId } = await makeRepository(t);
+
+  const noExecutor = await runE2eScenario(root, scenarioId, { ...options(root), config: { fixtures: {}, scenarioFixtures: {} } });
+  assert.equal(noExecutor.receipt.status, "blocked");
+  assert.equal(noExecutor.receipt.performed, false);
+  assert.match(noExecutor.receipt.reason, /No executor is configured/);
+  assert.equal(noExecutor.receiptPath, undefined);
+
+  const unknown = await runE2eScenario(root, "scenario:000000000000", { ...options(root), config: await loadRepoConfig(root) });
+  assert.equal(unknown.receipt.status, "blocked");
+  assert.match(unknown.receipt.reason, /No drafted scenario matches/);
+
+  const badFixtureConfig = {
+    ...(await loadRepoConfig(root)),
+    fixtures: { photo: { kind: "file", path: "fixtures/missing.bin" }, seeded: { kind: "seed", command: ["node", "seed.mjs"] } },
+  };
+  const missingFixture = await runE2eScenario(root, scenarioId, { ...options(root), config: badFixtureConfig });
+  assert.equal(missingFixture.receipt.status, "blocked");
+  assert.match(missingFixture.receipt.reason, /could not be copied/);
+  assert.equal(missingFixture.receipt.fixtures.status, "blocked");
+  assert.equal(missingFixture.receipt.fixtures.fixtures[0].status, "failed");
+
+  const escapingFixture = {
+    ...(await loadRepoConfig(root)),
+    fixtures: { photo: { kind: "file", path: "../outside.bin" }, seeded: { kind: "seed", command: ["node", "seed.mjs"] } },
+  };
+  const escaped = await runE2eScenario(root, scenarioId, { ...options(root), config: escapingFixture });
+  assert.equal(escaped.receipt.status, "blocked");
+  assert.match(escaped.receipt.reason, /inside the repository/);
+
+  assert.deepEqual(
+    assessScenarioExecutability({ scenarioId, status: "partial" }, await loadRepoConfig(root)).status,
+    "not-compiled",
+  );
+  assert.deepEqual(
+    assessScenarioExecutability({ scenarioId, status: "compiled" }, { executors: {}, fixtures: {}, scenarioFixtures: {} }).status,
+    "executor-missing",
+  );
+  assert.deepEqual(
+    assessScenarioExecutability({ scenarioId, status: "compiled" }, await loadRepoConfig(root)),
+    { status: "executable", executor: "fake", fixtureIds: ["photo", "seeded"], reason: "A compiled scenario, a configured executor, and declared fixtures are all present." },
+  );
+});
+
+test("qamap qa marks scenarios executable when the executor and fixtures are declared", async (t) => {
+  const { root, scenarioId } = await makeRepository(t);
+  const config = await loadRepoConfig(root);
+
+  const draft = await generateQaDraft(root, { base: "main", head: "HEAD", includeWorkingTree: true, config });
+  const receipts = draft.flows.flatMap((flow) => flow.scenarioAutomation);
+  const target = receipts.find((receipt) => receipt.scenarioId === scenarioId);
+  assert.ok(target, "the executed scenario must appear in the qa draft");
+  assert.equal(target.executable?.status, "executable");
+  assert.equal(target.executable?.executor, "fake");
+  assert.ok(receipts.filter((receipt) => receipt.status !== "compiled").every((receipt) => receipt.executable?.status === "not-compiled"));
+
+  const { stdout } = await execFileAsync(process.execPath, [cliPath, "qa", root, "--base", "main", "--head", "HEAD", "--include-working-tree", "--format", "markdown"]);
+  assert.match(stdout, new RegExp(`Executable now: \`qamap e2e run ${scenarioId}\` for .* \\(executor fake; not run by qamap qa\\)`));
+
+  // The compact agent payload may drop scenario automation under its byte limit; the recoverable full report keeps it.
+  const agent = await execFileAsync(process.execPath, [cliPath, "qa", root, "--base", "main", "--head", "HEAD", "--include-working-tree", "--format", "agent"]);
+  const agentPayload = JSON.parse(agent.stdout);
+  const fullReportPath = agentPayload.compaction?.fullReport ?? agentPayload.context?.recovery?.fullReport;
+  const fullReport = fullReportPath ? await readFile(fullReportPath, "utf8") : agent.stdout;
+  assert.match(fullReport, new RegExp(`"scenarioId": ?"${scenarioId}"[\\s\\S]{0,400}"executable": ?\\{[\\s\\S]{0,80}"status": ?"executable"`));
+});
+
+test("qamap e2e run returns the receipt as json or markdown with exit codes for passed, failed, and blocked", async (t) => {
+  const { root, scenarioId } = await makeRepository(t);
+  const run = (...args) => execFileAsync(process.execPath, [cliPath, "e2e", "run", ...args], { cwd: root }).then(
+    (result) => ({ code: 0, stdout: result.stdout }),
+    (error) => ({ code: error.code, stdout: error.stdout ?? "" }),
+  );
+
+  const passed = await run(scenarioId, root, "--base", "main", "--head", "HEAD", "--include-working-tree", "--format", "json");
+  assert.equal(passed.code, 0);
+  const payload = JSON.parse(passed.stdout);
+  assert.equal(payload.receipt.status, "passed");
+  assert.equal(payload.scenarioId, scenarioId);
+
+  await writeFile(path.join(root, "runner-mode.txt"), "fail\n");
+  const failed = await run(scenarioId, root, "--base", "main", "--head", "HEAD", "--include-working-tree");
+  assert.equal(failed.code, 1);
+  assert.match(failed.stdout, /Status: failed/);
+  assert.match(failed.stdout, /Verdict: regressed/);
+
+  const blocked = await run("scenario:000000000000", root, "--base", "main", "--head", "HEAD", "--include-working-tree");
+  assert.equal(blocked.code, 2);
+  assert.match(blocked.stdout, /Status: blocked/);
+
+  const withoutId = await run(root);
+  assert.notEqual(withoutId.code, 0);
+
+  const prefix = await run(scenarioId.replace("scenario:", "").slice(0, 8), root, "--base", "main", "--head", "HEAD", "--include-working-tree", "--format", "json");
+  assert.equal(prefix.code, 1);
+  assert.equal(JSON.parse(prefix.stdout).scenarioId, scenarioId);
+});
+
+test("config validation rejects executors without a file token and bindings to undeclared fixtures", async (t) => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "qamap-e2e-run-config-"));
+  const write = (value) => writeFile(path.join(tempRoot, "qamap.config.json"), JSON.stringify(value));
+
+  await write({ executors: { web: { runner: "playwright", command: ["pnpm", "exec", "playwright", "test"] } } });
+  await assert.rejects(loadConfig(tempRoot), /must reference \{file\}/);
+
+  await write({ executors: { web: { runner: "browser", command: ["x", "{file}"] } } });
+  await assert.rejects(loadConfig(tempRoot), /runner must be playwright or command/);
+
+  await write({ executors: { web: { runner: "command", command: ["x", "{file}", "{nope}"] } } });
+  await assert.rejects(loadConfig(tempRoot), /unknown token \{nope\}/);
+
+  await write({ fixtures: { photo: { kind: "blob", path: "a" } } });
+  await assert.rejects(loadConfig(tempRoot), /kind must be file or seed/);
+
+  await write({ fixtures: { photo: { kind: "file", path: "a.jpg" } }, scenarioFixtures: { "scenario:abcdef123456": ["photo", "ghost"] } });
+  await assert.rejects(loadConfig(tempRoot), /references unknown fixture ghost/);
+
+  await write({ scenarioFixtures: { "compose-thumbnail": [] } });
+  await assert.rejects(loadConfig(tempRoot), /must be a scenario id/);
+
+  await write({
+    executors: { web: { runner: "playwright", command: ["pnpm", "exec", "playwright", "test", "{file}", "--grep", "{grep}", "--reporter=json"], timeoutMs: 120000, env: { CI: "1" } } },
+    fixtures: { photo: { kind: "file", path: "fixtures/geo-photo.jpg", description: "geotagged sample" }, seed: { kind: "seed", command: ["node", "scripts/seed.mjs"], timeoutMs: 5000 } },
+    scenarioFixtures: { "scenario:abcdef123456": ["photo", "seed"] },
+  });
+  const { config } = await loadConfig(tempRoot);
+  assert.equal(config.executors.web.runner, "playwright");
+  assert.equal(config.executors.web.timeoutMs, 120000);
+  assert.deepEqual(config.scenarioFixtures, { "scenario:abcdef123456": ["photo", "seed"] });
+  assert.equal(config.fixtures.photo.description, "geotagged sample");
+  assert.ok(await stat(path.join(tempRoot, "qamap.config.json")));
+});
+
+test("diffE2eRunReceipts reports added, removed, and changed assertions", () => {
+  const base = { status: "passed", performed: true, scope: "scenario-executor", durationMs: 100, assertions: [
+    { title: "a", status: "passed", durationMs: 1 },
+    { title: "b", status: "passed", durationMs: 1 },
+  ] };
+  const next = { ...base, status: "failed", durationMs: 140, assertions: [
+    { title: "a", status: "failed", durationMs: 1 },
+    { title: "c", status: "passed", durationMs: 1 },
+  ] };
+  const comparison = diffE2eRunReceipts(base, next);
+  assert.equal(comparison.verdict, "regressed");
+  assert.deepEqual(comparison.added, ["c"]);
+  assert.deepEqual(comparison.removed, ["b"]);
+  assert.deepEqual(comparison.statusChanged, [{ title: "a", from: "passed", to: "failed" }]);
+  assert.equal(comparison.durationDeltaMs, 40);
+  assert.equal(diffE2eRunReceipts(base, base).verdict, "same");
+  assert.equal(diffE2eRunReceipts({ status: "blocked", performed: false, scope: "scenario-executor", reason: "x" }, base).verdict, "changed");
+});


### PR DESCRIPTION
## Summary

QAMap already answers what to verify and drafts E2E scenarios, but verification still restarted from scratch after that hand-off: hand-built fixtures, step-by-step browser driving, screenshots judged by eye. This adds `qamap e2e run <scenario-id>`: it resolves one compiled scenario to its draft, materializes the fixtures the repository declared for that scenario, invokes the executor the repository configured, and returns a receipt with pass/fail per assertion, timing, and failure-only artifacts. Receipts persist under `.qamap/runs/e2e`, so rerunning the same id after a fix compares receipts instead of re-driving the flow. `qamap qa` now marks which drafted scenarios are executable.

## Behavioral Contract

- `qamap.config.json` gains `executors` (runner `playwright` or `command`, an argument-vector `command` run without a shell that must reference `{file}` and may use `{grep}`, `{scenarioId}`, `{fixtureDir}`, `{artifactDir}`), `fixtures` (`file` copies a repository file; `seed` runs a hook without a shell; paths must stay inside the repository), and `scenarioFixtures` (scenario id to fixture ids). Invalid shapes fail config loading with a specific message.
- `qamap qa` attaches `executable` (`executable`, `executor-missing`, `fixtures-missing`, `not-compiled`) to each scenario automation receipt when executors are configured, lists executable scenarios under "Executable Evidence Available Now" as `qamap e2e run <id>` (explicitly not run by `qa`), and the compact agent payload carries `executable: true`.
- `qamap e2e run <scenario-id>` accepts the full id or a unique hash prefix, regenerates the draft index, and returns `blocked` — nothing executed — when the scenario is not found, not compiled, the draft file is not written, no executor is configured, or any declared fixture fails to materialize. Otherwise it runs the executor with `QAMAP_SCENARIO_ID`, `QAMAP_FIXTURE_DIR`, `QAMAP_ARTIFACT_DIR`, and `PLAYWRIGHT_JSON_OUTPUT_NAME` set, parses the Playwright JSON reporter into per-assertion results (exit code only for `command` executors), keeps artifacts only when the run failed, hashes stdout/stderr instead of storing them, records git-observable worktree changes, writes the receipt, and compares it with the previous receipt for the same id (`same`, `regressed`, `recovered`, `changed`). Exit codes: passed 0, failed 1, blocked 2.
- Scenarios without a configured executor keep today's draft-only behavior; `e2e plan`, `setup`, and `draft` are unchanged.

## Evidence

Closes #210.

- Execution contract: `web-repeated-action-guard` in `execution-bench.config.json` now also runs the compiled "Duplicate renewal request" scenario through `qamap e2e run` with a real Playwright executor — `failed` on the seeded regression, `passed` on the fix, comparison verdict `recovered`. The scenario is resolved from the committed range so its id stays stable while the overlays change the working tree the executor runs against.
- Focused tests (`test/e2e-run.test.mjs`): a Playwright-shaped executor stand-in proves fixture materialization (file sha256, seed hook executed), per-assertion results with project names, failure-only artifacts, receipt persistence, `regressed`/`recovered`/`same` comparisons, every blocked path (no executor, unknown id, missing fixture, fixture path escaping the repository, uncompiled scenario), `qamap qa` executable marking in markdown and the recoverable agent report, CLI json/markdown output with exit codes, and config validation errors. Negative control: a blocked run stores no receipt and reports `performed: false`.
- `test/cli-help.test.mjs` pins the new usage line and the execution-boundary wording.

## Checks

- [x] Focused regression test
- [x] `pnpm test`
- [x] `pnpm bench:ci` for inference, routing, trace, or output
- [x] `pnpm bench:execution` for E2E compiler or execution fixtures
- [x] `pnpm scan` for scanner, security, or repository policy
- [ ] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
- [x] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

`pnpm bench:context` (10/10), `pnpm plugin:check`, and `pnpm plugin:smoke` also pass locally; plugin checks are marked N/A because no plugin asset changed. Maestro executors are out of scope for this change: the executor interface is runner-neutral, but only the Playwright JSON reporter is parsed today and `command` executors report the exit code as a single assertion. Scenario selection uses `--grep` on the scenario title, which matches how routed scenarios are named in drafts; primary-flow tests are not selected by id. Receipts store hashes of executor output, never the output itself, matching the `qa run` evidence boundary. Docs updated: commands, configuration fields and example, architecture execution boundary, README tables (en, ko), and an `Unreleased` changelog section that also records the two scanner additions merged since 0.4.14.