### PR TITLE
Fix: preserve required scenario traceability

### DIFF
--- a/bench.config.json
+++ b/bench.config.json
@@ -438,6 +438,10 @@
           "break shared package import cycle",
           "preserve shared package button compatibility"
         ],
+        "mustNotIncludeQaScenarios": [
+          "Scheduling, calendar, and duplicate boundary"
+        ],
+        "maxUntraceableRequiredScenarios": 0,
         "maxGenericTitles": 0,
         "maxAgentBytes": 4096
       }
@@ -1065,12 +1069,14 @@
           "Asynchronous lifecycle ordering and result delivery"
         ],
         "mustNotIncludeQaScenarios": [
-          "Scheduling, calendar, and duplicate boundary"
+          "Scheduling, calendar, and duplicate boundary",
+          "Entry payload and destination routing"
         ],
         "mustTraceScenarioFiles": [
           "jobs/submit.py",
           "jobs/consume.py"
         ],
+        "maxUntraceableRequiredScenarios": 0,
         "maxBlankActions": 0,
         "maxGenericTitles": 0,
         "maxAgentBytes": 4096

--- a/src/change-intent.ts
+++ b/src/change-intent.ts
@@ -1287,6 +1287,7 @@ function buildLifecycle(
   }
 
   stages.push(...lifecycleFromDetectedRiskEvidence(roleEvidence));
+  stages.push(...lifecycleFromAsyncLifecycleEvidence(roleEvidence));
   stages.push(...lifecycleFromSourceRoles(roleEvidence));
   stages.push(...lifecycleFromDeliveryIntegrityEvidence(roleEvidence.filter(isDeliveryIntegrityEvidence)));
   stages.push(...lifecycleFromRuntimeActivationEvidence(roleEvidence.filter(isRuntimeActivationEvidence)));
@@ -1348,6 +1349,46 @@ function lifecycleFromDetectedRiskEvidence(
       files,
     ),
   ];
+}
+
+function lifecycleFromAsyncLifecycleEvidence(
+  evidence: ChangeIntentEvidence[],
+): BehaviorLifecycleStage[] {
+  const groups = groupAsyncLifecycleEvidence(evidence);
+  if (!hasAsyncLifecycleContract(groups)) {
+    return [];
+  }
+  const stageByRole: Record<
+    AsyncLifecycleRole,
+    { kind: BehaviorLifecycleStageKind; label: string }
+  > = {
+    consistency: {
+      kind: "condition",
+      label: "Apply the changed stale or duplicate delivery guard.",
+    },
+    dispatch: {
+      kind: "side-effect",
+      label: "Dispatch the changed asynchronous work.",
+    },
+    state: {
+      kind: "state-change",
+      label: "Persist the changed asynchronous lifecycle state.",
+    },
+    completion: {
+      kind: "observable-outcome",
+      label: "Observe the changed result handling or acknowledgement.",
+    },
+  };
+
+  return (["consistency", "dispatch", "state", "completion"] as const).flatMap((role) => {
+    const roleEvidence = groups.get(role) ?? [];
+    if (roleEvidence.length === 0) {
+      return [];
+    }
+    const stage = stageByRole[role];
+    const files = uniqueStrings(roleEvidence.map((item) => item.file ?? "").filter(Boolean));
+    return [createLifecycleStage(stage.kind, stage.label, "medium", roleEvidence, files)];
+  });
 }
 
 function lifecycleFromPerformanceEvidence(
@@ -2029,12 +2070,7 @@ function buildIntentQaScenarios(
   const hasState = asyncLifecycleRoles.has("state");
   const hasCompletion = asyncLifecycleRoles.has("completion");
   const hasConsistency = asyncLifecycleRoles.has("consistency");
-  const hasAsyncLifecycleContract = (
-    hasCompletion && (hasDispatch || hasState || hasConsistency)
-  ) || (
-    hasConsistency && (hasDispatch || hasState)
-  );
-  if (hasAsyncLifecycleContract) {
+  if (hasAsyncLifecycleContract(asyncLifecycleGroups)) {
     const asyncEvidence = uniqueEvidence(
       [...asyncLifecycleGroups.values()].flatMap((items) => items.slice(0, 2)),
     );
@@ -3289,7 +3325,7 @@ function collectDiffRiskEvidence(
 
 function matchRoutingSignal(line: string): string | undefined {
   const direct = line.match(
-    /\b(payload|deep.?link|destination|redirect\w*|router\.(?:push|replace)|navigate\w*|openurl|openlink|URLSearchParams|searchParams|location\.href|window\.location)\b/i,
+    /\b(deep.?link|destination|redirect\w*|router\.(?:push|replace)|navigate\w*|openurl|openlink|URLSearchParams|searchParams|location\.href|window\.location)\b/i,
   )?.[1];
   if (direct) {
     return direct;
@@ -4449,7 +4485,7 @@ function isBackgroundDispatchSchedulingLine(text: string, calendarSymbol: string
   if (!calendarSymbol || !/^schedul/i.test(calendarSymbol)) {
     return /^scheduler$/i.test(calendarSymbol ?? "");
   }
-  const hasBackgroundWork = /\b(?:job|task|worker|queue|dispatch|enqueue|consumer|scheduler)\b/i.test(
+  const hasBackgroundWork = /\b(?:build|job|task|worker|queue|dispatch|enqueue|consumer|scheduler)\b/i.test(
     text.replace(/([a-z])([A-Z])/g, "$1 $2"),
   );
   const hasTemporalBoundary =
@@ -4534,6 +4570,21 @@ function groupAsyncLifecycleEvidence(
     groups.set(role, items);
   }
   return groups;
+}
+
+function hasAsyncLifecycleContract(
+  groups: Map<AsyncLifecycleRole, ChangeIntentEvidence[]>,
+): boolean {
+  const roles = new Set(groups.keys());
+  const hasDispatch = roles.has("dispatch");
+  const hasState = roles.has("state");
+  const hasCompletion = roles.has("completion");
+  const hasConsistency = roles.has("consistency");
+  return (
+    hasCompletion && (hasDispatch || hasState || hasConsistency)
+  ) || (
+    hasConsistency && (hasDispatch || hasState)
+  );
 }
 
 function isUiBehaviorEvidence(evidence: ChangeIntentEvidence): boolean {

--- a/test/change-intent.test.mjs
+++ b/test/change-intent.test.mjs
@@ -763,6 +763,12 @@ test("long pull requests preserve independent intents across broad shared vocabu
   assert.ok(analysis.intents.some((intent) => /optimize shared package build concurrency/i.test(intent.title)));
   assert.ok(analysis.intents.some((intent) => /remove shared package legacy preview/i.test(intent.title)));
   assert.ok(analysis.intents.some((intent) => /break shared package import cycle/i.test(intent.title)));
+  assert.equal(
+    analysis.intents
+      .flatMap((intent) => intent.scenarios)
+      .some((scenario) => scenario.title === "Scheduling, calendar, and duplicate boundary"),
+    false,
+  );
   const buttonIntent = analysis.intents.find((intent) =>
     /preserve shared package button compatibility/i.test(intent.title)
   );
@@ -4894,6 +4900,19 @@ test("JavaScript producer and consumer changes expose asynchronous ordering risk
   assert.ok(scenario.evidence.some((item) => /lifecycle completion evidence/i.test(item.value)));
   assert.ok(scenario.evidence.some((item) => /lifecycle consistency evidence/i.test(item.value)));
   assert.ok(scenario.assertions.some((assertion) => /repeated delivery creates one durable effect/i.test(assertion)));
+  assert.equal(
+    analysis.intents
+      .flatMap((intent) => intent.scenarios)
+      .some((candidate) => candidate.title === "Entry payload and destination routing"),
+    false,
+  );
+
+  const qa = await generateQaDraft(root, { base: "main", head: "HEAD" });
+  const trace = qa.traces.find((candidate) => candidate.scenario.id === scenario.id);
+  assert.ok(trace);
+  assert.equal(trace.status, "traceable");
+  assert.equal(trace.evidenceAssessment.disposition, "confirmed");
+  assert.ok(trace.behavior.every((stage) => stage.relation === "evidence-linked"));
 });
 
 test("Python task and callback changes expose the same asynchronous lifecycle contract", async (t) => {
@@ -4944,6 +4963,19 @@ test("Python task and callback changes expose the same asynchronous lifecycle co
   assert.ok(scenario.edgeCases.includes("Stale result"));
   assert.equal(scenario.edgeCases.includes("Repeated delivery"), false);
   assert.ok(scenario.evidence.some((item) => item.file === callbackFile && /consistency evidence/i.test(item.value)));
+  assert.equal(
+    analysis.intents
+      .flatMap((intent) => intent.scenarios)
+      .some((candidate) => candidate.title === "Entry payload and destination routing"),
+    false,
+  );
+
+  const qa = await generateQaDraft(root, { base: "main", head: "HEAD" });
+  const trace = qa.traces.find((candidate) => candidate.scenario.id === scenario.id);
+  assert.ok(trace);
+  assert.equal(trace.status, "traceable");
+  assert.equal(trace.evidenceAssessment.disposition, "confirmed");
+  assert.ok(trace.behavior.every((stage) => stage.relation === "evidence-linked"));
 });
 
 test("status vocabulary and background scheduling names do not fabricate lifecycle or calendar QA", async (t) => {


### PR DESCRIPTION
## Summary

- Suppress calendar QA for build-queue scheduling names and routing QA for generic payload variables.
- Attach valid asynchronous lifecycle evidence to exact behavior stages so required scenarios remain traceable.
- Lock both boundaries into public benchmark contracts with zero untraceable required scenarios.

## Behavioral Contract

QAMap should keep true calendar, navigation, and asynchronous lifecycle behavior, while refusing to promote isolated vocabulary into unrelated required QA. Valid multi-role asynchronous evidence should produce evidence-linked lifecycle stages. Static QA output remains `not-run` until a separate runner executes a command.

## Evidence

Closes #246.

Positive coverage includes JavaScript and Python producer-consumer lifecycles plus the existing calendar and redirect fixtures. Negative controls cover build scheduling, generic payload arguments, and isolated state vocabulary that must not fabricate a lifecycle.

## Checks

Check only what applies. Mark the rest `N/A` in Review Notes.

- [x] Focused regression test
- [x] `pnpm test`
- [x] `pnpm bench:ci` for inference, routing, trace, or output
- [ ] `pnpm bench:execution` for E2E compiler or execution fixtures
- [ ] `pnpm scan` for scanner, security, or repository policy
- [ ] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
- [ ] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

- `pnpm test`: 440 tests passed.
- `pnpm bench:ci`: all 41 public contracts passed; both affected cases report zero untraceable required scenarios.
- `pnpm check`, `git diff --check`, and coverage passed. Coverage is 90.83% lines, 87.11% branches, and 95.79% functions.
- QAMap's independent static comparison produced two confirmed traces with no source or mapping gaps and correctly kept execution as `not-run`.
- `pnpm bench:agent --dry-run --assert` passed its dry-run contract; no provider token or cost result is claimed.
- Execution benchmark, scanner, plugin checks, and documentation verification are N/A because those surfaces did not change.
