### PR TITLE
Feat: enforce pull request contribution policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.32.1
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           cache: pnpm
@@ -50,13 +50,13 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 10.32.1
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,25 @@
+name: Dependency review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -1,0 +1,27 @@
+name: PR policy
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-policy-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  contribution-policy:
+    name: Contribution policy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+      - name: Validate contribution policy
+        run: node scripts/check-pr-policy.mjs "$GITHUB_EVENT_PATH"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,16 @@ Every pull request should:
 - complete every applicable template section
 - exclude private repository and local smoke details
 
+The `PR policy` workflow checks these conventions when a pull request is ready
+for review. It validates the title and branch prefix, required template
+sections, completed public-OSS confirmations, exactly one `type:` label, and at
+least one `area:` label. Draft pull requests are intentionally skipped so work
+in progress can remain incomplete.
+
+Dependency changes also receive a read-only vulnerability review. Neither check
+comments on the pull request, changes labels, or executes code from the pull
+request with elevated permissions.
+
 Maintainers assign `@ivory-code`, apply exactly one `type:` label plus relevant
 `area:` labels, and squash-merge after required checks pass. Contributors do not
 need elevated permissions.

--- a/scripts/check-pr-policy.mjs
+++ b/scripts/check-pr-policy.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const REQUIRED_SECTIONS = [
+  "Summary",
+  "Behavioral Contract",
+  "Evidence",
+  "Checks",
+  "Public OSS Check",
+  "Review Notes",
+];
+
+const CONTENT_SECTIONS = ["Summary", "Behavioral Contract", "Evidence"];
+const TITLE_PATTERN = /^(?:Feat|Fix|Test|Docs|Refactor|Style|Chore|Hotfix): \S(?:.*\S)?$/;
+const BRANCH_PATTERN = /^(?:feat|fix|test|refactor|style|hotfix|chore|docs)\/[a-z0-9](?:[a-z0-9._/-]*[a-z0-9])?$/;
+
+export function validatePullRequestEvent(event) {
+  const pullRequest = event?.pull_request;
+  if (!pullRequest) {
+    return {
+      skipped: false,
+      errors: ["The event payload does not contain a pull request."],
+    };
+  }
+
+  if (pullRequest.draft === true) {
+    return { skipped: true, errors: [] };
+  }
+
+  const errors = [];
+  const title = typeof pullRequest.title === "string" ? pullRequest.title : "";
+  const branch = typeof pullRequest.head?.ref === "string" ? pullRequest.head.ref : "";
+  const body = typeof pullRequest.body === "string" ? pullRequest.body : "";
+  const labels = Array.isArray(pullRequest.labels)
+    ? pullRequest.labels
+        .map((label) => (typeof label === "string" ? label : label?.name))
+        .filter((label) => typeof label === "string")
+    : [];
+
+  if (!TITLE_PATTERN.test(title)) {
+    errors.push(
+      "Use a capitalized Conventional Commit type in the PR title, for example `Feat: add route evidence`.",
+    );
+  }
+
+  if (!BRANCH_PATTERN.test(branch)) {
+    errors.push(
+      "Use a documented lowercase branch prefix: feat/, fix/, test/, refactor/, style/, hotfix/, chore/, or docs/.",
+    );
+  }
+
+  const sections = extractSections(body);
+  for (const heading of REQUIRED_SECTIONS) {
+    const matchingSections = sections.filter((section) => section.heading === heading);
+    if (matchingSections.length === 0) {
+      errors.push(`Add the required \`## ${heading}\` section.`);
+    } else if (matchingSections.length > 1) {
+      errors.push(`Keep exactly one \`## ${heading}\` section.`);
+    }
+  }
+
+  for (const heading of CONTENT_SECTIONS) {
+    const section = sections.find((candidate) => candidate.heading === heading);
+    if (section && !hasVisibleContent(section.content)) {
+      errors.push(`Describe the pull request in \`## ${heading}\` instead of leaving it empty.`);
+    }
+  }
+
+  const checks = sections.find((section) => section.heading === "Checks");
+  if (checks && countCheckedBoxes(checks.content) === 0) {
+    errors.push("Mark at least one completed item in `## Checks`.");
+  }
+
+  const publicOss = sections.find((section) => section.heading === "Public OSS Check");
+  if (publicOss) {
+    const boxes = checkboxStates(publicOss.content);
+    if (boxes.length < 3 || boxes.some((checked) => !checked)) {
+      errors.push("Complete every checkbox in `## Public OSS Check`.");
+    }
+  }
+
+  const typeLabels = labels.filter((label) => label.startsWith("type: "));
+  if (typeLabels.length !== 1) {
+    errors.push("Apply exactly one `type:` label.");
+  }
+  if (!labels.some((label) => label.startsWith("area: "))) {
+    errors.push("Apply at least one `area:` label.");
+  }
+
+  return { skipped: false, errors };
+}
+
+function extractSections(body) {
+  const matches = [...body.matchAll(/^##[ \t]+(.+?)[ \t]*$/gm)];
+  return matches.map((match, index) => {
+    const contentStart = (match.index ?? 0) + match[0].length;
+    const contentEnd = matches[index + 1]?.index ?? body.length;
+    return {
+      heading: match[1],
+      content: body.slice(contentStart, contentEnd),
+    };
+  });
+}
+
+function hasVisibleContent(content) {
+  return content.replace(/<!--[\s\S]*?-->/g, "").trim().length > 0;
+}
+
+function checkboxStates(content) {
+  return [...content.matchAll(/^\s*-\s+\[([ xX])\]\s+/gm)].map(
+    (match) => match[1].toLowerCase() === "x",
+  );
+}
+
+function countCheckedBoxes(content) {
+  return checkboxStates(content).filter(Boolean).length;
+}
+
+async function runCli() {
+  const eventPath = process.argv[2] ?? process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) {
+    throw new Error("Pass the pull request event path or set GITHUB_EVENT_PATH.");
+  }
+
+  const event = JSON.parse(await readFile(eventPath, "utf8"));
+  const result = validatePullRequestEvent(event);
+
+  if (result.skipped) {
+    console.log("Draft pull request: contribution policy check skipped.");
+    return;
+  }
+
+  if (result.errors.length > 0) {
+    console.error("Pull request contribution policy failed:");
+    for (const error of result.errors) {
+      console.error(`- ${error}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log("Pull request contribution policy passed.");
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  await runCli();
+}

--- a/test/contributor-workflow.test.mjs
+++ b/test/contributor-workflow.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFile, stat } from "node:fs/promises";
+import { readFile, readdir, stat } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -75,6 +75,53 @@ test("the pull request template asks for behavior and evidence", async () => {
   ]) {
     assert.match(template, new RegExp(`^${heading}$`, "m"));
   }
+});
+
+test("pull request workflows stay read-only and pin external actions", async () => {
+  const workflowDirectory = path.join(repositoryRoot, ".github/workflows");
+  const workflowFiles = (await readdir(workflowDirectory)).filter((file) => file.endsWith(".yml"));
+
+  for (const filename of workflowFiles) {
+    const source = await readFile(path.join(workflowDirectory, filename), "utf8");
+    const workflow = parseYaml(source);
+
+    assert.ok(!source.includes("pull_request_target"), `${filename} must remain safe for fork PRs`);
+    if (workflow.on?.pull_request !== undefined) {
+      assert.equal(workflow.permissions?.contents, "read", `${filename} needs read-only contents`);
+    }
+
+    for (const match of source.matchAll(/^\s*uses:\s*(\S+)/gm)) {
+      const action = match[1];
+      if (action.startsWith("./")) {
+        continue;
+      }
+      assert.match(
+        action,
+        /^[^@\s]+@[0-9a-f]{40}$/,
+        `${filename} must pin ${action} to a full commit SHA`,
+      );
+    }
+  }
+});
+
+test("ready pull requests receive policy and dependency review checks", async () => {
+  const policy = parseYaml(
+    await readFile(path.join(repositoryRoot, ".github/workflows/pr-policy.yml"), "utf8"),
+  );
+  const dependencyReview = parseYaml(
+    await readFile(path.join(repositoryRoot, ".github/workflows/dependency-review.yml"), "utf8"),
+  );
+
+  assert.equal(policy.jobs["contribution-policy"].name, "Contribution policy");
+  assert.match(
+    policy.jobs["contribution-policy"].steps.at(-1).run,
+    /scripts\/check-pr-policy\.mjs/,
+  );
+  assert.equal(dependencyReview.jobs["dependency-review"].name, "Dependency review");
+  assert.equal(
+    dependencyReview.jobs["dependency-review"].steps.at(-1).with["fail-on-severity"],
+    "high",
+  );
 });
 
 test("entry-point documentation links resolve inside the repository", async () => {

--- a/test/pr-policy.test.mjs
+++ b/test/pr-policy.test.mjs
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { REQUIRED_SECTIONS, validatePullRequestEvent } from "../scripts/check-pr-policy.mjs";
+
+const scriptPath = fileURLToPath(new URL("../scripts/check-pr-policy.mjs", import.meta.url));
+
+const validBody = `## Summary
+
+Add a deterministic contribution policy check.
+
+## Behavioral Contract
+
+Ready pull requests report every policy violation in one run.
+
+## Evidence
+
+Closes #265.
+
+## Checks
+
+- [x] Focused regression test
+- [ ] \`pnpm test\`
+
+## Public OSS Check
+
+- [x] No private repository data is included.
+- [x] Shared inference coverage is present or not applicable.
+- [x] User-facing claims match actual behavior.
+
+## Review Notes
+
+Other checks are not applicable.
+`;
+
+function eventWith(overrides = {}) {
+  const pullRequest = {
+    draft: false,
+    title: "Feat: enforce pull request contribution policy",
+    body: validBody,
+    head: { ref: "feat/contribution-policy-ci" },
+    labels: [{ name: "type: feat" }, { name: "area: github-action" }],
+    ...overrides,
+  };
+  return { pull_request: pullRequest };
+}
+
+test("accepts a ready pull request that follows the contribution contract", () => {
+  assert.deepEqual(validatePullRequestEvent(eventWith()), { skipped: false, errors: [] });
+});
+
+test("allows an incomplete draft without weakening ready pull request policy", () => {
+  assert.deepEqual(
+    validatePullRequestEvent(
+      eventWith({ draft: true, title: "work in progress", body: "", labels: [] }),
+    ),
+    { skipped: true, errors: [] },
+  );
+});
+
+test("reports title and branch violations together", () => {
+  const result = validatePullRequestEvent(
+    eventWith({ title: "feat: lowercase type", head: { ref: "feature/unsupported" } }),
+  );
+
+  assert.equal(result.errors.length, 2);
+  assert.match(result.errors[0], /PR title/);
+  assert.match(result.errors[1], /branch prefix/);
+});
+
+test("requires every template section with visible core evidence", () => {
+  const body = validBody
+    .replace("Add a deterministic contribution policy check.", "<!-- empty -->")
+    .replace("## Evidence\n\nCloses #265.\n\n", "");
+  const result = validatePullRequestEvent(eventWith({ body }));
+
+  assert.ok(result.errors.some((error) => error.includes("`## Evidence`")));
+  assert.ok(result.errors.some((error) => error.includes("`## Summary`")));
+});
+
+test("requires completed validation and public OSS confirmations", () => {
+  const body = validBody.replaceAll("[x]", "[ ]");
+  const result = validatePullRequestEvent(eventWith({ body }));
+
+  assert.ok(result.errors.some((error) => error.includes("`## Checks`")));
+  assert.ok(result.errors.some((error) => error.includes("`## Public OSS Check`")));
+});
+
+test("requires one type label and at least one area label", () => {
+  const result = validatePullRequestEvent(
+    eventWith({ labels: [{ name: "type: feat" }, { name: "type: test" }] }),
+  );
+
+  assert.ok(result.errors.some((error) => error.includes("exactly one `type:`")));
+  assert.ok(result.errors.some((error) => error.includes("at least one `area:`")));
+});
+
+test("fails closed when the event is not a pull request", () => {
+  const result = validatePullRequestEvent({});
+
+  assert.equal(result.skipped, false);
+  assert.match(result.errors[0], /does not contain a pull request/);
+});
+
+test("the CLI reads a GitHub event file and returns its policy result", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "qamap-pr-policy-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const eventPath = path.join(root, "event.json");
+  await writeFile(eventPath, JSON.stringify(eventWith()), "utf8");
+
+  const result = spawnSync(process.execPath, [scriptPath, eventPath], { encoding: "utf8" });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /contribution policy passed/);
+});
+
+test("the CLI exits non-zero with actionable errors for an invalid ready PR", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "qamap-pr-policy-invalid-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const eventPath = path.join(root, "event.json");
+  await writeFile(
+    eventPath,
+    JSON.stringify(eventWith({ title: "feat: invalid title", labels: [] })),
+    "utf8",
+  );
+
+  const result = spawnSync(process.execPath, [scriptPath, eventPath], { encoding: "utf8" });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /contribution policy failed/);
+  assert.match(result.stderr, /PR title/);
+  assert.match(result.stderr, /exactly one `type:` label/);
+  assert.match(result.stderr, /at least one `area:` label/);
+});
+
+test("the validator and pull request template share the same required headings", () => {
+  assert.deepEqual(REQUIRED_SECTIONS, [
+    "Summary",
+    "Behavioral Contract",
+    "Evidence",
+    "Checks",
+    "Public OSS Check",
+    "Review Notes",
+  ]);
+});


### PR DESCRIPTION
## Summary

- Enforce the documented contribution contract on ready pull requests.
- Add a read-only dependency vulnerability review for pull request changes.
- Pin every current third-party GitHub Action to an immutable commit SHA.
- Document the automated checks for contributors.

Closes #265.

## Behavioral Contract

Draft pull requests remain unrestricted. Once a pull request is ready, one fast check validates its title, branch prefix, required body sections, completed validation and public-OSS confirmations, exactly one `type:` label, and at least one `area:` label. Policy failures are reported together without comments or repository writes. Dependency changes fail review only for high or critical vulnerabilities.

## Evidence

- Added positive, draft, failure, boundary, label, and CLI exit-code coverage in `test/pr-policy.test.mjs`.
- Added repository workflow assertions for read-only permissions, fork-safe triggers, immutable action references, and dependency review severity.
- QAMap selected and ran `pnpm build && node --test test/contributor-workflow.test.mjs test/pr-policy.test.mjs`; 22 tests passed and the execution changed no Git-observable files.

## Checks

- [x] Focused regression test
- [x] `pnpm test`
- [ ] `pnpm bench:ci` for inference, routing, trace, or output
- [ ] `pnpm bench:execution` for E2E compiler or execution fixtures
- [x] `pnpm scan` for scanner, security, or repository policy
- [ ] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
- [x] Documentation links and commands verified

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

Inference, E2E compiler, and plugin checks are not applicable because this change affects repository contribution policy only. The existing full test suite passed with 460 tests and no failures. The repository scan returned zero findings.
