### PR TITLE
Docs: simplify first-run README guidance

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -6,320 +6,104 @@
 [![npm version](https://img.shields.io/npm/v/@ivorycanvas/qamap.svg)](https://www.npmjs.com/package/@ivorycanvas/qamap)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-![QAMap: 병합 전에 무엇을 테스트할지 확인하세요](docs/assets/qamap-cover-ko.png)
+![QAMap: 병합 전에 무엇을 테스트할지 확인하세요.](docs/assets/qamap-cover-ko.png)
 
-**병합 전에 무엇을 테스트할지 확인하세요.**
+**PR을 병합하기 전에 확인할 내용을 코드 근거와 함께 정리합니다.**
 
-QAMap은 현재 브랜치의 커밋과 코드 변경, 저장소 구조, 기존 테스트를
-로컬에서 살펴보고 병합 전에 확인할 내용을 정리하는 CLI입니다.
+QAMap은 현재 브랜치의 커밋과 diff, 저장소 구조, 기존 테스트를 로컬에서
+분석하는 CLI입니다. 다음 세 가지 질문에 답합니다.
 
-- 어떤 기능과 사용자 흐름이 달라졌는지
-- 정상 동작뿐 아니라 실패, 경계값, 상태 변화에서 무엇을 확인해야 하는지
-- 각 판단이 어느 파일과 코드에서 나왔는지
-- 지금 실행할 수 있는 검증과 추가로 만들 수 있는 E2E 초안이 무엇인지
+- 어떤 기능과 사용자 흐름이 영향을 받을 수 있는가?
+- 정상, 실패, 경계 조건, 상태 변화 중 무엇을 확인해야 하는가?
+- 각 판단은 어떤 파일, 줄, 심볼, 커밋을 근거로 하는가?
 
-분석 과정에서 소스 코드를 외부로 보내거나 별도의 LLM을 호출하지 않습니다.
-처음 사용할 때 설정 파일이나 테스트 실행 환경이 없어도 됩니다.
-
-에이전트가 사용할 때는 여러 PR에서 반복되는 저장소 QA 정보와 이번 PR의
-변경 내용을 따로 전달합니다. 같은 정보가 유지되는지는 식별자로 확인할 수
-있지만, QAMap을 호출한 에이전트의 모델 사용량까지 0이 되는 것은 아닙니다.
+QA 항목을 정리한 뒤에는 저장소에 이미 있는 검증 명령이나 선택적인 자동화
+초안으로 이어갈 수 있습니다. 소스 코드를 외부로 보내거나 QAMap 자체가
+LLM을 호출하지는 않습니다.
 
 ## 설치하고 실행하기
 
-터미널에서 직접 사용하려면 로컬 CLI를 실행하세요. ChatGPT나 Codex에서
-같은 분석을 요청하려면 [QAMap 플러그인](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629)을
-설치할 수 있습니다.
-
 ### 로컬 CLI (권장)
 
-QAMap은 Node.js 20 이상이 필요합니다. 가능하면
-[현재 지원 중인 Node.js LTS](https://nodejs.org/en/about/previous-releases)를
-사용하세요.
-
-확인하려는 브랜치로 이동한 뒤 실행합니다.
-
-#### 저장소를 바꾸지 않고 한 번 실행
-
-저장소가 npm, pnpm, Yarn, Bun 중 무엇을 사용하더라도 다음 명령을 실행할
-수 있습니다. 프로젝트 의존성이나 설정 파일은 바뀌지 않습니다.
+Node.js 20 이상이 설치되어 있다면 확인할 브랜치에서 실행하세요.
 
 ```sh
 npx --yes @ivorycanvas/qamap@latest qa
 ```
 
-#### 반복 사용을 위해 프로젝트에 설치
-
-프로젝트에서 QAMap 버전을 고정해 사용하려면 이미 쓰고 있는 패키지
-매니저로 개발 의존성에 추가하세요.
-
-| 패키지 매니저 | 설치 | 짧은 스크립트 추가 |
-| --- | --- | --- |
-| npm | `npm install --save-dev @ivorycanvas/qamap` | `npm exec -- qamap init --scripts` |
-| pnpm | `pnpm add --save-dev @ivorycanvas/qamap` | `pnpm exec qamap init --scripts` |
-| Yarn 1 이상 | `yarn add --dev @ivorycanvas/qamap` | `yarn qamap init --scripts` |
-| Bun | `bun add --dev @ivorycanvas/qamap` | `bun run qamap init --scripts` |
-
-짧은 스크립트와 다른 실행 방법은
-[반복해서 CLI 사용하기](#반복해서-cli-사용하기)에서 확인할 수 있습니다.
+이 명령은 코드를 읽기만 합니다. 프로젝트 파일을 바꾸거나 제품 테스트를
+실행하지 않습니다. 반복 사용, 다른 패키지 매니저, 커밋하지 않은 변경을
+분석하는 방법은 [도입 가이드](docs/adoption.md)에서 확인할 수 있습니다.
 
 ### ChatGPT와 Codex 플러그인
 
-에이전트가 PR 검토나 테스트 계획 중에 QAMap을 호출하도록 하려면
-플러그인을 설치하세요.
+PR 리뷰나 테스트 계획을 세울 때 에이전트가 같은 로컬 분석을 실행하도록
+하려면 공개 플러그인을 설치하세요.
 
 [![OpenAI 플러그인 디렉터리에서 QAMap 설치](docs/assets/openai-plugin-directory-badge.svg)](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629)
 
-[QAMap 플러그인 페이지](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629)
-| [OpenAI 공식 설치 안내](https://learn.chatgpt.com/docs/plugins#install-and-use-a-plugin)
+[플러그인 설치 방법](https://learn.chatgpt.com/docs/plugins#install-and-use-a-plugin)
 
-1. QAMap 플러그인 페이지를 엽니다.
-2. **+**를 눌러 설치합니다.
-3. 분석할 저장소를 연 ChatGPT 또는 Codex 작업에서 QAMap을 선택합니다.
-
-플러그인도 같은 로컬 QAMap 패키지를 실행합니다. QAMap의 정적 분석은
-별도의 LLM을 호출하지 않지만, QAMap을 호출하고 결과를 읽는 에이전트는
-자체 모델과 권한을 사용합니다. 로컬 파일을 읽을 수 없는 일반 웹
-대화에서는 현재 저장소를 분석할 수 없습니다.
+호스트 에이전트는 자체 모델과 권한을 사용합니다. QAMap은 그 과정에서
+저장소를 로컬의 일관된 규칙으로 분석하는 역할을 맡습니다.
 
 ## 결과 읽는 방법
 
-| 출력 영역 | 확인할 내용 |
+| 항목 | 알 수 있는 내용 |
 | --- | --- |
-| **Change** | 이번 변경에서 달라졌을 가능성이 높은 동작 |
-| **Verify before merge** | 병합 전에 확인할 정상, 실패, 경계값, 상태 변화 |
-| **Evidence** | 판단에 사용한 커밋, 파일, 코드 위치 |
-| **Next** | 지금 실행할 검증 또는 검토할 자동화 초안 |
+| **변경** | 어떤 기능이나 동작이 달라졌는지 |
+| **병합 전 확인** | 어떤 시나리오를 확인해야 하는지 |
+| **근거** | 어떤 커밋과 코드 위치에서 판단했는지 |
+| **다음 단계** | 무엇을 검토하거나 실행하거나 초안으로 만들 수 있는지 |
 
-기본 `qa` 명령은 코드를 분석할 뿐, 제품 QA나 테스트를 직접 실행하지
-않습니다. 시나리오나 E2E 초안이 만들어져도 통과한 테스트로 표시하지
-않습니다. 화면이나 저장 상태처럼 사용자가 확인할 수 있는 결과를 코드에서
-찾지 못하면 임의의 검증 조건을 만들지 않고 근거가 부족하다고 표시합니다.
-
-한 PR에서 서로 다른 테스트나 벤치마크가 함께 바뀌면 확인할 명령도 여러
-개일 수 있습니다. `qamap qa run`은 안전 범위를 넓히지 않고 QAMap이 고른
-명령 하나만 실행합니다. 나머지는 **Additional required validation**으로
-보여주며, 직접 실행하기 전까지 `not run` 상태로 남습니다.
-**Supplemental validation**은 저장소에 실행할 수 있는 명령이 있지만 이번
-변경의 필수 검증으로 선택되지는 않았다는 뜻입니다.
-
-릴리스 정보가 함께 바뀐 PR에서는 저장소에 선언된 `release:check` 같은
-비배포 검증 명령을 우선합니다. 그 명령 안에서 이미 실행되는 테스트나
-오프라인 벤치마크는 중복해서 나열하지 않습니다. 게시, 태그, 푸시, 배포를
-수행하는 명령은 자동으로 선택하지 않습니다. 작업 트리에만 릴리스 변경이
-있다면 이전 커밋의 테스트를 현재 변경의 검증 근거로 섞지 않습니다.
-
-네트워크 변경은 QA 항목을 찾는 것과 mock 응답을 만드는 것을 구분합니다.
-저장소 코드만으로 영향받는 동작은 찾을 수 있지만, JSON 응답은 대상 동작과
-상태에 연결된 OpenAPI 또는 Swagger의 구체적인 예시가 있을 때만 초안에
-넣습니다. 예시가 없으면 값을 추측하지 않고 필요한 계약 근거를 알려줍니다.
-
-지원하는 저장소 구조에서는 변경된 화면이나 진입점부터 실제로 필요한
-모듈과 실행 조건까지 따라갑니다. 테스트가 그 조건을 모의 처리로
-우회했다면 완전한 검증 근거로 보지 않습니다.
-
-변경 파일이 없는 이미지를 참조하거나 검증 작업이 공유 이력을 바꿀 수
-있다면 E2E보다 먼저 배포 무결성 문제로 알려줍니다. 지원하는 활성화 설정은
-조건문과 설정 출처, 실제 실행 동작, 재시작 또는 새로고침 필요 여부를 함께
-근거로 남깁니다.
-
-성능 최적화 PR에서는 일반적인 화면 점검에 그치지 않고, 실제로 바뀐 코드
-위치를 기준으로 애니메이션과 렌더링 비용, 이미지 요청 우선순위, 지연 로딩,
-초기 HTML과 하이드레이션, 폰트 로딩, 배포 캐시 정합성을 확인할 항목으로
-정리합니다. 이 항목들은 정적 분석으로 만든 QA 계획이며, 브라우저 측정이나
-배포 검증을 이미 실행했다는 뜻은 아닙니다.
+기본 `qa` 명령은 계획만 만들며 실행 상태는 `not run`입니다. QAMap이 고른
+저장소 명령을 실제로 실행할 때만 `qamap qa run`을 사용합니다. 브라우저,
+모바일, API, CLI 또는 수동 자동화 초안은 `qamap e2e draft . --dry-run`으로
+미리 볼 수 있습니다.
 
 ## 실제 실행 예시
 
-아래 녹화는 공개 예제 저장소를 사용합니다. QAMap은 중복 요청 위험과
-관련 코드 위치를 찾고, 실제 실행 상태는 `not run`으로 남깁니다.
+공개 예제 저장소의 구독 갱신 흐름을 수정한 상황입니다. QAMap은 중복 요청
+위험과 관련 코드 위치를 찾고, 실행 상태는 `not run`으로 남깁니다.
 
-![QAMap이 브랜치의 코드 변경을 읽고 근거가 연결된 QA 요약을 만드는 화면](docs/assets/qamap-quickstart.gif)
+![QAMap이 브랜치 변경을 읽고 근거가 연결된 QA 요약을 만드는 모습](docs/assets/qamap-quickstart.gif)
 
-아래 코드 블록은 설명을 위해 번역한 문장이 아니라 현재 CLI가 실제로
-출력하는 내용입니다.
-
-```txt
-QAMap QA
-Local static analysis. No cloud or LLM token. Product QA was not run.
-
-Change
-  Prevent duplicate subscription renewal requests (medium confidence; review required)
-  Flow:
-    action: Prevent duplicate subscription renewal requests.
-    -> observable-outcome: Subscription status becomes active.
-  Affected behavior: Prevent duplicate subscription renewal requests
-
-Verify before merge
-  REQUIRED  Prevent duplicate subscription renewal requests
-    Proof: Verify visible text "Subscription active" appears.
-    Evidence: src/pages/renewal.tsx:11 (RenewalPage)
-  RECOMMENDED  Failure, timeout, and retry handling
-    Proof: Verify each response produces the intended visible or persisted state.
-    Evidence: src/pages/renewal.tsx:11 (RenewalPage)
-  RECOMMENDED  Duplicate renewal request
-    Proof: Verify duplicate renewal request is prevented or handled explicitly.
-    Evidence: src/pages/renewal.tsx:11 (RenewalPage)
-
-Evidence
-  3/3 scenarios connect to 5 unique diff source(s).
-  Routing: 1 required, 2 recommended, 0 review-only.
-  Optional E2E mapping: 0 mapped, 1 partial, 2 unmapped; not executed.
-  Supplemental validation: npm run test:e2e (available, not selected for this QA route)
-
-Next
-  Review the selected scenarios before choosing an execution step.
-  Preview an optional automation or checklist draft: qamap e2e draft . --dry-run
-  Open the full reasoning trace: qamap qa --format markdown
-```
-
-## 반복해서 CLI 사용하기
-
-### 짧은 스크립트 추가
-
-`init --scripts`를 실행하면 `qa`, `qa:local`, `qa:run`, `qa:e2e` 스크립트가
-추가됩니다. 프로젝트가 사용하는 패키지 매니저에 맞춰 실행하세요.
-
-```sh
-npm run qa       # npm
-pnpm qa          # pnpm
-yarn qa          # Yarn
-bun run qa       # Bun
-```
-
-아직 커밋하지 않은 변경을 포함하려면 `qa:local`, QAMap이 고른 기존 검증을
-실행하려면 `qa:run`, E2E 초안을 미리 보려면 `qa:e2e`를 사용합니다. 다른
-언어로 만든 저장소에서도 앞에서 본 `npx` 명령을 그대로 사용할 수 있습니다.
-
-### 패키지 매니저별 일회성 실행
-
-프로젝트에 QAMap을 설치하지 않고도 다음 명령을 사용할 수 있습니다.
-
-```sh
-pnpm dlx @ivorycanvas/qamap@latest qa
-yarn dlx @ivorycanvas/qamap@latest qa  # Yarn 2+
-bunx @ivorycanvas/qamap@latest qa
-```
-
-Yarn Classic은 `npx` 명령을 사용하거나 프로젝트에 QAMap을 설치하세요.
-Corepack으로 관리되는 패키지 매니저는 저장소의 `packageManager` 값을
-추가하거나 바꿀 수 있습니다. 파일을 건드리지 않고 처음 확인할 때는
-`npx` 명령이 가장 단순합니다.
-
-### 확인한 Node.js 버전
-
-공개된 `0.4.13` 패키지는 2026-08-11에 다음 Node.js 버전에서 설치와 `qa`
-실행을 확인했습니다. 설치 명령은 모두 같습니다.
-
-| Node.js | 설치 및 실행 확인 | 안내 |
-| --- | --- | --- |
-| 20 | 통과 | 패키지는 호환되지만 공식 지원 종료 상태이므로 업그레이드 권장 |
-| 22 | 통과 | 검증 당시 지원 중인 LTS |
-| 24 | 통과 | 검증 당시 지원 중인 LTS |
-| 26 | 통과 | 검증 당시 Current 버전이며 운영 환경은 LTS 권장 |
-
-정확한 버전과 패키지 매니저 범위는
-[패키지 매니저 호환성 기록](docs/release-validation.md#package-manager-compatibility---2026-08-11)에서
-확인할 수 있습니다.
-
-### 자주 쓰는 CLI 옵션
-
-일반적인 저장소에서는 기준 브랜치를 자동으로 찾습니다. 자동으로 찾은
-브랜치가 맞지 않을 때만 직접 지정하세요.
-
-```sh
-npx --yes @ivorycanvas/qamap@latest qa . --base origin/main --head HEAD
-```
-
-판단에 사용한 전체 근거를 보려면 Markdown 형식으로 출력합니다.
-
-```sh
-npx --yes @ivorycanvas/qamap@latest qa --format markdown
-```
-
-## 분석, 실행, E2E의 차이
-
-| 명령 | 하는 일 | 프로젝트 코드를 실행하거나 파일을 만드는가? |
-| --- | --- | --- |
-| `qamap qa` | 코드 변경을 동작, 위험, 근거, QA 항목에 연결 | 아니요 |
-| `qamap qa run` | QAMap이 고른 검증 명령 하나만 실행하며, 나머지 필수 명령은 `not run`으로 표시 | 예 |
-| `qamap e2e draft . --dry-run` | Playwright, Maestro, CLI, API, 수동 점검표 초안을 미리 보기 | 아니요 |
-| `qamap e2e run <scenario-id>` | `qamap.config.json` 에 선언한 실행기와 픽스처로 컴파일된 시나리오 하나를 실행하고, 영수증을 저장해 이전 실행과 비교합니다. | 예, 선언한 실행기와 시드 훅 |
-
-화면 요소 식별자, 테스트 데이터, Playwright, Maestro, 테스트 실행 환경이
-없어도 중요한 QA 항목을 숨기지 않습니다. 먼저 무엇을 확인해야 하는지
-정리하고, 실제로 자동화할 근거가 있을 때만 도구나 초안에 연결합니다.
+[실제 CLI 출력과 첫 실행 과정을 자세히 보기](docs/ko/quickstart.md)
 
 ## 동작 방식
 
 ```txt
-커밋 + 코드 변경
-    -> 달라진 동작과 영향받는 흐름
-    -> 확인할 위험과 QA 항목
-    -> 파일과 코드 위치로 연결된 판단 근거
-    -> 기존 검증 또는 E2E 초안
+커밋과 diff
+    -> 영향을 받는 기능과 흐름
+    -> 위험에 맞는 QA 시나리오
+    -> 각 판단의 코드 근거
+    -> 기존 검증 명령 또는 선택적 자동화
 ```
 
-QAMap은 저장소 전체를 막연히 추측하기보다 직접 바뀐 동작을 먼저 봅니다.
-공유 컴포넌트가 바뀌면 그 컴포넌트를 실제로 가져다 쓰는 화면까지 따라가되,
-관련 없는 화면은 분석 범위에서 제외하도록 보수적으로 판단합니다.
-
-## 에이전트와 팀 맥락
-
-에이전트는 같은 결과를 간결한 JSON 형식으로 읽을 수 있습니다.
-
-```sh
-npx --yes @ivorycanvas/qamap@latest qa --format agent
-```
-
-이 JSON은 저장소에서 반복해서 쓰이는 QA 맥락과 이번 PR의 변경 내용을
-분리해 식별합니다. 에이전트는 바뀌지 않은 manifest, 검증 명령, 동작 구조를
-다시 설명받지 않고, 자세한 근거가 필요할 때만 로컬 복구 보고서를 읽을 수
-있습니다.
-
-OpenAI 플러그인, 프로젝트용 스킬, `qamap init --agent`는 모두 같은
-로컬 CLI를 호출합니다. QAMap 자체는 추가 LLM을 호출하지 않지만, 에이전트가
-QAMap을 호출하고 결과를 해석하는 데에는 해당 에이전트의 모델 토큰이
-사용됩니다.
-
-처음 실행할 때 별도 설정은 필요하지 않습니다. QAMap이 같은 흐름을
-반복해서 잘못 이해할 때만 저장소별 QA 기준 파일을 만들고 팀에서
-검토하세요.
-
-```sh
-npx --yes @ivorycanvas/qamap@latest manifest init
-```
+QAMap은 넓은 추측보다 실제 변경 근거를 먼저 봅니다. Playwright, Maestro,
+selector, fixture, 테스트 실행 환경이 없다고 해서 중요한 시나리오를 숨기지
+않습니다. 근거가 부족하면 계약이나 성공 결과를 임의로 만들지 않고 멈춥니다.
 
 ## 목적별 문서
 
-| 하고 싶은 일 | 시작 문서 |
+| 목적 | 문서 |
 | --- | --- |
-| 한 번 실행하고 결과 이해하기 | [한국어 빠른 시작](docs/ko/quickstart.md) |
-| 에이전트 또는 OpenAI 플러그인에서 사용하기 | [한국어 에이전트 연동](docs/ko/agent-integration.md) |
-| 반복되는 오해를 저장소별 QA 기준으로 보정하기 | [한국어 manifest 안내](docs/ko/manifest.md) |
-| 모든 한국어 문서 보기 | [한국어 문서 홈](docs/ko/README.md) |
-| 전체 기술 명세 보기 | [영문 기술 문서](docs/en/README.md) |
-| 문제를 제보하거나 기여하기 | [기여 안내](CONTRIBUTING.md) |
+| 브랜치 하나를 처음 분석하기 | [한국어 빠른 시작](docs/ko/quickstart.md) |
+| 팀에서 반복해서 사용하기 | [도입 가이드](docs/adoption.md) |
+| 에이전트와 함께 사용하기 | [한국어 에이전트 연동](docs/ko/agent-integration.md) |
+| 전체 명령 확인하기 | [명령어 안내](docs/commands.md) |
+| 벤치마크 근거 확인하기 | [벤치마크](docs/benchmarking.md) |
 
 ## 현재 한계
 
-QAMap은 아직 `1.0` 이전입니다. 정적 분석만으로 제품의 모든 규칙을 알 수
-없으므로 제안된 QA 항목은 사람이 검토해야 합니다. 저장소의 검증 명령
-하나가 통과해도 제품 전체 QA가 통과했다는 뜻은 아닙니다.
-
-릴리스 전 공개 벤치마크에서는 여러 웹 및 모바일 프레임워크와 API, CLI,
-모노레포, 테스트가 없는 저장소와 오탐 대조 사례를 함께 확인합니다.
-자세한 범위와 결과는 영문 [벤치마크 문서](docs/benchmarking.md)에서 볼 수
-있습니다.
-
-[에이전트 토큰 벤치마크](docs/benchmarking.md#run-the-agent-token-benchmark)는 같은 QA 작업을 QAMap 없이, 그리고 QAMap과 함께 수행할 때의 제공자 보고 토큰, 도구 호출 수, 결정적 작업 성공 여부를 보고하며 가격이나 고정 절감률은 추론하지 않습니다.
+QAMap은 아직 `1.0` 이전 단계입니다. 정적 분석만으로 모든 제품 판단을 알 수
+없으므로 제안된 시나리오는 사람이 검토해야 합니다. 하나의 검증 명령이
+통과했다고 해서 제품 전체의 QA가 끝난 것도 아닙니다.
 
 ## 기여하기
 
-QAMap이 잘못 짚은 항목, 놓친 위험, 쓸 수 없는 초안, 재현 가능한 작은
-예시가 특히 도움이 됩니다. [기여 안내](CONTRIBUTING.md)에서 시작해 주세요.
-공개 제보에는 비공개 저장소, 고객 정보, 사내 경로를 포함하면 안 됩니다.
+잘못된 판단, 놓친 위험, 사용할 수 없는 초안을 환영합니다.
+[CONTRIBUTING.md](CONTRIBUTING.md)에서 시작해 주세요. 비공개 저장소, 고객
+정보, 인증 정보는 공개 이슈나 재현 자료에 포함하면 안 됩니다.
 
-QAMap은 사람의 리뷰나 실행 가능한 테스트, 보안 도구를 대신하지 않습니다.
-PR마다 무엇을 확인할지 처음부터 다시 판단하는 시간을 줄이는 것이
-QAMap의 목표입니다.
+[English README](README.md) | [행동 강령](CODE_OF_CONDUCT.md) | [MIT 라이선스](LICENSE)

--- a/README.md
+++ b/README.md
@@ -8,347 +8,105 @@
 
 ![QAMap: know what to test before merge](docs/assets/qamap-cover.png)
 
-**Find what a change needs to prove before merge.**
+**Turn a PR diff into an evidence-backed QA plan before merge.**
 
-QAMap is a local-first QA CLI. It reads the current branch, repository structure,
-existing tests, and diff evidence to answer:
+QAMap is a local-first CLI that reads the current branch, repository structure,
+and existing tests. It answers three questions:
 
-1. What behavior changed?
-2. What could fail?
-3. What should be verified before merge, and why?
-4. What can be checked now or drafted as E2E?
+- Which behavior and user flows may be affected?
+- Which normal, failure, boundary, and state-transition scenarios matter?
+- Which changed files, lines, symbols, and commits support each judgment?
 
-QAMap itself makes no cloud analysis, source upload, or additional LLM call. A
-manifest and test runner are optional.
-
-For agent integrations, QAMap keeps reusable repository QA facts separate from
-the current pull request delta. Stable identifiers make repeated context visible
-without claiming that the calling agent uses no model tokens.
+QAMap can then route an existing validation command or prepare optional
+automation. It does not upload source code or make its own LLM call.
 
 ## Install And Run
 
-Choose the local CLI for any repository, or
-[install the QAMap plugin](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629)
-when you want ChatGPT or Codex to invoke the same workflow.
-
 ### Local CLI (Recommended)
 
-QAMap requires Node.js 20 or newer. Use an
-[actively supported Node.js LTS release](https://nodejs.org/en/about/previous-releases)
-when possible.
-
-Run commands from the branch you want to review.
-
-#### Try Without Changing The Repository
-
-This one-off command works regardless of whether the repository uses npm, pnpm,
-Yarn, or Bun. It does not add QAMap to the project's dependencies:
+With Node.js 20 or newer, run this from the branch you want to review:
 
 ```sh
 npx --yes @ivorycanvas/qamap@latest qa
 ```
 
-#### Install For Repeat Use
-
-To pin QAMap in a JavaScript project, use the repository's package manager:
-
-| Package manager | Install | Add the short scripts |
-| --- | --- | --- |
-| npm | `npm install --save-dev @ivorycanvas/qamap` | `npm exec -- qamap init --scripts` |
-| pnpm | `pnpm add --save-dev @ivorycanvas/qamap` | `pnpm exec qamap init --scripts` |
-| Yarn 1 or newer | `yarn add --dev @ivorycanvas/qamap` | `yarn qamap init --scripts` |
-| Bun | `bun add --dev @ivorycanvas/qamap` | `bun run qamap init --scripts` |
-
-Short scripts, alternative one-off commands, Node.js validation, and advanced
-options are collected in [Daily CLI Use](#daily-cli-use).
+The command performs read-only static analysis. It does not change project files
+or run product tests. For repeat use, other package managers, and local changes,
+see the [adoption guide](docs/adoption.md).
 
 ### ChatGPT And Codex Plugin
 
-Install the plugin when you want an agent to call QAMap as part of PR review or
-test planning.
+Install the plugin when you want an agent to invoke the same local workflow
+during PR review or test planning.
 
 <a href="https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629">
   <img src="docs/assets/openai-plugin-directory-badge.svg" alt="Install QAMap from the OpenAI Plugin Directory" height="64">
 </a>
 
-[Install the QAMap plugin](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629)
-| [OpenAI's official plugin installation steps](https://learn.chatgpt.com/docs/plugins#install-and-use-a-plugin)
+[Plugin installation help](https://learn.chatgpt.com/docs/plugins#install-and-use-a-plugin)
 
-1. Open the QAMap listing.
-2. Select **+**.
-3. Start a new ChatGPT or Codex conversation with access to the checked-out
-   repository and local shell.
-
-The plugin invokes the same local QAMap package. QAMap's static analysis makes
-no additional LLM call, but the host agent uses its own model and permissions.
+The host agent still uses its own model and permissions. QAMap provides the
+local, deterministic repository analysis inside that workflow.
 
 ## Read The Result
 
-| Section | Question it answers |
+| Section | What it tells you |
 | --- | --- |
-| **Change** | What behavior probably changed? |
-| **Verify before merge** | Which normal, failure, boundary, or state-transition checks matter? |
-| **Evidence** | Which commit, file, line, or symbol supports each judgment? |
-| **Next** | Is there an existing command to run or an optional draft to preview? |
+| **Change** | Which behavior probably changed. |
+| **Verify before merge** | Which scenarios matter before merge. |
+| **Evidence** | Which commit and code location support the judgment. |
+| **Next** | What can be reviewed, run, or drafted next. |
 
-QAMap keeps static reasoning and executed QA separate. A proposed scenario or E2E
-draft is never reported as a passing test.
-
-When one change modifies several independent test or benchmark contracts,
-QAMap keeps every applicable command visible. `qamap qa run` remains bounded to
-one selected command; the others appear as **Additional required validation**
-and remain `not run` until they are executed explicitly. **Supplemental
-validation** means a repository command exists but was not selected as proof for
-this QA route.
-
-For a release-focused change set, QAMap prefers a declared non-publishing gate
-such as `release:check` when package metadata is accompanied by release notes,
-plugin metadata, or a synchronized version source. Tests and offline benchmark
-assertions already invoked by that gate are not listed again. A generic
-`release` script or a command that publishes, tags, pushes, or deploys is never
-promoted by this rule. Working-tree-only release preparation also stays isolated
-from test contracts introduced by an earlier target-branch commit.
-
-Network QA routing and mock generation have separate evidence boundaries.
-Repository code can identify affected behavior, but QAMap emits a JSON response
-scaffold only from an exact OpenAPI or Swagger example for one unambiguous
-operation and status. Without that example, it reports the missing contract
-evidence instead of inventing payload values.
-
-For supported runtime contracts, QAMap can trace a changed entry point through
-local imports to a required provider. A test that mocks away that prerequisite
-is disclosed as incomplete evidence instead of being promoted as proof.
-
-Delivery checks run before optional E2E work when the diff references a missing
-asset or a validation workflow can rewrite shared history. Supported activation
-changes also retain the guard, configuration source, runtime side effect, and
-restart or reload boundary that must be verified.
-
-When a diff changes runtime performance mechanics, QAMap keeps the exact source
-line and routes a measurable contract for rendering work, image request
-priority, deferred modules, initial HTML and hydration, font loading, or cache
-version coherence. These are static QA requirements, not claims that a browser
-profile or deployment check already ran.
-
-Cleanup-only commits remain visible as provenance but do not become standalone
-QA requirements. Unrelated issue tags and lifecycle stages stay separate. When
-the changed source does not prove an externally observable result, QAMap reports
-that proof gap instead of turning a commit title or function name into an
-assertion.
+The default `qa` command creates a plan and remains `not run`. Use `qamap qa run`
+only when you want to execute a selected repository command. Use
+`qamap e2e draft . --dry-run` to preview optional browser, mobile, API, CLI, or
+manual automation.
 
 ## See A Real Run
 
-This recording uses a committed public fixture. QAMap finds a duplicate-request
-guard, routes the relevant scenarios, cites changed lines, and leaves execution
-marked `not run`.
+This public fixture changes a subscription renewal flow. QAMap finds the
+duplicate-request risk, cites the changed source, and keeps execution marked
+`not run`.
 
-![QAMap reads a branch diff and returns a concise, evidence-backed QA summary](docs/assets/qamap-quickstart.gif)
+![QAMap reads a branch diff and returns an evidence-backed QA summary](docs/assets/qamap-quickstart.gif)
 
-<details>
-<summary>Open the shortened terminal output</summary>
-
-```txt
-QAMap QA
-Local static analysis. No cloud or LLM token. Product QA was not run.
-
-Change
-  Prevent duplicate subscription renewal requests (medium confidence; review required)
-  Flow:
-    action: Prevent duplicate subscription renewal requests.
-    -> observable-outcome: Subscription status becomes active.
-  Affected behavior: Prevent duplicate subscription renewal requests
-
-Verify before merge
-  REQUIRED  Prevent duplicate subscription renewal requests
-    Proof: Verify visible text "Subscription active" appears.
-    Evidence: src/pages/renewal.tsx:11 (RenewalPage)
-  RECOMMENDED  Failure, timeout, and retry handling
-    Proof: Verify each response produces the intended visible or persisted state.
-    Evidence: src/pages/renewal.tsx:11 (RenewalPage)
-  RECOMMENDED  Duplicate renewal request
-    Proof: Verify duplicate renewal request is prevented or handled explicitly.
-    Evidence: src/pages/renewal.tsx:11 (RenewalPage)
-
-Evidence
-  3/3 scenarios connect to 5 unique diff source(s).
-  Routing: 1 required, 2 recommended, 0 review-only.
-  Optional E2E mapping: 0 mapped, 1 partial, 2 unmapped; not executed.
-  Supplemental validation: npm run test:e2e (available, not selected for this QA route)
-
-Next
-  Review the selected scenarios before choosing an execution step.
-  Preview an optional automation or checklist draft: qamap e2e draft . --dry-run
-  Open the full reasoning trace: qamap qa --format markdown
-```
-
-</details>
-
-The generated browser checks are exercised separately by the
-[execution benchmark](docs/benchmarking.md#run-the-execution-contract).
-
-The [agent token benchmark](docs/benchmarking.md#run-the-agent-token-benchmark) reports provider-reported tokens, tool calls, and deterministic task success for the same QA tasks with and without QAMap; it infers no pricing or fixed saving.
-
-## Daily CLI Use
-
-### Add Short Scripts
-
-`init --scripts` adds `qa`, `qa:local`, `qa:run`, and `qa:e2e`. Run the same
-script with the syntax your project already uses:
-
-```sh
-npm run qa       # npm
-pnpm qa          # pnpm
-yarn qa          # Yarn
-bun run qa       # Bun
-```
-
-Replace `qa` with `qa:local` to include uncommitted changes, `qa:run` to run the
-selected existing validation, or `qa:e2e` to preview the optional E2E draft.
-Non-JavaScript repositories can keep using the universal `npx` command.
-
-<details>
-<summary>Package-manager-specific one-off commands</summary>
-
-These commands also work without adding QAMap as a project dependency:
-
-```sh
-pnpm dlx @ivorycanvas/qamap@latest qa
-yarn dlx @ivorycanvas/qamap@latest qa  # Yarn 2+
-bunx @ivorycanvas/qamap@latest qa
-```
-
-Yarn Classic users can use the universal `npx` command or install QAMap in the
-project. Corepack-managed package managers may add or update the repository's
-`packageManager` metadata; use the `npx` first run when a no-write check matters.
-
-</details>
-
-<details>
-<summary>Validated Node.js lines</summary>
-
-The published `0.4.13` package completed an install and real `qa` smoke on these
-lines on 2026-08-11. The install command is the same for every line.
-
-| Node.js | Smoke | Guidance |
-| --- | --- | --- |
-| 20 | Passed | Package-compatible, but upstream EOL; upgrade for security fixes |
-| 22 | Passed | Supported LTS at the time of validation |
-| 24 | Passed | Supported LTS at the time of validation |
-| 26 | Passed | Current release at the time of validation; prefer LTS for production |
-
-See the [package-manager compatibility receipt](docs/release-validation.md#package-manager-compatibility---2026-08-11)
-for exact versions and package-manager coverage.
-
-</details>
-
-### Useful CLI Options
-
-QAMap infers the base branch in standard repositories. Override it only when
-needed:
-
-```sh
-npx --yes @ivorycanvas/qamap@latest qa . --base origin/main --head HEAD
-```
-
-The default output is concise. Open the complete reasoning trace with:
-
-```sh
-npx --yes @ivorycanvas/qamap@latest qa --format markdown
-```
-
-## Analysis, Execution, And E2E
-
-| Command | What it does | Writes or runs project code? |
-| --- | --- | --- |
-| `qamap qa` | Maps the diff to behavior, risk, evidence, and QA scenarios. | No |
-| `qamap qa run` | Runs one selected repository validation. Other required commands stay listed and `not run`. | Yes, explicitly |
-| `qamap e2e draft . --dry-run` | Previews optional Playwright, Maestro, CLI, API, or manual automation. | No |
-| `qamap e2e run <scenario-id>` | Executes one compiled scenario through the executor and fixtures declared in `qamap.config.json`, then stores and compares the receipt. | Yes, the declared executor and seed hooks |
-
-QAMap does not hide an important QA scenario because a repository lacks a
-selector, fixture, Playwright, Maestro, or test runner. Those are automation
-details. Missing evidence remains visible instead of becoming a fabricated pass.
+[Open the exact CLI output and first-run walkthrough](docs/quickstart-demo.md).
 
 ## How It Works
 
 ```txt
 commit + diff
-    -> changed behavior and flow
-    -> risk and QA scenario routing
-    -> file and line reasoning trace
-    -> existing validation or optional E2E draft
+    -> affected behavior and flow
+    -> risk-based QA scenarios
+    -> evidence for every judgment
+    -> existing validation or optional automation
 ```
 
-QAMap ranks direct changed behavior ahead of broad repository guesses. Shared
-components can reach importing surfaces through reverse-import context, while
-unrelated consumers remain out of scope.
-
-## Agents And Team Context
-
-Agents can consume the same decision in a compact, versioned payload:
-
-```sh
-npx --yes @ivorycanvas/qamap@latest qa --format agent
-```
-
-The payload separates stable repository QA context from the current PR delta
-with content-derived IDs. Agents can reuse unchanged manifest, validation, and
-behavior blocks and open the private local recovery report only when detailed
-evidence is needed.
-
-Install the portable project skill with `skills add`, use `qamap init --agent`,
-or install the published
-[OpenAI Plugin Directory](https://chatgpt.com/plugins/plugins_6a752ca134a481919b90c45c09ab1629)
-version. Every path calls the same local CLI. See
-[Agent integration](docs/agent-skill.md).
-
-The first run needs no configuration. If QAMap repeatedly misunderstands a
-durable team flow, create and review repo-local QA context:
-
-```sh
-npx --yes @ivorycanvas/qamap@latest manifest init
-```
-
-See [Verification manifest](docs/manifest.md) before committing
-`.qamap/manifest.yaml`.
+QAMap follows direct change evidence before broad repository guesses. Missing
+Playwright, Maestro, selectors, fixtures, or a test runner does not hide an
+important scenario. When evidence is insufficient, QAMap stops instead of
+inventing a contract or a passing result.
 
 ## Documentation
 
-| Goal | Start here |
+| Goal | Guide |
 | --- | --- |
 | Review one branch | [First-run walkthrough](docs/quickstart-demo.md) |
-| Use QAMap every day | [Adoption guide](docs/adoption.md) |
+| Adopt QAMap in a team | [Adoption guide](docs/adoption.md) |
 | Use QAMap from an agent | [Agent integration](docs/agent-skill.md) |
-| Correct repeated misunderstandings | [Verification manifest](docs/manifest.md) |
-| Understand every command | [Command reference](docs/commands.md) |
-| Contribute a fix or failure case | [Contributing](CONTRIBUTING.md) |
-| Browse all documentation | [English documentation](docs/en/README.md) |
-
-Most users only need the first two rows.
+| Review every command | [Command reference](docs/commands.md) |
+| Inspect benchmark evidence | [Benchmarking](docs/benchmarking.md) |
 
 ## Limits
 
-QAMap is early and pre-`1.0`. Static analysis cannot know every product decision.
-Inferred scenarios require review, and one green repository command does not
-prove that the whole product passed QA.
-
-The public release gate includes cross-framework, API, CLI, monorepo, testless,
-false-positive, scenario-to-diff trace, generated-browser-test, package, coverage,
-and no-private-fixture contracts. See [Benchmarking](docs/benchmarking.md) for
-the exact evidence.
-
-## Other Languages
-
-- [한국어 README](README.ko.md)
-- [한국어 문서](docs/ko/README.md)
+QAMap is early and pre-`1.0`. Static analysis cannot know every product decision,
+and inferred scenarios still require review. One passing command does not prove
+that an entire product passed QA.
 
 ## Contributing
 
-Real false positives, missed risks, unusable drafts, and minimized failing
-repositories are especially valuable. Start with
-[CONTRIBUTING.md](CONTRIBUTING.md); public reports must not contain private
-repository or customer information.
+False positives, missed risks, and unusable drafts are especially useful. Start
+with [CONTRIBUTING.md](CONTRIBUTING.md), and never publish private repository,
+customer, or credential data.
 
-QAMap does not replace human review, executable tests, or security tooling. It
-reduces the repeated work between receiving a change and deciding what that
-change must prove.
+[한국어 README](README.ko.md) | [Code of Conduct](CODE_OF_CONDUCT.md) | [MIT License](LICENSE)

--- a/docs/assets/openai-plugin-directory-badge.svg
+++ b/docs/assets/openai-plugin-directory-badge.svg
@@ -2,17 +2,16 @@
   <title id="title">Install QAMap from the OpenAI Plugin Directory</title>
   <desc id="description">Open the published QAMap listing and install the plugin.</desc>
   <rect x="0.5" y="0.5" width="359" height="63" rx="8" fill="#07111f" stroke="#27466e"/>
-  <g transform="translate(10 10)">
-    <rect x="0.5" y="0.5" width="43" height="43" rx="10" fill="#07111f" stroke="#27466e"/>
-    <path d="M12 13V22C12 28 16 32 22 34" fill="none" stroke="#19bef2" stroke-width="2" stroke-linecap="round"/>
-    <path d="M32 13V22C32 28 28 32 22 34" fill="none" stroke="#19bef2" stroke-width="2" stroke-linecap="round"/>
-    <path d="M22 13V34" fill="none" stroke="#19bef2" stroke-width="2" stroke-linecap="round"/>
-    <circle cx="12" cy="10" r="3.5" fill="#07111f" stroke="#19bef2" stroke-width="2"/>
-    <circle cx="22" cy="10" r="3.5" fill="#07111f" stroke="#19bef2" stroke-width="2"/>
-    <circle cx="32" cy="10" r="3.5" fill="#07111f" stroke="#19bef2" stroke-width="2"/>
-    <circle cx="22" cy="34" r="3.5" fill="#07111f" stroke="#19bef2" stroke-width="2"/>
-    <circle cx="22" cy="41" r="6" fill="#07111f" stroke="#ffb414" stroke-width="2"/>
-    <path d="M18.5 41L21 43.5L25.5 38.5" fill="none" stroke="#ffb414" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <g transform="translate(10 10) scale(0.04296875)">
+    <rect x="56" y="56" width="912" height="912" rx="218" fill="#07111F"/>
+    <path d="M 184 354 H 536 C 490 392 438 420 398 458 C 344 508 338 580 382 626 C 408 654 448 670 498 670 H 720" fill="none" stroke="#20BCEB" stroke-width="72" stroke-linecap="butt" stroke-linejoin="round"/>
+    <path d="M 720 670 H 850" fill="none" stroke="#FFB31A" stroke-width="72" stroke-linecap="butt" stroke-linejoin="round"/>
+    <circle cx="184" cy="354" r="84" fill="#20BCEB"/>
+    <circle cx="184" cy="354" r="40" fill="#F4F7FB"/>
+    <circle cx="536" cy="354" r="84" fill="#20BCEB"/>
+    <circle cx="536" cy="354" r="40" fill="#07111F"/>
+    <circle cx="850" cy="670" r="70" fill="#FFB31A"/>
+    <path d="M 811 670 L 837 696 L 884 642" fill="none" stroke="#F4F7FB" stroke-width="30" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
   <text x="68" y="25" fill="#8ea4bc" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600">INSTALL QAMAP FROM</text>
   <text x="68" y="47" fill="#f5f8fc" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="18" font-weight="600">OpenAI Plugin Directory</text>

--- a/docs/quickstart-demo.md
+++ b/docs/quickstart-demo.md
@@ -38,19 +38,32 @@ Local static analysis. No cloud or LLM token. Product QA was not run.
 
 Change
   Prevent duplicate subscription renewal requests (medium confidence; review required)
+  Flow:
+    action: Prevent duplicate subscription renewal requests.
+    -> observable-outcome: Subscription status becomes active.
   Affected behavior: Prevent duplicate subscription renewal requests
 
 Verify before merge
   REQUIRED  Prevent duplicate subscription renewal requests
     Proof: Verify visible text "Subscription active" appears.
     Evidence: src/pages/renewal.tsx:11 (RenewalPage)
+  RECOMMENDED  Failure, timeout, and retry handling
+    Proof: Verify each response produces the intended visible or persisted state.
+    Evidence: src/pages/renewal.tsx:11 (RenewalPage)
   RECOMMENDED  Duplicate renewal request
     Proof: Verify duplicate renewal request is prevented or handled explicitly.
+    Evidence: src/pages/renewal.tsx:11 (RenewalPage)
 
 Evidence
-  3/3 scenarios connect to 6 unique diff sources.
-  Optional E2E mapping: 2 mapped, 1 unmapped; not executed.
-  Existing validation: npm run test:e2e (selected, not run)
+  3/3 scenarios connect to 5 unique diff source(s).
+  Routing: 1 required, 2 recommended, 0 review-only.
+  Optional E2E mapping: 0 mapped, 1 partial, 2 unmapped; not executed.
+  Supplemental validation: npm run test:e2e (available, not selected for this QA route)
+
+Next
+  Review the selected scenarios before choosing an execution step.
+  Preview an optional automation or checklist draft: qamap e2e draft . --dry-run
+  Open the full reasoning trace: qamap qa --format markdown
 ```
 
 The wording matters:

--- a/test/contributor-workflow.test.mjs
+++ b/test/contributor-workflow.test.mjs
@@ -230,33 +230,25 @@ test("public READMEs present local setup before the optional plugin path", async
       file: "README.md",
       install: "## Install And Run",
       local: "### Local CLI (Recommended)",
-      package: "#### Install For Repeat Use",
       plugin: "### ChatGPT And Codex Plugin",
       result: "## Read The Result",
       demo: "## See A Real Run",
-      daily: "## Daily CLI Use",
-      analysis: "## Analysis, Execution, And E2E",
       how: "## How It Works",
-      agents: "## Agents And Team Context",
       docs: "## Documentation",
       limits: "## Limits",
-      stale: ["## Run The CLI In 60 Seconds", "## Install For Repeat Use"],
+      stale: ["## Start Here", "## Daily CLI Use", "## Agents And Team Context"],
     },
     {
       file: "README.ko.md",
       install: "## 설치하고 실행하기",
       local: "### 로컬 CLI (권장)",
-      package: "#### 반복 사용을 위해 프로젝트에 설치",
       plugin: "### ChatGPT와 Codex 플러그인",
       result: "## 결과 읽는 방법",
       demo: "## 실제 실행 예시",
-      daily: "## 반복해서 CLI 사용하기",
-      analysis: "## 분석, 실행, E2E의 차이",
       how: "## 동작 방식",
-      agents: "## 에이전트와 팀 맥락",
       docs: "## 목적별 문서",
       limits: "## 현재 한계",
-      stale: ["## 60초 만에 실행하기", "## 반복 사용을 위한 설치"],
+      stale: ["## 시작하기", "## 반복해서 CLI 사용하기", "## 에이전트와 팀 맥락"],
     },
   ];
 
@@ -265,14 +257,10 @@ test("public READMEs present local setup before the optional plugin path", async
     const orderedSections = [
       contract.install,
       contract.local,
-      contract.package,
       contract.plugin,
       contract.result,
       contract.demo,
-      contract.daily,
-      contract.analysis,
       contract.how,
-      contract.agents,
       contract.docs,
       contract.limits,
     ].map((heading) => source.indexOf(heading));
@@ -285,6 +273,10 @@ test("public READMEs present local setup before the optional plugin path", async
       [...orderedSections].sort((left, right) => left - right),
       orderedSections,
       `${contract.file} must present local setup before the plugin and result guide`,
+    );
+    assert.ok(
+      source.split("\n").length <= 140,
+      `${contract.file} must remain a focused entry point instead of a full reference`,
     );
     for (const staleHeading of contract.stale) {
       assert.ok(

--- a/test/readme-demo.test.mjs
+++ b/test/readme-demo.test.mjs
@@ -9,7 +9,7 @@ import { formatTextQaDraft, generateQaDraft } from "../dist/qa.js";
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-test("public README demos are generated from the current QA engine", async (t) => {
+test("the public walkthrough demo is generated from the current QA engine", async (t) => {
   const root = await mkdtemp(path.join(os.tmpdir(), "qamap-readme-demo-"));
   t.after(() => rm(root, { recursive: true, force: true }));
   git(root, "init", "-b", "main");
@@ -38,12 +38,22 @@ test("public README demos are generated from the current QA engine", async (t) =
   const result = await generateQaDraft(root, { base: "main", head: "HEAD" });
   const actual = formatTextQaDraft(result).trimEnd();
 
-  for (const [file, heading] of [
-    ["README.md", "## See A Real Run"],
-    ["README.ko.md", "## 실제 실행 예시"],
-  ]) {
+  const walkthrough = await readFile(
+    path.join(repositoryRoot, "docs/quickstart-demo.md"),
+    "utf8",
+  );
+  assert.equal(
+    extractTextBlock(walkthrough, "## 2. Read The Five Sections"),
+    actual,
+    "docs/quickstart-demo.md demo drifted from the QA engine",
+  );
+
+  for (const file of ["README.md", "README.ko.md"]) {
     const source = await readFile(path.join(repositoryRoot, file), "utf8");
-    assert.equal(extractTextBlock(source, heading), actual, `${file} demo drifted from the QA engine`);
+    assert.ok(
+      source.includes("quickstart"),
+      `${file} must route detailed first-run guidance out of the entry point`,
+    );
   }
 });
 


### PR DESCRIPTION
## Summary

- Reduce the English and Korean READMEs from reference-sized documents to focused first-run entry points.
- Keep the local CLI path first while preserving a visible OpenAI Plugin Directory path with the current QAMap mark.
- Move the exact generated CLI output into the walkthrough and protect the shorter hierarchy with repository tests.

## Behavioral Contract

No runtime behavior change. Public READMEs must keep local setup before the optional plugin path, stay within 140 lines, link to valid repository documents, and route generated output details to the synchronized walkthrough.

## Evidence

Closes #236

The updated directory badge renders the current QAMap product mark and keeps the established public listing URL.

## Checks

- [x] Focused regression test
- [x] `pnpm test`
- [ ] `pnpm bench:ci` for inference, routing, trace, or output
- [ ] `pnpm bench:execution` for E2E compiler or execution fixtures
- [ ] `pnpm scan` for scanner, security, or repository policy
- [ ] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
- [x] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

`pnpm plugin:check` passed. `pnpm plugin:smoke`, `pnpm bench:ci`, `pnpm bench:execution`, and `pnpm scan` are not applicable because this change does not modify plugin metadata, packaged skills, runtime inference, execution fixtures, scanner behavior, or repository policy. QAMap selected and passed the focused documentation validation without changing the worktree.