### PR TITLE
Fix: isolate working-tree release validation

### DIFF
--- a/src/qa.ts
+++ b/src/qa.ts
@@ -326,16 +326,25 @@ export async function generateQaDraft(rootInput: string, options: QaDraftOptions
     workspaceRoot: e2eOptions.workspaceRoot,
     includeWorkingTree: draft.plan.includeWorkingTree,
   });
+  const committedDiffEvidence = draft.plan.includeWorkingTree
+    ? await collectAddedDiffEvidence(root, {
+      base: draft.plan.base,
+      head: draft.plan.head,
+      workspaceRoot: e2eOptions.workspaceRoot,
+    })
+    : addedDiffEvidence;
   const currentDelta = await collectCurrentDelta(root, draft, e2eOptions.workspaceRoot);
-  const latestCommitContracts = await collectLatestCommitContracts(
-    root,
-    draft.plan.head,
-    e2eOptions.workspaceRoot,
-  );
+  const latestCommitContracts = Object.keys(committedDiffEvidence).length > 0
+    ? await collectLatestCommitContracts(
+      root,
+      draft.plan.head,
+      e2eOptions.workspaceRoot,
+    )
+    : [];
   const changedTestContracts = uniqueChangedTestContracts([
     ...(currentDelta?.repositoryContracts ?? []),
     ...latestCommitContracts,
-    ...collectChangedTestContracts(addedDiffEvidence),
+    ...collectChangedTestContracts(committedDiffEvidence),
   ]);
   const runtimePrerequisiteTestGaps = await collectRuntimePrerequisiteTestGaps(
     root,

--- a/test/scanner.test.mjs
+++ b/test/scanner.test.mjs
@@ -354,6 +354,85 @@ test("qa prefers a repository release gate for release-only metadata changes", a
   assert.equal(qa.execution.status, "not-run");
 });
 
+test("working-tree release validation ignores prior committed test contracts", async () => {
+  const root = await makeTempRepo();
+  await initGitRepo(root);
+  await mkdir(path.join(root, ".codex-plugin"), { recursive: true });
+  await mkdir(path.join(root, "docs"), { recursive: true });
+  await mkdir(path.join(root, "src"), { recursive: true });
+  await mkdir(path.join(root, "test"), { recursive: true });
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      name: "working-tree-release-gate",
+      version: "1.0.0",
+      packageManager: "pnpm@10.0.0",
+      scripts: {
+        test: "node --test test/*.test.mjs",
+        "release:check": "pnpm test && pnpm pack --dry-run",
+      },
+    }),
+  );
+  await writeFile(path.join(root, ".codex-plugin/plugin.json"), '{"name":"working-tree-release-gate","version":"1.0.0"}\n');
+  await writeFile(path.join(root, "CHANGELOG.md"), "# Changelog\n\n## 1.0.0\n");
+  await writeFile(path.join(root, "docs/release-validation.md"), "# Release validation\n");
+  await writeFile(path.join(root, "src/version.ts"), 'export const VERSION = "1.0.0";\n');
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "base"]);
+  await git(root, ["branch", "-M", "main"]);
+
+  await writeFile(
+    path.join(root, "test/repository-workflow.test.mjs"),
+    [
+      'import test from "node:test";',
+      'test("keeps the prior repository contract", () => {});',
+      "",
+    ].join("\n"),
+  );
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "test: cover repository workflow"]);
+
+  await writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      name: "working-tree-release-gate",
+      version: "1.0.1",
+      packageManager: "pnpm@10.0.0",
+      scripts: {
+        test: "node --test test/*.test.mjs",
+        "release:check": "pnpm test && pnpm pack --dry-run",
+      },
+    }),
+  );
+  await writeFile(path.join(root, ".codex-plugin/plugin.json"), '{"name":"working-tree-release-gate","version":"1.0.1"}\n');
+  await writeFile(path.join(root, "CHANGELOG.md"), "# Changelog\n\n## 1.0.1\n");
+  await writeFile(
+    path.join(root, "docs/release-validation.md"),
+    "# Release validation\n\nRun the repository release gate.\n",
+  );
+  await writeFile(path.join(root, "src/version.ts"), 'export const VERSION = "1.0.1";\n');
+
+  const plan = await generateTestPlan(root, {
+    base: "HEAD",
+    head: "HEAD",
+    includeWorkingTree: true,
+  });
+  const qa = await generateQaDraft(root, {
+    base: "HEAD",
+    head: "HEAD",
+    includeWorkingTree: true,
+  });
+  const agent = JSON.parse(formatAgentQaDraft(qa));
+
+  assert.deepEqual(qa.currentDelta?.repositoryContracts, []);
+  assert.deepEqual(qa.changedTestContracts, []);
+  assert.equal(plan.suggestedCommands[0], "pnpm run release:check");
+  assert.equal(qa.route.command, "pnpm run release:check");
+  assert.equal(agent.testContracts.declared, 0);
+  assert.equal(agent.execution.status, "not-run");
+  assert.equal(qa.suggestedCommands.some((command) => /repository-workflow\.test\.mjs/.test(command)), false);
+});
+
 test("qa does not treat an unrelated release script as a validation gate", async () => {
   const root = await makeTempRepo();
   await initGitRepo(root);


### PR DESCRIPTION
## Summary

- Prevent working-tree-only release analysis from importing test contracts from the previous target-branch commit.
- Keep committed branch test contracts when they are part of the active base/head comparison.
- Add a synthetic release-only regression fixture that proves the repository release gate remains the selected validation.

## Behavioral Contract

When base and head resolve to the same commit and only release metadata or documentation changes exist in the working tree, QAMap must not treat tests from the previous commit as part of the current change. It must select the repository-owned release validation gate and keep execution marked not-run.

## Evidence

Closes #232.

The positive case preserves test contracts from an actual committed comparison. The negative case uses a prior committed test plus a release-only working tree and verifies that the stale test contract is excluded.

## Checks

- [x] Focused regression test
- [x] pnpm test
- [x] pnpm bench:ci for inference, routing, trace, or output
- [ ] pnpm bench:execution for E2E compiler or execution fixtures
- [ ] pnpm scan for scanner, security, or repository policy
- [ ] pnpm plugin:check and pnpm plugin:smoke for plugin changes
- [ ] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

QAMap's static result remains not-run; the selected regression command was executed separately and passed. Execution, scanner, plugin, and documentation checks are not applicable to this focused validation fix.
