### PR TITLE
Fix: make temporary Git cleanup deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,38 +8,59 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
         with:
           version: 10.32.1
-      - uses: actions/setup-node@v6
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm test
-      - run: pnpm plugin:check
-      - run: pnpm plugin:smoke
-      - run: pnpm bench:ci
-      - run: pnpm bench:agent --dry-run --assert
-      - run: pnpm bench:context
-      - run: pnpm scan
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run tests
+        run: pnpm test
+      - name: Validate plugin metadata
+        run: pnpm plugin:check
+      - name: Smoke-test the packed plugin
+        run: pnpm plugin:smoke
+      - name: Run deterministic QA benchmarks
+        run: pnpm bench:ci
+      - name: Validate the offline agent benchmark
+        run: pnpm bench:agent --dry-run --assert
+      - name: Validate context reuse
+        run: pnpm bench:context
+      - name: Scan repository policy
+        run: pnpm scan
 
   execution-benchmark:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
         with:
           version: 10.32.1
-      - uses: actions/setup-node@v6
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm bench:execution
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run execution benchmarks
+        run: pnpm bench:execution

--- a/test/change-intent.test.mjs
+++ b/test/change-intent.test.mjs
@@ -5770,12 +5770,26 @@ async function analyze(root, files) {
 
 async function makeRepo(t) {
   const root = await mkdtemp(path.join(os.tmpdir(), "qamap-change-intent-"));
-  t.after(() => rm(root, { recursive: true, force: true }));
+  t.after(() => rm(root, {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 50,
+  }));
   git(root, "init", "-b", "main");
   git(root, "config", "user.email", "qamap@example.test");
   git(root, "config", "user.name", "QAMap Test");
+  git(root, "config", "gc.auto", "0");
+  git(root, "config", "maintenance.auto", "false");
   return root;
 }
+
+test("temporary Git fixtures disable background maintenance", async (t) => {
+  const root = await makeRepo(t);
+
+  assert.equal(readGitConfig(root, "gc.auto"), "0");
+  assert.equal(readGitConfig(root, "maintenance.auto"), "false");
+});
 
 async function write(root, file, content) {
   await mkdir(path.dirname(path.join(root, file)), { recursive: true });
@@ -5793,6 +5807,13 @@ function branch(root, name) {
 
 function git(root, ...args) {
   execFileSync("git", args, { cwd: root, stdio: "ignore" });
+}
+
+function readGitConfig(root, key) {
+  return execFileSync("git", ["config", "--get", key], {
+    cwd: root,
+    encoding: "utf8",
+  }).trim();
 }
 
 test("near-duplicate badge copy on a new surface is flagged against the existing surface", async (t) => {


### PR DESCRIPTION
## Summary
- Disable automatic Git maintenance inside temporary test repositories.
- Retry only recursive fixture cleanup for a short, bounded window when the filesystem reports a transient conflict.
- Pin the CI runner image, cancel superseded runs, and give every validation step an explicit name.
- Add a regression test for the temporary repository maintenance policy.

Closes #240.

## Behavioral Contract
- Pull requests and `main` pushes continue to run the full CI suite.
- Test assertions and whole test commands are never retried or allowed to fail.
- Only temporary directory removal may retry, up to five times with a 50 ms delay.
- A newer run may cancel an older run only within the same pull request or branch ref.

## Evidence
- The failed `main` run completed all 428 assertions before an `ENOTEMPTY` cleanup error in a temporary Git object directory: https://github.com/IvoryCanvas/QAMap/actions/runs/33305170085
- 99 of the latest 100 CI runs passed; the single failure matched this cleanup race.
- The formerly failing fixture passed 50 consecutive focused runs after the change.
- The full release validation passed locally with 433 tests, all public benchmarks, 3/3 execution contracts, repository scan, plugin checks, coverage thresholds, and package preview.

## Checks
- [x] Focused regression test
- [x] `pnpm test`
- [x] `pnpm bench:ci`
- [x] `pnpm bench:execution`
- [x] `pnpm scan`
- [x] Plugin checks
- [x] Documentation links and commands verified

## Public OSS Check
- [x] No private repository names, paths, domain language, or internal data added
- [x] The reproduction and fix are repository-neutral
- [x] No generated or tool attribution added

## Review Notes
The CI workflow remains a required signal. This change removes a known source of false failures without weakening assertion or benchmark coverage.
