### PR TITLE
Fix: preserve independent test lifecycle contracts

### DIFF
--- a/docs/agent-format.md
+++ b/docs/agent-format.md
@@ -83,6 +83,21 @@ Read `inferenceBoundary` before treating an inferred lifecycle as repository pol
 
 List fields are capped to keep the payload small; caps may grow within version 1 but the shapes above will not change.
 
+## Independent Test Expectations
+
+When two or more related changed tests contain contract-bearing assertions,
+QAMap gives each its own review-required scenario. A typing expectation stays
+with its typing condition; a pending-request expectation stays separate from
+success, failure, and recovery. Equal test titles remain distinct by their file
+and declaration line. These expectations do not become a combined assertion in
+the aggregate product scenario.
+
+Only supported assertions near an added test declaration participate. Setup and
+actions come from that declaration's bounded lifecycle evidence; missing fields
+stay empty. Existing scenario limits still apply, so inspect omitted counts and
+the full report when consuming compact output. This is static contract analysis,
+not proof that the tests or the application passed.
+
 ## Example
 
 The trace portion below is shown with line breaks for readability. The CLI keeps it on the same single JSON line as the compatibility fields that follow.

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -4,6 +4,22 @@
 > public release. Older released sections are preserved as historical receipts
 > and are not required reading for contributors or users.
 
+## Unreleased - Lifecycle Contracts
+
+Changed tests can now connect to commit-backed product lifecycles, including
+Ruby Minitest contracts. Contract-bearing assertions strengthen the associated
+lifecycle; implementation-only existence checks remain supporting evidence.
+
+Related changed tests keep their conditions and assertions in separate
+scenarios. Public fixtures cover masked typing, paste, display policy, submission,
+and asynchronous loading, success, failure, and retry. Equal titles preserve
+distinct declaration locations; missing actions remain empty. The five tests in
+`test/independent-lifecycle-contracts.test.mjs` failed before the fix and pass
+after it. The full suite passes 472 tests.
+
+These results verify QAMap's static analysis, not browser or device execution.
+The implementation is pending a package release.
+
 ## Package Manager Compatibility - 2026-08-11
 
 The public `@ivorycanvas/qamap@0.4.13` package was installed and exercised in
@@ -38,13 +54,10 @@ evidence from both sides.
 Repository evidence is also more useful across toolchains. Flutter and Dart
 tests participate in project detection and focused validation, and Python
 Compose commands fall back only when the same repository-declared runner is
-available. Changed tests can recover a review-required working-tree intent,
-connect to a commit-backed product lifecycle, and retain a bounded explicit
-assertion. Contract-bearing assertions can strengthen lifecycle evidence while
-implementation-only existence checks remain supporting test evidence. The
-validation command's selected contract survives the 4 KB agent handoff, omitted
-contracts remain counted, and static analysis never reports those tests as
-executed.
+available. Changed tests can recover a review-required working-tree intent and
+retain a bounded explicit assertion. The validation command's selected contract
+survives the 4 KB agent handoff, omitted contracts remain counted, and static
+analysis never reports those tests as executed.
 
 | Gate | Candidate result |
 | --- | --- |

--- a/src/change-intent.ts
+++ b/src/change-intent.ts
@@ -941,7 +941,7 @@ function buildCommitIntent(
   const housekeepingOnly = commits.every((commit) => isCleanupCommitStatement(commit.statement));
   const scenarios = housekeepingOnly
     ? []
-    : buildIntentQaScenarios(id, title, lifecycle, keywords, scenarioEvidence, confidence);
+    : buildIntentQaScenarios(id, title, lifecycle, keywords, scenarioEvidence, confidence, relevantTestContracts);
   return {
     id,
     title,
@@ -1229,7 +1229,7 @@ function buildDiffOnlyIntent(
     keywords,
     evidence,
     lifecycle,
-    scenarios: buildIntentQaScenarios(id, title, lifecycle, keywords, evidence, "low"),
+    scenarios: buildIntentQaScenarios(id, title, lifecycle, keywords, evidence, "low", testContracts),
     reviewRequired: true,
   };
 }
@@ -1271,7 +1271,7 @@ function changedTestContractEvidenceSet(contract: ChangedTestContract): ChangeIn
 }
 
 function lifecycleFromChangedTestContracts(contracts: ChangedTestContract[]): BehaviorLifecycleStage[] {
-  return contracts.slice(0, 3).flatMap((contract) => {
+  return contracts.flatMap((contract) => {
     const contractEvidence = changedTestContractEvidence(contract);
     const assertionEvidence = changedTestAssertionEvidence(contract);
     if (!assertionEvidence || !isContractBearingChangedAssertion(assertionEvidence.value)) {
@@ -1307,6 +1307,44 @@ function lifecycleFromChangedTestContracts(contracts: ChangedTestContract[]): Be
     ));
     return stages;
   });
+}
+
+function changedTestQaScenarios(intentId: string, contracts: ChangedTestContract[]): IntentQaScenario[] {
+  const boundedContracts = contracts.filter((contract) =>
+    contract.assertion && isContractBearingChangedAssertion(contract.assertion)
+  );
+  if (boundedContracts.length < 2) {
+    return [];
+  }
+  return boundedContracts.map((contract) => {
+    const lifecycle = lifecycleFromChangedTestContracts([contract]);
+    const evidence = changedTestContractEvidenceSet(contract);
+    const scenario = makeScenario(
+      intentId,
+      `test-contract:${contract.file}:${contract.line}:${contract.title}`,
+      "state-transition",
+      "recommended",
+      sentenceTitle(contract.title),
+      lifecycle.filter((stage) => stage.kind === "condition").map((stage) => stage.label),
+      lifecycle.filter((stage) => stage.kind === "trigger" || stage.kind === "action").map((stage) => stage.label),
+      [`Verify repository-authored assertion \`${contract.assertion}\`.`],
+      [],
+      evidence,
+    );
+    scenario.rationale =
+      "A changed repository test pairs this condition with its own expected result. Review it as a draft contract; missing actions or setup require repository evidence and execution remains unverified.";
+    return scenario;
+  });
+}
+
+function isChangedTestEvidence(evidence: ChangeIntentEvidence): boolean {
+  return evidence.sourceRole === "test" &&
+    (evidence.symbol === "changed-test-contract" || evidence.symbol === "changed-test-assertion");
+}
+
+function changedTestEvidenceKey(evidence: ChangeIntentEvidence[]): string {
+  return evidence.filter((item) => item.symbol === "changed-test-contract")
+    .map((item) => `${item.file}:${item.startLine}`).join(":");
 }
 
 function isContractBearingChangedAssertion(assertion: string): boolean {
@@ -1750,7 +1788,7 @@ function createLifecycleStage(
 ): BehaviorLifecycleStage {
   const normalizedLabel = sentenceLabel(label);
   return {
-    id: stableId("stage", `${kind}:${normalizedLabel}:${evidence.map((item) => item.commit ?? item.file ?? item.value).join(":")}`),
+    id: stableId("stage", `${kind}:${normalizedLabel}:${evidence.map((item) => item.commit ?? item.file ?? item.value).join(":")}${symbol === "changed-test-contract" ? `:${changedTestEvidenceKey(evidence)}` : ""}`),
     kind,
     label: normalizedLabel,
     confidence,
@@ -1767,7 +1805,18 @@ function buildIntentQaScenarios(
   keywords: string[],
   evidence: ChangeIntentEvidence[],
   confidence: ChangeIntentConfidence,
+  testContracts: ChangedTestContract[] = [],
 ): IntentQaScenario[] {
+  const testScenarios = changedTestQaScenarios(intentId, testContracts);
+  if (testScenarios.length > 0) {
+    // Different tests can describe mutually exclusive states. Keep their
+    // conditions and expectations out of the aggregate product scenario.
+    lifecycle = lifecycle.map((stage) => ({
+      ...stage,
+      evidence: stage.evidence.filter((item) => !isChangedTestEvidence(item)),
+    })).filter((stage) => stage.evidence.length > 0);
+    evidence = evidence.filter((item) => !isChangedTestEvidence(item));
+  }
   const conditions = lifecycle.filter((stage) => stage.kind === "condition").map((stage) => stage.label);
   const actions = selectPrimaryLifecycleSteps(lifecycle, keywords);
   const outcomeStages = lifecycle
@@ -1813,7 +1862,7 @@ function buildIntentQaScenarios(
     primary.assertions.push(unresolvedPrimaryScenarioAssertion);
   }
 
-  const scenarios = [primary];
+  const scenarios = [primary, ...testScenarios];
   for (const annotatedRisk of qaAnnotationRiskScenarios(evidence).slice(0, 3)) {
     const riskScenario = makeScenario(
       intentId,
@@ -5513,7 +5562,7 @@ function uniqueLifecycleStages(stages: BehaviorLifecycleStage[]): BehaviorLifecy
   const unique: BehaviorLifecycleStage[] = [];
   const indexByKey = new Map<string, number>();
   for (const stage of stages) {
-    const key = `${stage.kind}:${stripTerminalPunctuation(stage.label).toLowerCase()}`;
+    const key = `${stage.kind}:${stripTerminalPunctuation(stage.label).toLowerCase()}${stage.symbol === "changed-test-contract" ? `:${changedTestEvidenceKey(stage.evidence)}` : ""}`;
     const existingIndex = indexByKey.get(key);
     if (existingIndex === undefined) {
       indexByKey.set(key, unique.length);
@@ -5553,7 +5602,7 @@ function uniqueCodeSignals(signals: CodeBehaviorSignal[]): CodeBehaviorSignal[] 
 function uniqueScenarios(scenarios: IntentQaScenario[]): IntentQaScenario[] {
   const seen = new Set<string>();
   return scenarios.filter((scenario) => {
-    const key = scenario.title.toLowerCase();
+    const key = `${scenario.title.toLowerCase()}:${changedTestEvidenceKey(scenario.evidence)}`;
     if (seen.has(key)) return false;
     seen.add(key);
     return true;

--- a/test/independent-lifecycle-contracts.test.mjs
+++ b/test/independent-lifecycle-contracts.test.mjs
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { generateQaDraft } from "../dist/qa.js";
+
+const inputContracts = [
+  ["shows a masked value after typing", "expect(input.value).toBe('12-34')"],
+  ["shows a normalized value after paste", "expect(input.value).toBe('56-78')"],
+  ["shows the display mask when unfocused", "expect(input.value).toBe('**-78')"],
+  ["preserves the raw value after submission", "expect(request.value).toBe('5678')"],
+];
+
+for (const committed of [true, false]) {
+  test(`input lifecycle contracts keep independent conditions and assertions (${committed ? "commit" : "working tree"})`, async (t) => {
+    const { qa, file } = await analyzeContracts(t, inputContracts, { committed });
+    const scenarios = assertIndependentContracts(qa, file, inputContracts);
+    for (const [index, scenario] of scenarios.entries()) {
+      const ownContext = ["After typing.", "After paste.", "When unfocused.", "After submission."][index];
+      assert.ok([...scenario.setup, ...scenario.steps].includes(ownContext));
+    }
+    assert.equal(qa.execution.status, "not-run");
+  });
+}
+
+test("mobile asynchronous outcomes retain pending, success, failure, and recovery contracts", async (t) => {
+  const contracts = [
+    ["shows loading while the request is pending", "expect(find.text('Loading'), findsOneWidget)"],
+    ["shows the result after the request succeeds", "expect(find.text('Ready'), findsOneWidget)"],
+    ["shows an error after the request fails", "expect(find.text('Unavailable'), findsOneWidget)"],
+    ["shows the result after retry succeeds", "expect(find.text('Recovered'), findsOneWidget)"],
+  ];
+  const { qa, file } = await analyzeContracts(t, contracts, { mobile: true });
+  const scenarios = assertIndependentContracts(qa, file, contracts);
+  assert.deepEqual(scenarios[0].setup, ["While the request is pending."]);
+  assert.ok(scenarios[3].steps.includes("After retry succeeds."));
+  assert.equal(qa.execution.status, "not-run");
+});
+
+test("equal test titles keep different expectations and evidence locations", async (t) => {
+  const contracts = [
+    ["shows the value after input", "expect(input.value).toBe('12-34')"],
+    ["shows the value after input", "expect(input.value).toBe('56-78')"],
+  ];
+  const { qa, file } = await analyzeContracts(t, contracts);
+  const scenarios = assertIndependentContracts(qa, file, contracts);
+  assert.equal(new Set(scenarios.map((scenario) => scenario.id)).size, 2);
+  const stages = qa.changeAnalysis.intents.flatMap((intent) => intent.lifecycle)
+    .filter((stage) => stage.kind === "observable-outcome" && stage.symbol === "changed-test-contract");
+  assert.equal(stages.length, 2);
+  assert.equal(new Set(stages.map((stage) => stage.id)).size, 2);
+  for (const stage of stages) {
+    assert.equal(stage.evidence.filter((item) => item.symbol === "changed-test-assertion").length, 1);
+  }
+});
+
+test("test contracts do not invent missing actions or promote existence checks", async (t) => {
+  const contracts = [
+    ["shows a valid value", "expect(input.value).toBe('12-34')"],
+    ["shows an empty value", "expect(input.value).toBe('')"],
+    ["shows an error after retry", "expect(helper).toBeDefined()"],
+  ];
+  const { qa, file } = await analyzeContracts(t, contracts);
+  const scenarios = assertIndependentContracts(qa, file, contracts.slice(0, 2));
+  for (const scenario of scenarios) {
+    assert.deepEqual(scenario.steps, []);
+    assert.deepEqual(scenario.setup, []);
+    assert.equal(scenario.reviewRequired, true);
+    assert.equal(scenario.confidence, "medium");
+  }
+  assert.ok(!scenarios.some((scenario) => /helper|retry/.test(JSON.stringify(scenario))));
+});
+
+function assertIndependentContracts(qa, file, contracts) {
+  const scenarios = qa.changeAnalysis.intents.flatMap((intent) => intent.scenarios)
+    .filter((scenario) => scenario.evidence.some((item) =>
+      item.file === file && item.symbol === "changed-test-assertion"
+    ));
+  assert.equal(scenarios.length, contracts.length, JSON.stringify(scenarios, null, 2));
+  return contracts.map(([title, assertion]) => {
+    const expected = `Verify repository-authored assertion \`${assertion}\`.`;
+    const scenario = scenarios.find((candidate) => candidate.assertions.includes(expected));
+    assert.ok(scenario, `Missing separate contract: ${title}\n${JSON.stringify(scenarios, null, 2)}`);
+    assert.deepEqual(scenario.assertions, [expected]);
+    const declarations = scenario.evidence.filter((item) => item.symbol === "changed-test-contract");
+    assert.equal(declarations.length, 1);
+    assert.equal(declarations[0].value, `Changed test contract: ${title}`);
+    assert.equal(declarations[0].file, file);
+    return scenario;
+  });
+}
+
+async function analyzeContracts(t, contracts, { committed = true, mobile = false } = {}) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "qamap-independent-contracts-"));
+  t.after(() => rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 }));
+  git(root, "init", "-b", "main");
+  git(root, "config", "user.email", "qamap@example.test");
+  git(root, "config", "user.name", "QAMap Test");
+  git(root, "config", "gc.auto", "0");
+  git(root, "config", "maintenance.auto", "false");
+  const sourceFile = mobile ? "lib/status_view.dart" : "src/MaskedInput.tsx";
+  const file = mobile ? "test/status_view_test.dart" : "src/MaskedInput.test.tsx";
+  if (mobile) {
+    await write(root, "pubspec.yaml", "name: status_app\ndependencies:\n  flutter:\n    sdk: flutter\n");
+  } else {
+    await write(root, "package.json", JSON.stringify({
+      name: "input-app", scripts: { test: "node --test" }, dependencies: { react: "19.0.0" },
+    }));
+  }
+  await write(root, sourceFile, mobile
+    ? "Widget statusView() => Text('Idle');\n"
+    : "export function MaskedInput() { return <input />; }\n");
+  await write(root, file, mobile
+    ? "import 'package:flutter_test/flutter_test.dart';\n"
+    : "import { MaskedInput } from './MaskedInput';\n");
+  git(root, "add", ".");
+  git(root, "commit", "-m", "chore: baseline");
+  git(root, "checkout", "-b", "fix/state-contracts");
+  await write(root, sourceFile, mobile
+    ? "Widget statusView(bool pending) => Text(pending ? 'Loading' : 'Ready');\n"
+    : "export function MaskedInput({ value, onChange, onPaste }) {\n  return <input value={value} onChange={onChange} onPaste={onPaste} />;\n}\n");
+  await write(root, file, [
+    mobile ? "import 'package:flutter_test/flutter_test.dart';" : "import { MaskedInput } from './MaskedInput';",
+    ...contracts.flatMap(([title, assertion]) => [
+      mobile
+        ? `testWidgets(${JSON.stringify(title)}, (tester) async {`
+        : `test(${JSON.stringify(title)}, () => {`,
+      `  ${assertion};`,
+      "});",
+    ]),
+    "",
+  ].join("\n"));
+  if (committed) {
+    git(root, "add", ".");
+    git(root, "commit", "-m", "fix: show the changed state after input");
+  }
+  const qa = await generateQaDraft(root, { base: "main", head: "HEAD", includeWorkingTree: !committed });
+  return { qa, file };
+}
+
+async function write(root, file, text) {
+  await mkdir(path.dirname(path.join(root, file)), { recursive: true });
+  await writeFile(path.join(root, file), text);
+}
+
+function git(root, ...args) {
+  return execFileSync("git", args, { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}


### PR DESCRIPTION
## Summary

Related changed tests could put mutually exclusive expected values into one QA scenario. A fourth contract was dropped by the lifecycle input cap, and equal test titles could erase different expectations.

Keep each contract-bearing test's condition and assertion in a separate scenario, identified by its file and declaration line. Preserve the aggregate product scenario without mixing those test expectations into it.

## Behavioral Contract

When two or more exactly related changed tests carry supported explicit assertions, each receives its own review-required scenario. This works for committed changes and working-tree analysis. Missing setup and actions remain empty; implementation-only existence checks do not create independent product contracts. Analysis does not execute tests.

## Evidence

Refs #261

Five public regression cases failed before the fix and pass afterward: web typing/paste/display/submission in committed and working-tree changes, mobile pending/success/failure/recovery, equal titles with distinct assertions, and missing-action/existence-check controls.

## Checks

- [x] Focused regression test
- [x] `pnpm test`
- [x] `pnpm bench:ci` for inference, routing, trace, or output
- [ ] `pnpm bench:execution` for E2E compiler or execution fixtures
- [ ] `pnpm scan` for scanner, security, or repository policy
- [ ] `pnpm plugin:check` and `pnpm plugin:smoke` for plugin changes
- [x] Documentation links and commands verified

472 tests and all 43 static benchmark contracts pass. Benchmarks reused the compiled build through `pnpm bench:ci:compiled`.

## Public OSS Check

- [x] No private repository, source, path, customer data, credential, or internal smoke output is included.
- [x] Shared inference has unrelated positive and negative coverage, or this is not applicable.
- [x] User-facing commands and claims match actual behavior.

## Review Notes

The unchecked local checks are N/A: no automation compiler, execution fixture, scanner rule, repository policy, or plugin metadata changed. The repository CI still runs its complete gates.

The fixtures validate static analysis of synthetic web and mobile source; they do not run a browser or device. Existing scenario and compact-output caps remain in effect. Source-only action/fixture extraction and broader priority improvements remain follow-up work in #261.

New behavior is documented as unreleased. The published 0.4.17 validation receipt is preserved.
