### PR TITLE
Chore: prepare 0.4.15 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qamap",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Turn PR changes into traceable local QA decisions and optional automation handoffs without an LLM call.",
   "author": {
     "name": "IvoryCanvas",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qamap",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Turn PR changes into traceable local QA decisions and optional automation handoffs without an LLM call.",
   "author": {
     "name": "IvoryCanvas",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.15 - 2026-08-26
 
 ### Added
 

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -26,6 +26,44 @@ a new runtime guarantee beyond the declared Node.js `>=20` engine contract.
 Node.js 20 is upstream EOL, so the README recommends an actively supported LTS
 release even though the compatibility smoke still passes.
 
+## 0.4.15 - 2026-08-26
+
+QAMap 0.4.15 adds a bounded path from a compiled QA scenario to local execution
+without making execution implicit. A repository can declare one executor, its
+fixtures, and scenario-to-fixture mapping in `qamap.config.json`; the explicit
+`qamap e2e run` command then records assertion results, timing, failure-only
+artifacts, and rerun comparison under an owner-controlled local directory.
+
+The release also improves static QA selection. Account-scoped client storage
+without an owner discriminator and divergent user-facing copy across related
+surfaces become evidence-backed review scenarios. Independent feature commits
+remain separate, identifier matching respects symbol boundaries, and every
+applicable changed test or benchmark command remains visible even though
+`qamap qa run` retains its single-command execution limit.
+
+A provider-neutral agent benchmark is included for opt-in measurement. The
+release gate uses only its deterministic dry-run assertion, so the receipt below
+does not claim a model-token saving or call an external model provider.
+
+| Gate | Candidate result |
+| --- | --- |
+| `pnpm release:check` | Passed end to end |
+| `pnpm test` | 412/412 passing |
+| `pnpm scan` | 0 findings |
+| `pnpm bench:ci` | 35/35 committed static recommendation contracts passing |
+| `pnpm bench:agent --dry-run --assert` | Offline harness and result-shape contract passed; no provider invoked |
+| `pnpm bench:context` | 10/10 context identity and reuse checks passing |
+| `pnpm bench:execution` | 3/3 execution contracts passing; all three seeded regressions caught |
+| Coverage | Lines 90.70%, branches 87.15%, functions 95.99% |
+| Plugin package smoke | Packed 198 files, installed the 0.4.15 artifact in isolation, and produced evidence-backed agent output |
+| Package preview | `pnpm pack --dry-run` passes for `@ivorycanvas/qamap@0.4.15`; 198 files packed |
+
+These gates prove deterministic selection, package integrity, and known seeded
+regressions in committed public fixtures. They do not prove arbitrary product
+behavior, turn a generated draft into passing QA, or establish a universal
+token-reduction ratio. npm publication, Git tagging, the GitHub Release, and an
+OpenAI directory update remain separate post-merge actions.
+
 ## 0.4.14 - 2026-08-20
 
 QAMap 0.4.14 strengthens the path from a pull request diff to the evidence a

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,40 +36,41 @@ Before treating the next public release as ready, the golden demo must satisfy t
 
 There is no fixed end date or patch count for `0.4.x`. QAMap will remain on compatible patch releases while real repositories still expose material gaps in change intent, affected-flow selection, scenario evidence, or automation-draft quality. `0.5.x` is not the next scheduled milestone; it is a release bar that must be earned by a stable, explicitly approved execution contract and evidence from repeated use outside the maintainer's repositories.
 
-### Current Focus After 0.4.14
+### Current Focus After 0.4.15
 
 The OpenAI Plugin Directory is a real first-run surface, so the next patches
 continue to prioritize recommendation quality over another distribution channel
 or runner name. The current generalized work queue is:
 
-1. Preserve every repository-owned validation contract changed by a pull
-   request. QAMap now keeps matching test and benchmark commands visible while
-   retaining a single-command `qa run` boundary. The next step is extending the
-   same coverage to public schemas and their consumers, package metadata, and
-   release manifests without reducing them to one convenient focused test.
-2. Treat changed repository tests as behavior contracts. Preserve explicit
+1. Prefer bounded offline validation when a repository exposes both a
+   deterministic contract and a provider-backed measurement command. External
+   model calls and token cost must remain an explicit, separately approved step.
+2. Expand declared executor coverage beyond the current browser fixtures. Add
+   unrelated API, CLI, or mobile controls that prove the same generated artifact
+   fails for its intended seeded regression and passes for the fixed behavior.
+3. Treat changed repository tests as behavior contracts. Preserve explicit
    positive, negative, boundary, state-transition, retry, and invariance
    assertions instead of reducing them to a generic request to run the suite.
-3. Trace shared semantic producers to every affected consumer. A change to a
+4. Trace shared semantic producers to every affected consumer. A change to a
    mapper, copy builder, aggregate, or service rule should retain the screens,
    history views, notifications, and exports that reuse its result when import
    and data-flow evidence connect them.
-4. Expand runtime lifecycle modeling beyond one guard and one process. Changes
+5. Expand runtime lifecycle modeling beyond one guard and one process. Changes
    that control workers, webhooks, deploy reconciliation, drains, or restarts
    should expose each execution plane and the fail-closed transition between
    disabled and enabled states.
-5. Extract framework-neutral presentation contracts from changed UI code only
+6. Extract framework-neutral presentation contracts from changed UI code only
    when the diff carries observable interaction or visual evidence. Formatting
    and resource vocabulary must remain contextual.
-6. Keep repository workflow metadata in its own behavior class. Documentation,
+7. Keep repository workflow metadata in its own behavior class. Documentation,
    issue forms, pull-request templates, package releases, and deployment
    transports should route to their exact repository contract instead of a
    fabricated product journey.
-7. Turn each real miss into a domain-neutral public fixture with a positive
+8. Turn each real miss into a domain-neutral public fixture with a positive
    contract and an unrelated negative control. A shared heuristic is incomplete
    until both sides pass the static benchmark and existing execution contracts
    remain honest.
-8. Re-run the published skill against unrelated repositories and compare its
+9. Re-run the published skill against unrelated repositories and compare its
    deterministic result with independent review. Preserve `not-run`, `passed`,
    `failed`, and `blocked` exactly; plugin availability is not evidence that
    product QA ran.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Local zero-LLM PR QA designer that maps commit intent and diffs to traceable behavior lifecycles, QA scenarios, and optional automation drafts.",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugin/submission.json
+++ b/plugin/submission.json
@@ -73,5 +73,5 @@
       "reason": "The plugin must preserve the host's approval policy and QAMap's explicit action boundary."
     }
   ],
-  "releaseNotes": "QAMap 0.4.14 separates stable repository QA context from each pull request delta, traces delivery and runtime activation risks, preserves independent intents, and adds a deterministic context reuse benchmark."
+  "releaseNotes": "QAMap 0.4.15 adds repository-declared E2E execution receipts, detects account-scoped storage and divergent-copy risks, preserves every applicable validation contract, and adds an opt-in provider-neutral agent benchmark."
 }

--- a/skills/qamap-pr-qa/SKILL.md
+++ b/skills/qamap-pr-qa/SKILL.md
@@ -21,7 +21,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
    If QAMap is not installed, disclose that the next command downloads the pinned package from the npm registry and follow the host's network approval policy before running it:
 
    ```sh
-   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.14 -- qamap qa . --base <base> --head HEAD --format agent
+   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.15 -- qamap qa . --base <base> --head HEAD --format agent
    ```
 
    This one-off form runs outside the target repository's package-manager contract, so it does not invoke Corepack or add a `packageManager` field. QAMap's analysis does not upload source code or make another LLM call. The calling agent still uses its own model tokens to invoke the skill and interpret the compact result.
@@ -37,7 +37,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
    - Use an explicit scoped pass only when a human wants to override that decision:
 
    ```sh
-   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.14 -- qamap qa <package-path> --workspace-root . --base <base> --head HEAD
+   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.15 -- qamap qa <package-path> --workspace-root . --base <base> --head HEAD
    ```
 
 4. Read and verify intent before generating code. In agent format:
@@ -60,7 +60,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
    - `run-repository-command` — when policy permits repository code execution, prefer QAMap's bounded executor so analysis and execution share one receipt:
 
      ```sh
-     npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.14 -- qamap qa run . --base <base> --head HEAD --format agent
+     npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.15 -- qamap qa run . --base <base> --head HEAD --format agent
      ```
 
      It re-analyzes the change and runs only the exact selected existing repository command. Do not substitute another command or run it again when `execution.performed` is true.
@@ -70,7 +70,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
 6. Only after a human or team accepts the scenario and automation adapter, create or preview executable coverage:
 
    ```sh
-   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.14 -- qamap e2e draft . --base <base> --head HEAD --dry-run
+   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.15 -- qamap e2e draft . --base <base> --head HEAD --dry-run
    ```
 
    If the selected adapter is absent, inspect and explicitly accept the `automation.setupCommand` proposal. Never install a runner merely because QAMap detected a web or mobile surface.
@@ -106,7 +106,7 @@ When the recommendation is wrong or too broad, do not repeatedly re-prompt for t
 If the team accepts QAMap for ongoing use, suggest this follow-up:
 
 ```sh
-npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.14 -- qamap manifest init .
+npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.15 -- qamap manifest init .
 ```
 
 Then humans should review `.qamap/manifest.yaml` and keep only durable team QA language.

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const TOOL_NAME = "QAMap";
-export const VERSION = "0.4.14";
+export const VERSION = "0.4.15";


### PR DESCRIPTION
## Summary

Prepare QAMap 0.4.15 by synchronizing package and plugin versions, documenting the merged static QA and bounded execution improvements, recording the completed release gates, and updating the post-release roadmap.

## Behavioral Contract

No new analyzer behavior is introduced by this release-preparation PR. The 0.4.15 package exposes the already merged account-scoped storage, divergent-copy, repository-declared E2E execution, validation-contract preservation, intent-isolation, identifier-boundary, and provider-neutral benchmark behavior under one synchronized version.

The release documentation keeps static QA, generated drafts, repository validation, provider-backed measurement, and executed product QA as separate evidence states. npm publication, Git tagging, the GitHub Release, and any OpenAI directory replacement remain post-merge actions.

## Evidence

Closes #219.

Release evidence:
- 412/412 unit and integration tests passed
- 35/35 static recommendation contracts passed
- 10/10 context identity and reuse checks passed
- 3/3 execution contracts passed and caught all three seeded regressions
- the agent benchmark dry-run assertion passed without invoking an external provider
- coverage reached 90.70% lines, 87.15% branches, and 95.99% functions
- plugin metadata validation and isolated package smoke passed
- the 0.4.15 package preview contains 198 files
- npm public publication dry-run passed

## Checks

- [x] Focused regression tests
- [x] `pnpm test`
- [x] `pnpm bench:ci`
- [x] `pnpm bench:agent --dry-run --assert`
- [x] `pnpm bench:context`
- [x] `pnpm bench:execution`
- [x] `pnpm scan`
- [x] `pnpm plugin:check` and `pnpm plugin:smoke`
- [x] `pnpm release:check`
- [x] `npm publish --dry-run --access public`
- [x] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

The full release gate passed from the versioned 0.4.15 branch. QAMap static self-analysis correctly kept execution `not-run` and routed the metadata-only change to repository validation, but selected the general `pnpm test` command rather than the stronger release gate. The release verdict therefore comes from the repository-owned `pnpm release:check` evidence above, and the narrower routing gap remains follow-up work.