### PR TITLE
Fix: pin README CI badge to main pushes

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -2,7 +2,7 @@
 
 [English](README.md) | **한국어**
 
-[![CI](https://github.com/IvoryCanvas/QAMap/actions/workflows/ci.yml/badge.svg)](https://github.com/IvoryCanvas/QAMap/actions/workflows/ci.yml)
+[![CI](https://github.com/IvoryCanvas/QAMap/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/IvoryCanvas/QAMap/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)
 [![npm version](https://img.shields.io/npm/v/@ivorycanvas/qamap.svg)](https://www.npmjs.com/package/@ivorycanvas/qamap)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **English** | [한국어](README.ko.md)
 
-[![CI](https://github.com/IvoryCanvas/QAMap/actions/workflows/ci.yml/badge.svg)](https://github.com/IvoryCanvas/QAMap/actions/workflows/ci.yml)
+[![CI](https://github.com/IvoryCanvas/QAMap/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/IvoryCanvas/QAMap/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)
 [![npm version](https://img.shields.io/npm/v/@ivorycanvas/qamap.svg)](https://www.npmjs.com/package/@ivorycanvas/qamap)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 


### PR DESCRIPTION
## Summary

Pin the English and Korean README CI badges to completed push runs on main. This replaces the unfiltered badge URL, refreshes the rendered badge after the transient failed run, and keeps public status aligned with the durable branch.

## Behavioral Contract

No runtime behavior change.

## Evidence

- The latest main CI run completed successfully after rerun: https://github.com/IvoryCanvas/QAMap/actions/runs/33239031148
- The filtered badge endpoint currently returns passing.
- Both README variants use the same branch and event filter.

## Checks

- [ ] Focused regression test
- [x] pnpm test
- [ ] pnpm bench:ci for inference, routing, trace, or output
- [ ] pnpm bench:execution for E2E compiler or execution fixtures
- [ ] pnpm scan for scanner, security, or repository policy
- [ ] pnpm plugin:check and pnpm plugin:smoke for plugin changes
- [x] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

Only README badge URLs changed. Focused regression, benchmark, scan, and plugin checks are not applicable. The full local test suite passed 429/429 before this documentation-only change.
