### PR TITLE
Chore: prepare 0.4.17 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qamap",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "Turn PR changes into traceable local QA decisions and optional automation handoffs without an LLM call.",
   "author": {
     "name": "IvoryCanvas",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qamap",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "Turn PR changes into traceable local QA decisions and optional automation handoffs without an LLM call.",
   "author": {
     "name": "IvoryCanvas",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,26 @@
 
 ## Unreleased
 
+## 0.4.17 - 2026-09-04
+
+### Added
+
+- OpenAPI and Swagger responses with usable schemas now retain method, status, media type, shape, and `schema-derived` provenance without inventing concrete payload values.
+- Diverged target and proposed branches now surface a critical preservation scenario when non-equivalent changes overlap on the same behavior-bearing file.
+- Flutter projects, Dart tests and assertions, `flutter test`, and compatible workspace wrappers now participate in project detection and repository validation.
+
+### Changed
+
+- The English and Korean READMEs are shorter first-run entry points, with detailed output and reference material routed to focused guides.
+- Commitless mixed diffs and multi-commit changes preserve independent intent and flow boundaries unless exact repository evidence connects them.
+- Changed repository tests remain visible as behavior contracts, retain supported explicit source assertions, and keep the selected contract through compact agent output with an omitted-contract count.
+- Repository validation prefers commands that can start in the current execution boundary. Python Compose commands can fall back to the same available local runner, while explicit execution probes only the selected prerequisite and reports blocked honestly.
+
 ### Fixed
 
+- CI cleanup retries only transient removal of temporary fixture repositories, while test commands and assertions remain strict. The README badge now reports `main` push health instead of unrelated pull-request runs.
+- Vocabulary-only scheduling and routing matches no longer create required scenarios, while valid asynchronous lifecycle stages keep exact source evidence.
 - Working-tree changes can recover a low-confidence behavior intent from an exactly related changed test contract without pulling in similarly named neighboring surfaces.
-- Changed repository test contracts remain visible beside more concrete product assertions, and review-only automation now routes to the focused repository test command when one is available.
-- Python validation no longer assumes a detected Compose wrapper exists in the local service image. Static QA falls back when Docker is unavailable, while explicit `qa run` probes only the selected runner prerequisite, uses the same framework command without the missing wrapper when possible, and otherwise returns a blocked receipt without starting project tests.
-- Changed test contracts now include a bounded source-level assertion when QAMap finds supported explicit syntax. Agent output ranks the contract selected by the repository validation command first, keeps at least one contract through 4 KB compaction, and reports how many contracts were omitted without claiming the tests ran.
 
 ## 0.4.16 - 2026-08-29
 

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -26,6 +26,44 @@ a new runtime guarantee beyond the declared Node.js `>=20` engine contract.
 Node.js 20 is upstream EOL, so the README recommends an actively supported LTS
 release even though the compatibility smoke still passes.
 
+## 0.4.17 - 2026-09-04
+
+QAMap 0.4.17 improves the path from an imperfect repository diff to an honest,
+compact QA handoff. Schema-backed network responses now retain their authority
+and provenance without becoming invented payloads. Independent working-tree and
+multi-commit changes stay separate, while genuinely overlapping target and
+proposed branch changes surface as an integration preservation risk with exact
+evidence from both sides.
+
+Repository evidence is also more useful across toolchains. Flutter and Dart
+tests participate in project detection and focused validation, and Python
+Compose commands fall back only when the same repository-declared runner is
+available. Changed tests can recover a review-required working-tree intent and
+retain a bounded explicit assertion. The validation command's selected contract
+survives the 4 KB agent handoff, omitted contracts remain counted, and static
+analysis never reports those tests as executed.
+
+| Gate | Candidate result |
+| --- | --- |
+| `pnpm release:check` | Passed end to end |
+| `pnpm test` | 450/450 passing |
+| `pnpm scan` | 0 findings |
+| `pnpm bench:ci` | 43/43 committed static recommendation contracts passing |
+| `pnpm bench:agent --dry-run --assert` | Offline harness and result-shape contract passed; no provider invoked |
+| `pnpm bench:context` | 10/10 context identity and reuse checks passing |
+| `pnpm bench:execution` | 3/3 execution contracts passing; all three seeded regressions caught |
+| Coverage | Lines 90.94%, branches 87.33%, functions 95.82% |
+| Plugin package smoke | Packed 213 files, installed the 0.4.17 artifact in isolation, and produced evidence-backed agent output |
+| Package preview | `pnpm pack --dry-run` and `npm publish --dry-run --access public` pass for `@ivorycanvas/qamap@0.4.17`; 213 files packed |
+
+QAMap's own working-tree analysis classified this candidate as repository
+release readiness, selected `pnpm run release:check`, retained zero unrelated
+test contracts, and kept execution `not-run`. These gates prove the committed
+public fixtures, package integrity, and bounded execution contracts. They do not
+prove arbitrary product behavior or turn inferred scenarios into passing QA.
+npm publication, Git tagging, the GitHub Release, and an OpenAI directory update
+remain separate post-merge actions.
+
 ## 0.4.16 - 2026-08-29
 
 QAMap 0.4.16 tightens three boundaries between static QA guidance and trusted

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,12 +36,13 @@ Before treating the next public release as ready, the golden demo must satisfy t
 
 There is no fixed end date or patch count for `0.4.x`. QAMap will remain on compatible patch releases while real repositories still expose material gaps in change intent, affected-flow selection, scenario evidence, or automation-draft quality. `0.5.x` is not the next scheduled milestone; it is a release bar that must be earned by a stable, explicitly approved execution contract and evidence from repeated use outside the maintainer's repositories.
 
-### Current Focus After 0.4.16
+### Current Focus After 0.4.17
 
 The OpenAI Plugin Directory is a real first-run surface, so the next patches
 continue to prioritize recommendation quality over another distribution channel
-or runner name. QAMap 0.4.16 closes the first performance-routing, network
-authority, release-gate, and working-tree isolation gaps. The remaining
+or runner name. QAMap 0.4.17 preserves schema-derived response provenance,
+independent and diverged branch intent, Flutter validation evidence, runnable
+Python validation, and explicit changed-test assertions. The remaining
 generalized work queue is:
 
 1. Add declared schema-aware materializer adapters and explicit repository-owned
@@ -51,9 +52,10 @@ generalized work queue is:
 2. Expand declared executor coverage beyond the current browser fixtures. Add
    unrelated API, CLI, or mobile controls that prove the same generated artifact
    fails for its intended seeded regression and passes for the fixed behavior.
-3. Treat changed repository tests as behavior contracts. Preserve explicit
-   positive, negative, boundary, state-transition, retry, and invariance
-   assertions instead of reducing them to a generic request to run the suite.
+3. Broaden changed-test contract recovery beyond the currently supported
+   single-line assertion forms. Preserve positive, negative, boundary,
+   state-transition, retry, and invariance meaning without copying arbitrary
+   literals or treating a test title as executed proof.
 4. Trace shared semantic producers to every affected consumer. A change to a
    mapper, copy builder, aggregate, or service rule should retain the screens,
    history views, notifications, and exports that reuse its result when import
@@ -77,6 +79,12 @@ generalized work queue is:
    deterministic result with independent review. Preserve `not-run`, `passed`,
    `failed`, and `blocked` exactly; plugin availability is not evidence that
    product QA ran.
+10. Recover working-tree behavior consistently across supported component and
+    mobile projects without pulling unchanged neighboring flows into the result.
+    Project detection alone must not be presented as affected behavior.
+11. Rank behavior-bearing source and test evidence ahead of supporting schemas,
+    generated metadata, and release files in compact output while keeping every
+    retained judgment traceable.
 
 - Stabilize commit-range Change Intent analysis: related behavior commits, diff symbols, confidence, review requirements, lifecycle stages, and runner-independent QA scenarios.
 - Preserve a conservative diff-only intent when commit messages are not descriptive, while keeping low-confidence scenarios recommended and review-required until stronger evidence exists.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivorycanvas/qamap",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "Local zero-LLM PR QA designer that maps commit intent and diffs to traceable behavior lifecycles, QA scenarios, and optional automation drafts.",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugin/submission.json
+++ b/plugin/submission.json
@@ -79,5 +79,5 @@
       "reason": "The plugin must preserve the host's approval policy and QAMap's explicit action boundary."
     }
   ],
-  "releaseNotes": "QAMap 0.4.16 routes supported performance changes to measurable runtime contracts, requires authoritative API examples before generating mock payloads, isolates working-tree release validation from earlier commit tests, and refreshes the public plugin assets."
+  "releaseNotes": "QAMap 0.4.17 preserves independent and diverged branch intents, adds schema-derived response provenance and Flutter validation evidence, selects runnable repository commands, and keeps changed test assertions visible in compact agent output."
 }

--- a/skills/qamap-pr-qa/SKILL.md
+++ b/skills/qamap-pr-qa/SKILL.md
@@ -21,7 +21,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
    If QAMap is not installed, disclose that the next command downloads the pinned package from the npm registry and follow the host's network approval policy before running it:
 
    ```sh
-   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.16 -- qamap qa . --base <base> --head HEAD --format agent
+   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.17 -- qamap qa . --base <base> --head HEAD --format agent
    ```
 
    This one-off form runs outside the target repository's package-manager contract, so it does not invoke Corepack or add a `packageManager` field. QAMap's analysis does not upload source code or make another LLM call. The calling agent still uses its own model tokens to invoke the skill and interpret the compact result.
@@ -37,7 +37,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
    - Use an explicit scoped pass only when a human wants to override that decision:
 
    ```sh
-   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.16 -- qamap qa <package-path> --workspace-root . --base <base> --head HEAD
+   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.17 -- qamap qa <package-path> --workspace-root . --base <base> --head HEAD
    ```
 
 4. Read and verify intent before generating code. In agent format:
@@ -60,7 +60,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
    - `run-repository-command` — when policy permits repository code execution, prefer QAMap's bounded executor so analysis and execution share one receipt:
 
      ```sh
-     npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.16 -- qamap qa run . --base <base> --head HEAD --format agent
+     npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.17 -- qamap qa run . --base <base> --head HEAD --format agent
      ```
 
      It re-analyzes the change and runs only the exact selected existing repository command. Do not substitute another command or run it again when `execution.performed` is true.
@@ -70,7 +70,7 @@ Use QAMap as a final local QA pass before presenting a pull request for human re
 6. Only after a human or team accepts the scenario and automation adapter, create or preview executable coverage:
 
    ```sh
-   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.16 -- qamap e2e draft . --base <base> --head HEAD --dry-run
+   npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.17 -- qamap e2e draft . --base <base> --head HEAD --dry-run
    ```
 
    If the selected adapter is absent, inspect and explicitly accept the `automation.setupCommand` proposal. Never install a runner merely because QAMap detected a web or mobile surface.
@@ -106,7 +106,7 @@ When the recommendation is wrong or too broad, do not repeatedly re-prompt for t
 If the team accepts QAMap for ongoing use, suggest this follow-up:
 
 ```sh
-npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.16 -- qamap manifest init .
+npm exec --yes --registry=https://registry.npmjs.org --package=@ivorycanvas/qamap@0.4.17 -- qamap manifest init .
 ```
 
 Then humans should review `.qamap/manifest.yaml` and keep only durable team QA language.

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const TOOL_NAME = "QAMap";
-export const VERSION = "0.4.16";
+export const VERSION = "0.4.17";


### PR DESCRIPTION
## Summary

- Synchronize the npm package, CLI, Codex plugin, Claude plugin, and portable skill at version 0.4.17.
- Publish one changelog and validation record for schema-backed response provenance, independent and diverged branch intent, Flutter and Python validation, and compact changed-test contracts.
- Update the roadmap and OpenAI submission notes while keeping the shorter English and Korean README entry points unchanged.

## Behavioral Contract

The 0.4.17 package must keep unrelated changes in separate QA intents, surface overlapping diverged-branch changes as preservation risks, retain schema-derived response authority without inventing payloads, select repository commands that can start, and preserve the selected changed-test assertion through compact agent output.

Static QAMap output remains not-run until a selected repository command is explicitly executed.

## Evidence

Closes #256.

Included work: #235, #237, #239, #241, #243, #245, #247, #252, #253, #254, and #255.

QAMap analyzed this release-only working tree, classified it as repository release readiness, selected pnpm run release:check, retained zero unrelated test contracts, and kept execution not-run.

## Checks

Check only what applies. Mark the rest N/A in Review Notes.

- [ ] Focused regression test
- [x] pnpm test
- [x] pnpm bench:ci for inference, routing, trace, or output
- [x] pnpm bench:execution for E2E compiler or execution fixtures
- [x] pnpm scan for scanner, security, or repository policy
- [x] pnpm plugin:check and pnpm plugin:smoke for plugin changes
- [x] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

Two consecutive pnpm release:check runs passed. The final candidate has 450 passing tests, 43 passing static benchmark contracts, 10 passing context checks, 3 passing execution contracts that catch all seeded regressions, zero scan findings, and a 213-file package smoke and preview. Coverage measured 90.94% lines, 87.27-87.33% branches, and 95.82% functions. npm publish --dry-run --access public also passed.

The focused regression test is not applicable to the release-only commit; every included behavior change was independently regression-tested before merge. npm publication, Git tagging, the GitHub Release, and the OpenAI directory replacement remain post-merge actions.
